### PR TITLE
Add filesystem safety: readOnly mode, onBeforeWrite hook, confirmation prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,27 @@ const agent = createAgent({
 // Files persist at ./agent-data/my-agent/
 ```
 
+### Security: FilesystemMemoryStore
+
+> **Warning:** `FilesystemMemoryStore` gives the agent read/write access to the
+> specified directory. The agent decides what files to create and modify. Use
+> `readOnly: true` to restrict to read-only access, or `onBeforeWrite` to
+> approve each write operation.
+
+```ts
+// Read-only mode — agent can read but not create/modify/delete
+const store = new FilesystemMemoryStore('./data', { readOnly: true });
+
+// Write confirmation — approve each operation
+const store = new FilesystemMemoryStore('./data', {
+  onBeforeWrite: async (agentId, path, operation) => {
+    console.log(`Agent ${agentId} wants to ${operation}: ${path}`);
+    // Return true to allow, false to block
+    return true;
+  },
+});
+```
+
 For other backends, implement the interface:
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -238,13 +238,16 @@ const agent = createAgent({
 
 ```ts
 // Read-only mode — agent can read but not create/modify/delete
-const store = new FilesystemMemoryStore('./data', { readOnly: true });
+const readOnlyStore = new FilesystemMemoryStore('./data', { readOnly: true });
+```
 
-// Write confirmation — approve each operation
-const store = new FilesystemMemoryStore('./data', {
-  onBeforeWrite: async (agentId, path, operation) => {
-    console.log(`Agent ${agentId} wants to ${operation}: ${path}`);
+```ts
+// Write confirmation — approve each operation (sync or async)
+const guardedStore = new FilesystemMemoryStore('./data', {
+  onBeforeWrite: (agentId, canonicalPath, operation) => {
+    console.log(`Agent ${agentId} wants to ${operation}: ${canonicalPath}`);
     // Return true to allow, false to block
+    // The path is canonicalized — ../traversal is resolved before this callback
     return true;
   },
 });

--- a/examples/11-filesystem-store.ts
+++ b/examples/11-filesystem-store.ts
@@ -22,6 +22,21 @@ console.log('  Example 11: Filesystem Memory Store');
 console.log('═══════════════════════════════════════════════\n');
 
 const DATA_DIR = path.resolve('.agent-data');
+
+// ── Safety warning and confirmation ──
+console.warn('⚠️  WARNING: This example gives an AI agent read/write access to:');
+console.warn(`   ${DATA_DIR}/`);
+console.warn('');
+console.warn('   The agent will create directories and write files on your');
+console.warn('   real filesystem. It decides what to create based on the task.');
+console.warn('   Files persist after this script exits.');
+console.warn('');
+console.warn('   Press Enter to continue, or Ctrl+C to abort.\n');
+
+await new Promise<void>(resolve => {
+  process.stdin.once('data', () => resolve());
+});
+
 console.log(`Storage directory: ${DATA_DIR}`);
 console.log('Files will persist across runs. Delete .agent-data/ to reset.\n');
 

--- a/examples/11-filesystem-store.ts
+++ b/examples/11-filesystem-store.ts
@@ -31,11 +31,15 @@ console.warn('   The agent will create directories and write files on your');
 console.warn('   real filesystem. It decides what to create based on the task.');
 console.warn('   Files persist after this script exits.');
 console.warn('');
-console.warn('   Press Enter to continue, or Ctrl+C to abort.\n');
 
-await new Promise<void>(resolve => {
-  process.stdin.once('data', () => resolve());
-});
+if (process.stdin.isTTY) {
+  console.warn('   Press Enter to continue, or Ctrl+C to abort.\n');
+  await new Promise<void>(resolve => {
+    process.stdin.once('data', () => resolve());
+  });
+} else {
+  console.warn('   Non-interactive stdin detected; continuing without confirmation.\n');
+}
 
 console.log(`Storage directory: ${DATA_DIR}`);
 console.log('Files will persist across runs. Delete .agent-data/ to reset.\n');

--- a/llms.txt
+++ b/llms.txt
@@ -33,7 +33,9 @@
 ## Memory Stores
 
 - `InMemoryMemoryStore` — in-memory (testing/prototyping, data lost on exit)
-- `FilesystemMemoryStore(baseDir: string)` — Node.js filesystem (persistent)
+- `FilesystemMemoryStore(baseDir: string, options?: FilesystemMemoryStoreOptions)` — Node.js filesystem (persistent)
+  - `options.readOnly: boolean` — block all write operations
+  - `options.onBeforeWrite: (agentId, canonicalPath, operation) => boolean | Promise<boolean>` — approve/deny each write
 - `MemoryStore` interface: read, write, append, delete, list, mkdir, exists, search
 
 ## Skills

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,4 +54,4 @@ export type {
 // Store interfaces and default implementations
 export type { MemoryStore, FileEntry } from './stores.js';
 export { InMemoryMemoryStore } from './stores/in-memory.js';
-export { FilesystemMemoryStore } from './stores/filesystem.js';
+export { FilesystemMemoryStore, type FilesystemMemoryStoreOptions } from './stores/filesystem.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,4 +54,5 @@ export type {
 // Store interfaces and default implementations
 export type { MemoryStore, FileEntry } from './stores.js';
 export { InMemoryMemoryStore } from './stores/in-memory.js';
-export { FilesystemMemoryStore, type FilesystemMemoryStoreOptions } from './stores/filesystem.js';
+export { FilesystemMemoryStore } from './stores/filesystem.js';
+export type { FilesystemMemoryStoreOptions } from './types.js';

--- a/src/stores/filesystem.ts
+++ b/src/stores/filesystem.ts
@@ -4,17 +4,47 @@
  * Stores agent files in {baseDir}/{agentId}/ on the local filesystem.
  * Files persist across process restarts.
  *
+ * Security options:
+ * - `readOnly: true` blocks all write operations
+ * - `onBeforeWrite` callback lets you approve/deny each write
+ *
  * Usage:
  *   import { FilesystemMemoryStore } from 'agent-do/stores/filesystem';
+ *
+ *   // Basic (full read/write access):
  *   const store = new FilesystemMemoryStore('/path/to/data');
+ *
+ *   // Read-only (agent can read but not modify):
+ *   const store = new FilesystemMemoryStore('/path/to/data', { readOnly: true });
+ *
+ *   // With write confirmation:
+ *   const store = new FilesystemMemoryStore('/path/to/data', {
+ *     onBeforeWrite: async (agentId, path) => {
+ *       return confirm(`Allow write to ${path}?`);
+ *     },
+ *   });
  */
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { MemoryStore, FileEntry } from '../stores.js';
 
+export interface FilesystemMemoryStoreOptions {
+  /** Block all write operations. Agent can only read existing files. */
+  readOnly?: boolean;
+  /**
+   * Called before any write/append/delete/mkdir operation.
+   * Return true to allow, false to block.
+   * If not provided, all writes are allowed (unless readOnly is true).
+   */
+  onBeforeWrite?: (agentId: string, filePath: string, operation: 'write' | 'append' | 'delete' | 'mkdir') => Promise<boolean>;
+}
+
 export class FilesystemMemoryStore implements MemoryStore {
-  constructor(private baseDir: string) {
+  private options: FilesystemMemoryStoreOptions;
+
+  constructor(private baseDir: string, options?: FilesystemMemoryStoreOptions) {
+    this.options = options || {};
     fs.mkdirSync(baseDir, { recursive: true });
   }
 
@@ -27,6 +57,18 @@ export class FilesystemMemoryStore implements MemoryStore {
     return resolved;
   }
 
+  private async checkWrite(agentId: string, filePath: string, op: 'write' | 'append' | 'delete' | 'mkdir'): Promise<void> {
+    if (this.options.readOnly) {
+      throw new Error(`Write blocked: store is read-only (attempted ${op} on ${filePath})`);
+    }
+    if (this.options.onBeforeWrite) {
+      const allowed = await this.options.onBeforeWrite(agentId, filePath, op);
+      if (!allowed) {
+        throw new Error(`Write blocked by onBeforeWrite callback (attempted ${op} on ${filePath})`);
+      }
+    }
+  }
+
   async read(agentId: string, filePath: string): Promise<string> {
     const full = this.resolve(agentId, filePath);
     if (!fs.existsSync(full)) throw new Error(`File not found: ${filePath}`);
@@ -34,18 +76,21 @@ export class FilesystemMemoryStore implements MemoryStore {
   }
 
   async write(agentId: string, filePath: string, content: string): Promise<void> {
+    await this.checkWrite(agentId, filePath, 'write');
     const full = this.resolve(agentId, filePath);
     fs.mkdirSync(path.dirname(full), { recursive: true });
     fs.writeFileSync(full, content, 'utf-8');
   }
 
   async append(agentId: string, filePath: string, content: string): Promise<void> {
+    await this.checkWrite(agentId, filePath, 'append');
     const full = this.resolve(agentId, filePath);
     fs.mkdirSync(path.dirname(full), { recursive: true });
     fs.appendFileSync(full, content, 'utf-8');
   }
 
   async delete(agentId: string, filePath: string): Promise<void> {
+    await this.checkWrite(agentId, filePath, 'delete');
     const full = this.resolve(agentId, filePath);
     if (fs.existsSync(full)) fs.unlinkSync(full);
   }
@@ -61,6 +106,7 @@ export class FilesystemMemoryStore implements MemoryStore {
   }
 
   async mkdir(agentId: string, dirPath: string): Promise<void> {
+    await this.checkWrite(agentId, dirPath, 'mkdir');
     fs.mkdirSync(this.resolve(agentId, dirPath), { recursive: true });
   }
 

--- a/src/stores/filesystem.ts
+++ b/src/stores/filesystem.ts
@@ -5,7 +5,7 @@
  * Files persist across process restarts.
  *
  * Security options:
- * - `readOnly: true` blocks all write operations
+ * - `readOnly: true` blocks all write operations (zero write side effects)
  * - `onBeforeWrite` callback lets you approve/deny each write
  *
  * Usage:
@@ -15,12 +15,13 @@
  *   const store = new FilesystemMemoryStore('/path/to/data');
  *
  *   // Read-only (agent can read but not modify):
- *   const store = new FilesystemMemoryStore('/path/to/data', { readOnly: true });
+ *   const readOnlyStore = new FilesystemMemoryStore('/path/to/data', { readOnly: true });
  *
- *   // With write confirmation:
- *   const store = new FilesystemMemoryStore('/path/to/data', {
- *     onBeforeWrite: async (agentId, path) => {
- *       return confirm(`Allow write to ${path}?`);
+ *   // With write confirmation (receives canonicalized path):
+ *   const guardedStore = new FilesystemMemoryStore('/path/to/data', {
+ *     onBeforeWrite: async (agentId, canonicalPath, operation) => {
+ *       console.log(`Agent ${agentId} wants to ${operation}: ${canonicalPath}`);
+ *       return true; // or false to block
  *     },
  *   });
  */
@@ -28,24 +29,20 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { MemoryStore, FileEntry } from '../stores.js';
+import type { FilesystemMemoryStoreOptions } from '../types.js';
 
-export interface FilesystemMemoryStoreOptions {
-  /** Block all write operations. Agent can only read existing files. */
-  readOnly?: boolean;
-  /**
-   * Called before any write/append/delete/mkdir operation.
-   * Return true to allow, false to block.
-   * If not provided, all writes are allowed (unless readOnly is true).
-   */
-  onBeforeWrite?: (agentId: string, filePath: string, operation: 'write' | 'append' | 'delete' | 'mkdir') => Promise<boolean>;
-}
+export type { FilesystemMemoryStoreOptions } from '../types.js';
 
 export class FilesystemMemoryStore implements MemoryStore {
   private options: FilesystemMemoryStoreOptions;
 
   constructor(private baseDir: string, options?: FilesystemMemoryStoreOptions) {
     this.options = options || {};
-    fs.mkdirSync(baseDir, { recursive: true });
+    // Only create the base directory if not in read-only mode
+    // so readOnly has zero write side effects
+    if (!this.options.readOnly) {
+      fs.mkdirSync(baseDir, { recursive: true });
+    }
   }
 
   private resolve(agentId: string, filePath: string): string {
@@ -57,14 +54,23 @@ export class FilesystemMemoryStore implements MemoryStore {
     return resolved;
   }
 
+  /** Returns the canonicalized relative path for use in callbacks. */
+  private canonicalRelativePath(agentId: string, filePath: string): string {
+    const resolved = this.resolve(agentId, filePath);
+    const agentDir = path.resolve(this.baseDir, agentId);
+    return path.relative(agentDir, resolved);
+  }
+
   private async checkWrite(agentId: string, filePath: string, op: 'write' | 'append' | 'delete' | 'mkdir'): Promise<void> {
     if (this.options.readOnly) {
       throw new Error(`Write blocked: store is read-only (attempted ${op} on ${filePath})`);
     }
     if (this.options.onBeforeWrite) {
-      const allowed = await this.options.onBeforeWrite(agentId, filePath, op);
+      // Pass the canonicalized path so policies can't be bypassed with ../
+      const canonicalPath = this.canonicalRelativePath(agentId, filePath);
+      const allowed = await Promise.resolve(this.options.onBeforeWrite(agentId, canonicalPath, op));
       if (!allowed) {
-        throw new Error(`Write blocked by onBeforeWrite callback (attempted ${op} on ${filePath})`);
+        throw new Error(`Write blocked by onBeforeWrite callback (attempted ${op} on ${canonicalPath})`);
       }
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -162,6 +162,19 @@ export interface ConversationMessage {
   content: string;
 }
 
+// Filesystem store options
+export interface FilesystemMemoryStoreOptions {
+  /** Block all write operations. Agent can only read existing files. */
+  readOnly?: boolean;
+  /**
+   * Called before any write/append/delete/mkdir operation.
+   * Receives the canonicalized relative path (safe against ../ bypass).
+   * Return true to allow, false to block.
+   * Supports both sync and async callbacks.
+   */
+  onBeforeWrite?: (agentId: string, filePath: string, operation: 'write' | 'append' | 'delete' | 'mkdir') => boolean | Promise<boolean>;
+}
+
 // Agent instance
 export interface Agent {
   readonly id: string;

--- a/tests/filesystem-store.test.ts
+++ b/tests/filesystem-store.test.ts
@@ -141,4 +141,84 @@ describe('FilesystemMemoryStore', () => {
       expect(results[0]!.path).toContain('deep.txt');
     });
   });
+
+  describe('readOnly mode', () => {
+    it('blocks write operations', async () => {
+      const roStore = new FilesystemMemoryStore(tmpDir, { readOnly: true });
+      await expect(roStore.write('agent-1', 'file.txt', 'data')).rejects.toThrow('read-only');
+    });
+
+    it('blocks append operations', async () => {
+      const roStore = new FilesystemMemoryStore(tmpDir, { readOnly: true });
+      await expect(roStore.append('agent-1', 'file.txt', 'data')).rejects.toThrow('read-only');
+    });
+
+    it('blocks delete operations', async () => {
+      const roStore = new FilesystemMemoryStore(tmpDir, { readOnly: true });
+      await expect(roStore.delete('agent-1', 'file.txt')).rejects.toThrow('read-only');
+    });
+
+    it('blocks mkdir operations', async () => {
+      const roStore = new FilesystemMemoryStore(tmpDir, { readOnly: true });
+      await expect(roStore.mkdir('agent-1', 'newdir')).rejects.toThrow('read-only');
+    });
+
+    it('allows read operations', async () => {
+      // Write with the normal store first
+      await store.write('agent-1', 'readable.txt', 'can read this');
+      const roStore = new FilesystemMemoryStore(tmpDir, { readOnly: true });
+      const content = await roStore.read('agent-1', 'readable.txt');
+      expect(content).toBe('can read this');
+    });
+
+    it('allows list operations', async () => {
+      await store.write('agent-1', 'listed.txt', 'data');
+      const roStore = new FilesystemMemoryStore(tmpDir, { readOnly: true });
+      const entries = await roStore.list('agent-1');
+      expect(entries.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('onBeforeWrite callback', () => {
+    it('blocks writes when callback returns false', async () => {
+      const guardedStore = new FilesystemMemoryStore(tmpDir, {
+        onBeforeWrite: async () => false,
+      });
+      await expect(guardedStore.write('agent-1', 'blocked.txt', 'nope')).rejects.toThrow('blocked by onBeforeWrite');
+    });
+
+    it('allows writes when callback returns true', async () => {
+      const guardedStore = new FilesystemMemoryStore(tmpDir, {
+        onBeforeWrite: async () => true,
+      });
+      await guardedStore.write('agent-1', 'allowed.txt', 'yes');
+      expect(await guardedStore.read('agent-1', 'allowed.txt')).toBe('yes');
+    });
+
+    it('receives correct arguments', async () => {
+      const calls: Array<{ agentId: string; path: string; op: string }> = [];
+      const guardedStore = new FilesystemMemoryStore(tmpDir, {
+        onBeforeWrite: async (agentId, filePath, operation) => {
+          calls.push({ agentId, path: filePath, op: operation });
+          return true;
+        },
+      });
+      await guardedStore.write('test-agent', 'notes/hello.md', 'hi');
+      expect(calls).toHaveLength(1);
+      expect(calls[0]!.agentId).toBe('test-agent');
+      expect(calls[0]!.path).toBe('notes/hello.md');
+      expect(calls[0]!.op).toBe('write');
+    });
+
+    it('is called for delete and mkdir too', async () => {
+      const ops: string[] = [];
+      const guardedStore = new FilesystemMemoryStore(tmpDir, {
+        onBeforeWrite: async (_a, _p, op) => { ops.push(op); return true; },
+      });
+      await guardedStore.write('agent-1', 'temp.txt', 'data');
+      await guardedStore.mkdir('agent-1', 'newdir');
+      await guardedStore.delete('agent-1', 'temp.txt');
+      expect(ops).toEqual(['write', 'mkdir', 'delete']);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #1 — Filesystem example should warn and confirm before giving agent file access.

### Changes

**FilesystemMemoryStore** (`src/stores/filesystem.ts`):
- New `readOnly` option — blocks all write/append/delete/mkdir operations, allows read/list/exists/search
- New `onBeforeWrite(agentId, path, operation)` callback — called before each mutation, return `false` to block
- Both options are optional, backwards-compatible (no options = full access as before)

**Example 11** (`examples/11-filesystem-store.ts`):
- Warning banner showing the directory path
- Explanation that the agent will write real files
- Requires Enter to continue, Ctrl+C to abort

**README** (`README.md`):
- Security note in MemoryStore section
- Code examples for `readOnly` and `onBeforeWrite`

**Tests** (`tests/filesystem-store.test.ts`):
- 10 new tests (111 total):
  - readOnly blocks write, append, delete, mkdir
  - readOnly allows read and list
  - onBeforeWrite blocks when returning false
  - onBeforeWrite allows when returning true
  - onBeforeWrite receives correct agentId, path, operation
  - onBeforeWrite called for write, mkdir, and delete operations

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` — 111 tests pass (10 new)
- [x] No `@chaos` references


🤖 Generated with [Claude Code](https://claude.com/claude-code)