### PR TITLE
Add comprehensive end-to-end demos

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,17 +26,38 @@ src/
   index.ts          — all exports
 
 tests/              — vitest unit tests (one file per module)
-examples/           — 11 runnable examples (npx tsx examples/NN-name.ts)
+examples/           — focused single-feature examples (npx tsx examples/NN-name.ts)
+demos/              — comprehensive end-to-end demo applications
+  assistant/        — interactive CLI assistant with persistent memory
+  research-team/    — multi-agent research pipeline (master + workers)
+  code-reviewer/    — automated code review (read-only filesystem)
 ```
 
 ## Rules for Every Change
 
 1. **Tests first** — write or update tests for every change. Run `npm test` before committing.
 2. **Examples** — if the change affects user-facing API, update the relevant example in `examples/`.
-3. **README** — keep the README API reference table and examples table current.
-4. **Types** — export all public types from `src/types.ts` and re-export from `src/index.ts`.
-5. **No internal dependencies** — this package must NOT reference `
-6. **llms.txt** — update `llms.txt` if you add new exports or change the API surface.
+3. **Demos** — if the change affects core API, verify all demos in `demos/` still work. Demos use `"agent-do": "file:../../"` so they always use the local version.
+4. **README** — keep the README API reference table and examples table current.
+5. **Types** — export all public types from `src/types.ts` and re-export from `src/index.ts`.
+6. **No internal dependencies** — this package must NOT reference any private/internal packages. It is standalone.
+7. **llms.txt** — update `llms.txt` if you add new exports or change the API surface.
+
+## Demos vs Examples
+
+| | examples/ | demos/ |
+|---|---|---|
+| Purpose | Learn one feature | See everything together |
+| Size | 30-80 lines | 100-300+ lines |
+| Interactivity | Runs and exits | Interactive / multi-turn |
+| Persistence | Usually in-memory | Filesystem-backed |
+| Complexity | Single agent, few tools | Multi-agent, hooks, skills, history |
+| Own package.json | No | Yes — `"agent-do": "file:../../"` |
+
+Demos import from `'agent-do'` (not relative paths) but resolve to the local copy via the `file:` dependency. This means:
+- Imports look exactly like what a published user would write
+- Changes to src/ are immediately reflected in demos
+- No version drift between demos and library
 
 ## Running Tests
 
@@ -54,6 +75,37 @@ npx tsx examples/01-basic-agent.ts
 npx tsx examples/11-filesystem-store.ts
 ```
 
+## Running Demos
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+cd demos/assistant && npm install && npm start
+cd demos/research-team && npm install && npm start
+cd demos/code-reviewer && npm install && npm start
+```
+
+## Testing Strategy
+
+### Unit Tests (tests/)
+Test individual functions and classes in isolation using `createMockModel()`:
+- Mock model returns predetermined responses — no API calls
+- Test tool execution, hook behavior, permission logic, usage tracking
+- Test store implementations (read/write/delete round-trips)
+
+### Integration Tests
+Use `createMockModel()` with multi-step response sequences to test:
+- Full agent loop execution (tool call → result → text)
+- Conversation history passed correctly
+- Hooks firing in the right order
+- Permission system blocking/allowing correctly
+
+### Eval Framework (future)
+For evaluating agent quality (not just correctness):
+- Define eval cases: input prompt + expected behavior
+- Run against real models with scoring criteria
+- Track quality metrics over time
+- Compare across model providers
+
 ## Key Design Decisions
 
 - **MemoryStore is agentId-scoped** — every method takes `agentId` as the first parameter. This allows one store instance to serve multiple agents.
@@ -62,11 +114,13 @@ npx tsx examples/11-filesystem-store.ts
 - **The mock model uses a response queue** — `responses[0]` for the first LLM call, `responses[1]` for the second, etc. This makes tests deterministic.
 - **Prompt caching is automatic** — `prepareStep` adds Anthropic cache control breakpoints. No configuration needed.
 - **HTML generation order** — the system prompt instructs: DOM first, CSS second, JS third.
+- **FilesystemMemoryStore safety** — supports `readOnly` mode and `onBeforeWrite` callback. The callback receives canonicalized paths (../ resolved before the callback fires).
 
 ## What NOT to Do
 
 - Do not add browser-specific code (no `chrome.*`, no DOM, no `window`)
-- Do not import from `
+- Do not import from any private/internal monorepo packages
 - Do not add heavy dependencies — keep the bundle small
 - Do not use `eval()` or `Function()` in production code
 - Do not modify the mock model to have side effects in tests
+- Do not let demos use relative imports — always import from `'agent-do'`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,9 +79,9 @@ npx tsx examples/11-filesystem-store.ts
 
 ```bash
 export ANTHROPIC_API_KEY=sk-ant-...
-cd demos/assistant && npm install && npm start
-cd demos/research-team && npm install && npm start
-cd demos/code-reviewer && npm install && npm start
+(cd demos/assistant && npm install && npm start)
+(cd demos/research-team && npm install && npm start)
+(cd demos/code-reviewer && npm install && npm start)
 ```
 
 ## Testing Strategy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,17 +26,38 @@ src/
   index.ts          — all exports
 
 tests/              — vitest unit tests (one file per module)
-examples/           — 11 runnable examples (npx tsx examples/NN-name.ts)
+examples/           — focused single-feature examples (npx tsx examples/NN-name.ts)
+demos/              — comprehensive end-to-end demo applications
+  assistant/        — interactive CLI assistant with persistent memory
+  research-team/    — multi-agent research pipeline (master + workers)
+  code-reviewer/    — automated code review (read-only filesystem)
 ```
 
 ## Rules for Every Change
 
 1. **Tests first** — write or update tests for every change. Run `npm test` before committing.
 2. **Examples** — if the change affects user-facing API, update the relevant example in `examples/`.
-3. **README** — keep the README API reference table and examples table current.
-4. **Types** — export all public types from `src/types.ts` and re-export from `src/index.ts`.
-5. **No internal dependencies** — this package must NOT reference `
-6. **llms.txt** — update `llms.txt` if you add new exports or change the API surface.
+3. **Demos** — if the change affects core API, verify all demos in `demos/` still work. Demos use `"agent-do": "file:../../"` so they always use the local version.
+4. **README** — keep the README API reference table and examples table current.
+5. **Types** — export all public types from `src/types.ts` and re-export from `src/index.ts`.
+6. **No internal dependencies** — this package must NOT reference any private/internal packages. It is standalone.
+7. **llms.txt** — update `llms.txt` if you add new exports or change the API surface.
+
+## Demos vs Examples
+
+| | examples/ | demos/ |
+|---|---|---|
+| Purpose | Learn one feature | See everything together |
+| Size | 30-80 lines | 100-300+ lines |
+| Interactivity | Runs and exits | Interactive / multi-turn |
+| Persistence | Usually in-memory | Filesystem-backed |
+| Complexity | Single agent, few tools | Multi-agent, hooks, skills, history |
+| Own package.json | No | Yes — `"agent-do": "file:../../"` |
+
+Demos import from `'agent-do'` (not relative paths) but resolve to the local copy via the `file:` dependency. This means:
+- Imports look exactly like what a published user would write
+- Changes to src/ are immediately reflected in demos
+- No version drift between demos and library
 
 ## Running Tests
 
@@ -54,6 +75,37 @@ npx tsx examples/01-basic-agent.ts
 npx tsx examples/11-filesystem-store.ts
 ```
 
+## Running Demos
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+cd demos/assistant && npm install && npm start
+cd demos/research-team && npm install && npm start
+cd demos/code-reviewer && npm install && npm start
+```
+
+## Testing Strategy
+
+### Unit Tests (tests/)
+Test individual functions and classes in isolation using `createMockModel()`:
+- Mock model returns predetermined responses — no API calls
+- Test tool execution, hook behavior, permission logic, usage tracking
+- Test store implementations (read/write/delete round-trips)
+
+### Integration Tests
+Use `createMockModel()` with multi-step response sequences to test:
+- Full agent loop execution (tool call → result → text)
+- Conversation history passed correctly
+- Hooks firing in the right order
+- Permission system blocking/allowing correctly
+
+### Eval Framework (future)
+For evaluating agent quality (not just correctness):
+- Define eval cases: input prompt + expected behavior
+- Run against real models with scoring criteria
+- Track quality metrics over time
+- Compare across model providers
+
 ## Key Design Decisions
 
 - **MemoryStore is agentId-scoped** — every method takes `agentId` as the first parameter. This allows one store instance to serve multiple agents.
@@ -62,11 +114,13 @@ npx tsx examples/11-filesystem-store.ts
 - **The mock model uses a response queue** — `responses[0]` for the first LLM call, `responses[1]` for the second, etc. This makes tests deterministic.
 - **Prompt caching is automatic** — `prepareStep` adds Anthropic cache control breakpoints. No configuration needed.
 - **HTML generation order** — the system prompt instructs: DOM first, CSS second, JS third.
+- **FilesystemMemoryStore safety** — supports `readOnly` mode and `onBeforeWrite` callback. The callback receives canonicalized paths (../ resolved before the callback fires).
 
 ## What NOT to Do
 
 - Do not add browser-specific code (no `chrome.*`, no DOM, no `window`)
-- Do not import from `
+- Do not import from any private/internal monorepo packages
 - Do not add heavy dependencies — keep the bundle small
 - Do not use `eval()` or `Function()` in production code
 - Do not modify the mock model to have side effects in tests
+- Do not let demos use relative imports — always import from `'agent-do'`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,9 +79,9 @@ npx tsx examples/11-filesystem-store.ts
 
 ```bash
 export ANTHROPIC_API_KEY=sk-ant-...
-cd demos/assistant && npm install && npm start
-cd demos/research-team && npm install && npm start
-cd demos/code-reviewer && npm install && npm start
+(cd demos/assistant && npm install && npm start)
+(cd demos/research-team && npm install && npm start)
+(cd demos/code-reviewer && npm install && npm start)
 ```
 
 ## Testing Strategy

--- a/demos/README.md
+++ b/demos/README.md
@@ -1,0 +1,70 @@
+# agent-do Demos
+
+Comprehensive demo applications showcasing agent-do in real-world scenarios. Each demo is a standalone project with its own dependencies.
+
+## Setup
+
+From the repo root, install the main package first:
+
+```bash
+npm install
+```
+
+Then install each demo's dependencies:
+
+```bash
+cd demos/assistant && npm install
+cd demos/research-team && npm install
+cd demos/code-reviewer && npm install
+```
+
+Make sure your `ANTHROPIC_API_KEY` environment variable is set:
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+```
+
+## Demos
+
+### 1. Interactive CLI Assistant (`demos/assistant/`)
+
+A multi-turn interactive assistant with persistent file storage, streaming output, lifecycle hooks, and session-level usage tracking.
+
+- Persistent memory via `FilesystemMemoryStore` (stored in `.data/`)
+- Conversation history across messages
+- File tools for read/write/search/list
+- Streaming mode shows tool calls as they happen
+- Lifecycle hooks log usage and cost after each run
+- Session summary on exit (total tokens, cost, messages)
+
+```bash
+cd demos/assistant && npm start
+```
+
+### 2. Multi-Agent Research Pipeline (`demos/research-team/`)
+
+A multi-agent orchestrator with a Master, Researcher, and Writer agent that collaborate to produce a research report.
+
+- Master receives a topic and delegates work to specialists
+- Researcher gathers information
+- Writer drafts a polished report
+- Real-time progress logging shows which agent is active
+- Final report saved to `.data/reports/`
+
+```bash
+cd demos/research-team && npm start "Rust programming language"
+```
+
+### 3. Automated Code Reviewer (`demos/code-reviewer/`)
+
+An agent that reads source files from a directory and produces a structured code review report.
+
+- Takes a directory path as argument (defaults to current directory)
+- Uses `FilesystemMemoryStore` in read-only mode
+- Structured review covering security, bugs, and readability
+- Saves review report to `.data/reviews/`
+- Progress output as files are read and analyzed
+
+```bash
+cd demos/code-reviewer && npm start /path/to/project
+```

--- a/demos/README.md
+++ b/demos/README.md
@@ -10,12 +10,12 @@ From the repo root, install the main package first:
 npm install
 ```
 
-Then install each demo's dependencies:
+Then install each demo's dependencies (using subshells so your working directory isn't changed):
 
 ```bash
-cd demos/assistant && npm install
-cd demos/research-team && npm install
-cd demos/code-reviewer && npm install
+(cd demos/assistant && npm install)
+(cd demos/research-team && npm install)
+(cd demos/code-reviewer && npm install)
 ```
 
 Make sure your `ANTHROPIC_API_KEY` environment variable is set:
@@ -38,7 +38,7 @@ A multi-turn interactive assistant with persistent file storage, streaming outpu
 - Session summary on exit (total tokens, cost, messages)
 
 ```bash
-cd demos/assistant && npm start
+(cd demos/assistant && npm start)
 ```
 
 ### 2. Multi-Agent Research Pipeline (`demos/research-team/`)
@@ -49,10 +49,10 @@ A multi-agent orchestrator with a Master, Researcher, and Writer agent that coll
 - Researcher gathers information
 - Writer drafts a polished report
 - Real-time progress logging shows which agent is active
-- Final report saved to `.data/reports/`
+- Final report saved to `.data/master/reports/` (scoped under the master agent's ID)
 
 ```bash
-cd demos/research-team && npm start "Rust programming language"
+(cd demos/research-team && npm start "Rust programming language")
 ```
 
 ### 3. Automated Code Reviewer (`demos/code-reviewer/`)
@@ -62,9 +62,9 @@ An agent that reads source files from a directory and produces a structured code
 - Takes a directory path as argument (defaults to current directory)
 - Uses `FilesystemMemoryStore` in read-only mode
 - Structured review covering security, bugs, and readability
-- Saves review report to `.data/reviews/`
+- Saves review report to `.data/reviews/reviewer/` (scoped under the reviewer agent's ID)
 - Progress output as files are read and analyzed
 
 ```bash
-cd demos/code-reviewer && npm start /path/to/project
+(cd demos/code-reviewer && npm start /path/to/project)
 ```

--- a/demos/assistant/.gitignore
+++ b/demos/assistant/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.data/

--- a/demos/assistant/README.md
+++ b/demos/assistant/README.md
@@ -13,7 +13,10 @@ A multi-turn interactive assistant that persists files to disk, streams response
 ## How to run
 
 ```bash
-# Install dependencies
+# Install repo root dependencies first (if not already done)
+# (cd ../.. && npm install)
+
+# Install demo dependencies
 npm install
 
 # Set your API key

--- a/demos/assistant/README.md
+++ b/demos/assistant/README.md
@@ -1,0 +1,55 @@
+# Interactive CLI Assistant
+
+A multi-turn interactive assistant that persists files to disk, streams responses in real-time, and tracks usage across your entire session.
+
+## What it does
+
+- **Persistent memory** -- Uses `FilesystemMemoryStore` to read/write files in `.data/`. Files survive across sessions.
+- **Multi-turn conversation** -- Maintains conversation history so the agent remembers what you said earlier in the session.
+- **Streaming output** -- Shows tool calls and text as they happen, so you see the agent working in real-time.
+- **Lifecycle hooks** -- Logs token counts and estimated cost after every LLM call.
+- **Session summary** -- When you exit, prints total tokens used, estimated cost, and number of messages exchanged.
+
+## How to run
+
+```bash
+# Install dependencies
+npm install
+
+# Set your API key
+export ANTHROPIC_API_KEY=sk-ant-...
+
+# Start the assistant
+npm start
+```
+
+## What to expect
+
+1. The assistant prints a welcome banner explaining its capabilities.
+2. You type a message and press Enter.
+3. The agent streams its response, showing tool calls (file reads/writes/searches) as they happen.
+4. The conversation continues until you type `quit` or press Ctrl+C.
+5. On exit, a session summary shows total tokens, cost, and message count.
+
+## Example session
+
+```
+You: Save a note about my meeting with Sarah tomorrow at 3pm
+  [tool-call] write_file({ path: "notes/meeting-sarah.md", ... })
+  [tool-result] Successfully wrote to notes/meeting-sarah.md
+
+  Assistant: I've saved a note about your meeting with Sarah...
+
+You: What notes do I have?
+  [tool-call] find_files({ path: "notes" })
+  [tool-result] [file] meeting-sarah.md
+
+  Assistant: You have one note: meeting-sarah.md about your meeting with Sarah...
+
+You: quit
+
+Session Summary
+  Messages:    4 (2 exchanges)
+  Total tokens: 3,421
+  Estimated cost: $0.0127
+```

--- a/demos/assistant/index.ts
+++ b/demos/assistant/index.ts
@@ -1,0 +1,257 @@
+/**
+ * Demo: Interactive CLI Assistant
+ *
+ * A multi-turn interactive assistant with persistent file storage,
+ * streaming output, lifecycle hooks, and session-level usage tracking.
+ *
+ * Features:
+ *   - FilesystemMemoryStore for persistent memory (.data/)
+ *   - Conversation history across messages
+ *   - File tools (read/write/search/list)
+ *   - Streaming mode shows tool calls as they happen
+ *   - Lifecycle hooks log usage and cost after each run
+ *   - Session summary on exit
+ *
+ * Run: npm start
+ */
+
+import * as readline from 'node:readline';
+import {
+  createAgent,
+  createFileTools,
+  type ConversationMessage,
+  type AgentHooks,
+  type RunUsage,
+} from 'agent-do';
+import { FilesystemMemoryStore } from 'agent-do/stores/filesystem';
+import { createAnthropic } from '@ai-sdk/anthropic';
+
+// ═══════════════════════════════════════════════
+//  Configuration
+// ═══════════════════════════════════════════════
+
+const AGENT_ID = 'assistant';
+const DATA_DIR = '.data';
+const MODEL_ID = 'claude-sonnet-4-6';
+
+// ═══════════════════════════════════════════════
+//  Session state
+// ═══════════════════════════════════════════════
+
+const history: ConversationMessage[] = [];
+let sessionInputTokens = 0;
+let sessionOutputTokens = 0;
+let sessionCost = 0;
+let messageCount = 0;
+
+// ═══════════════════════════════════════════════
+//  Setup
+// ═══════════════════════════════════════════════
+
+const apiKey = process.env.ANTHROPIC_API_KEY;
+if (!apiKey) {
+  console.error('Error: ANTHROPIC_API_KEY environment variable is required.');
+  console.error('  export ANTHROPIC_API_KEY=sk-ant-...');
+  process.exit(1);
+}
+
+const provider = createAnthropic({ apiKey });
+const model = provider(MODEL_ID);
+
+// Persistent filesystem store
+const store = new FilesystemMemoryStore(DATA_DIR);
+
+// File tools for the agent
+const fileTools = createFileTools(store, AGENT_ID);
+
+// Lifecycle hooks
+const hooks: AgentHooks = {
+  onStepStart: async (event) => {
+    if (event.step > 0) {
+      console.log(`  [step ${event.step + 1}] ${event.tokensSoFar.toLocaleString()} tokens so far, $${event.costSoFar.toFixed(4)} spent`);
+    }
+    return { decision: 'continue' };
+  },
+
+  onUsage: async (record) => {
+    sessionInputTokens += record.inputTokens;
+    sessionOutputTokens += record.outputTokens;
+    sessionCost += record.estimatedCost;
+    console.log(`  [usage] step ${record.step}: ${record.inputTokens.toLocaleString()} in + ${record.outputTokens.toLocaleString()} out ($${record.estimatedCost.toFixed(4)})`);
+  },
+
+  onComplete: async (event) => {
+    console.log(`  [complete] ${event.totalSteps} step(s), $${event.usage.totalCost.toFixed(4)} this turn`);
+  },
+};
+
+// Create the agent
+const agent = createAgent({
+  id: AGENT_ID,
+  name: 'Assistant',
+  model: model as any,
+  systemPrompt: `You are a helpful interactive assistant with access to a persistent filesystem.
+
+You can:
+- Save and read notes, documents, and any text files
+- Search across your stored files
+- List directory contents
+- Organize information into folders
+
+Files are stored persistently in your workspace. They survive across sessions.
+Be helpful, concise, and proactive about organizing information.
+When the user asks you to remember something, save it to a file.
+When searching, use grep_file and find_files to locate content.`,
+  tools: fileTools,
+  maxIterations: 10,
+  hooks,
+  usage: { enabled: true },
+});
+
+// ═══════════════════════════════════════════════
+//  Welcome message
+// ═══════════════════════════════════════════════
+
+console.log('');
+console.log('='.repeat(55));
+console.log('  Interactive CLI Assistant');
+console.log('='.repeat(55));
+console.log('');
+console.log('  I am an interactive assistant with persistent storage.');
+console.log('  I can save notes, search files, and remember things');
+console.log('  across our conversation.');
+console.log('');
+console.log('  What I can do:');
+console.log('    - Save and read files      (write_file, read_file)');
+console.log('    - Search file contents      (grep_file)');
+console.log('    - Browse stored files        (list_directory, find_files)');
+console.log('    - Delete files               (delete_file)');
+console.log('');
+console.log('  Files are stored in .data/ and persist across sessions.');
+console.log('');
+console.log('  Type a message to chat. Type "quit" or press Ctrl+C to exit.');
+console.log('');
+console.log('-'.repeat(55));
+console.log('');
+
+// ═══════════════════════════════════════════════
+//  Session summary
+// ═══════════════════════════════════════════════
+
+function printSessionSummary(): void {
+  console.log('');
+  console.log('='.repeat(55));
+  console.log('  Session Summary');
+  console.log('='.repeat(55));
+  console.log(`  Messages exchanged: ${messageCount} (${messageCount / 2} exchanges)`);
+  console.log(`  Input tokens:       ${sessionInputTokens.toLocaleString()}`);
+  console.log(`  Output tokens:      ${sessionOutputTokens.toLocaleString()}`);
+  console.log(`  Total tokens:       ${(sessionInputTokens + sessionOutputTokens).toLocaleString()}`);
+  console.log(`  Estimated cost:     $${sessionCost.toFixed(4)}`);
+  console.log('='.repeat(55));
+  console.log('');
+}
+
+// ═══════════════════════════════════════════════
+//  Interactive loop
+// ═══════════════════════════════════════════════
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
+
+// Handle Ctrl+C gracefully
+process.on('SIGINT', () => {
+  printSessionSummary();
+  process.exit(0);
+});
+
+async function chat(userMessage: string): Promise<void> {
+  messageCount++;
+
+  console.log('');
+
+  // Stream the response
+  let fullResponse = '';
+  let printedHeader = false;
+
+  for await (const event of agent.stream(userMessage, undefined, history)) {
+    switch (event.type) {
+      case 'tool-call': {
+        const argsStr = event.toolArgs
+          ? JSON.stringify(event.toolArgs, null, 0).slice(0, 120)
+          : '';
+        console.log(`  [tool-call] ${event.toolName}(${argsStr})`);
+        break;
+      }
+
+      case 'tool-result': {
+        const resultStr = event.toolResult
+          ? String(event.toolResult).slice(0, 120)
+          : '';
+        console.log(`  [tool-result] ${resultStr}${String(event.toolResult || '').length > 120 ? '...' : ''}`);
+        break;
+      }
+
+      case 'text': {
+        if (!printedHeader) {
+          console.log('');
+          process.stdout.write('  Assistant: ');
+          printedHeader = true;
+        }
+        process.stdout.write(event.content);
+        fullResponse += event.content;
+        break;
+      }
+
+      case 'done': {
+        if (printedHeader) {
+          console.log('');
+        }
+        break;
+      }
+
+      case 'error': {
+        console.log(`  [error] ${event.content}`);
+        break;
+      }
+    }
+  }
+
+  // Update conversation history
+  history.push({ role: 'user', content: userMessage });
+  if (fullResponse) {
+    history.push({ role: 'assistant', content: fullResponse });
+    messageCount++;
+  }
+
+  console.log('');
+}
+
+function prompt(): void {
+  rl.question('You: ', async (input) => {
+    const trimmed = input.trim();
+
+    if (!trimmed) {
+      prompt();
+      return;
+    }
+
+    if (trimmed.toLowerCase() === 'quit' || trimmed.toLowerCase() === 'exit') {
+      printSessionSummary();
+      rl.close();
+      process.exit(0);
+    }
+
+    try {
+      await chat(trimmed);
+    } catch (err) {
+      console.error(`  [error] ${err instanceof Error ? err.message : String(err)}`);
+    }
+
+    prompt();
+  });
+}
+
+prompt();

--- a/demos/assistant/package-lock.json
+++ b/demos/assistant/package-lock.json
@@ -1,0 +1,660 @@
+{
+  "name": "agent-do-demo-assistant",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "agent-do-demo-assistant",
+      "dependencies": {
+        "agent-do": "file:../../"
+      },
+      "devDependencies": {
+        "@ai-sdk/anthropic": "^3.0.0",
+        "tsx": "^4.0.0"
+      }
+    },
+    "../..": {
+      "version": "0.1.0",
+      "dependencies": {
+        "ai": "^6.0.0",
+        "zod": "^3.23.0"
+      },
+      "devDependencies": {
+        "@types/node": "^25.6.0",
+        "typedoc": "^0.28.0",
+        "typedoc-plugin-markdown": "^4.4.0",
+        "typescript": "^5.5.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@ai-sdk/anthropic": {
+      "version": "3.0.69",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.69.tgz",
+      "integrity": "sha512-LshR7X3pFugY0o41G2VKTmg1XoGpSl7uoYWfzk6zjVZLhCfeFiwgpOga+eTV4XY1VVpZwKVqRnkDbIL7K2eH5g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.23.tgz",
+      "integrity": "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/agent-do": {
+      "resolved": "../..",
+      "link": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
+      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "dev": true,
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/demos/assistant/package.json
+++ b/demos/assistant/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "agent-do-demo-assistant",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx index.ts"
+  },
+  "dependencies": {
+    "agent-do": "file:../../"
+  },
+  "devDependencies": {
+    "@ai-sdk/anthropic": "^3.0.0",
+    "tsx": "^4.0.0"
+  }
+}

--- a/demos/code-reviewer/.gitignore
+++ b/demos/code-reviewer/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.data/

--- a/demos/code-reviewer/README.md
+++ b/demos/code-reviewer/README.md
@@ -7,13 +7,16 @@ An agent that reads source files from a directory and produces a structured code
 - **Directory scanning** -- Reads all source files from the target directory.
 - **Read-only mode** -- Uses `FilesystemMemoryStore` with `readOnly: true` so the agent cannot modify your code.
 - **Structured review** -- Produces a report organized by severity (critical, warning, suggestion).
-- **File output** -- Saves the review report to `.data/reviews/` as a markdown file.
+- **File output** -- Saves the review report to `.data/reviews/reviewer/` as a markdown file (scoped under the reviewer agent's ID by `FilesystemMemoryStore`).
 - **Progress logging** -- Shows which files are being read and analyzed.
 
 ## How to run
 
 ```bash
-# Install dependencies
+# Install repo root dependencies first (if not already done)
+# (cd ../.. && npm install)
+
+# Install demo dependencies
 npm install
 
 # Set your API key
@@ -35,7 +38,7 @@ npm start
    - Bugs and logic errors
    - Code readability and maintainability
    - Best practices and patterns
-4. A structured review report is saved to `.data/reviews/review-TIMESTAMP.md`.
+4. A structured review report is saved to `.data/reviews/reviewer/review-TIMESTAMP.md`.
 5. The report summary is printed to the console.
 
 ## Example output
@@ -48,7 +51,7 @@ Reading project structure...
 
 Analyzing code...
 
-Review saved to .data/reviews/review-2025-01-15T10-30-00.md
+Review saved to .data/reviews/reviewer/review-2025-01-15T10-30-00.md
 
 Summary:
   Files reviewed: 5

--- a/demos/code-reviewer/README.md
+++ b/demos/code-reviewer/README.md
@@ -1,0 +1,58 @@
+# Automated Code Reviewer
+
+An agent that reads source files from a directory and produces a structured code review report covering security, bugs, readability, and best practices.
+
+## What it does
+
+- **Directory scanning** -- Reads all source files from the target directory.
+- **Read-only mode** -- Uses `FilesystemMemoryStore` with `readOnly: true` so the agent cannot modify your code.
+- **Structured review** -- Produces a report organized by severity (critical, warning, suggestion).
+- **File output** -- Saves the review report to `.data/reviews/` as a markdown file.
+- **Progress logging** -- Shows which files are being read and analyzed.
+
+## How to run
+
+```bash
+# Install dependencies
+npm install
+
+# Set your API key
+export ANTHROPIC_API_KEY=sk-ant-...
+
+# Review a specific directory
+npm start /path/to/your/project
+
+# Review the current directory (default)
+npm start
+```
+
+## What to expect
+
+1. The agent scans the target directory structure.
+2. Progress output shows files being read.
+3. The agent analyzes code for:
+   - Security vulnerabilities (injection, auth issues, secrets)
+   - Bugs and logic errors
+   - Code readability and maintainability
+   - Best practices and patterns
+4. A structured review report is saved to `.data/reviews/review-TIMESTAMP.md`.
+5. The report summary is printed to the console.
+
+## Example output
+
+```
+Reading project structure...
+  [tool-call] find_files({ path: "." })
+  [tool-call] read_file({ path: "src/index.ts" })
+  [tool-call] read_file({ path: "src/auth.ts" })
+
+Analyzing code...
+
+Review saved to .data/reviews/review-2025-01-15T10-30-00.md
+
+Summary:
+  Files reviewed: 5
+  Critical issues: 1
+  Warnings: 3
+  Suggestions: 7
+```

--- a/demos/code-reviewer/index.ts
+++ b/demos/code-reviewer/index.ts
@@ -68,23 +68,27 @@ console.log('');
 //  Read-only filesystem store for the source code
 // ═══════════════════════════════════════════════
 
-// The review target is mounted read-only -- the agent cannot modify the code
-const sourceStore = new FilesystemMemoryStore(targetDir, { readOnly: true });
+// The review target is mounted read-only -- the agent cannot modify the code.
+// FilesystemMemoryStore scopes to {baseDir}/{agentId}/, so we use the parent
+// directory as baseDir and the directory name as agentId. This way
+// read_file("src/index.ts") reads from the actual target directory.
+const sourceStore = new FilesystemMemoryStore(path.dirname(targetDir), { readOnly: true });
+const SOURCE_AGENT_ID = path.basename(targetDir);
 
 // A writable store for saving the review output
 const outputStore = new FilesystemMemoryStore(OUTPUT_DIR);
 fs.mkdirSync(OUTPUT_DIR, { recursive: true });
 
 // Combine both into tools:
-//   - Source code tools are read-only (prefixed with source_)
+//   - Source code tools are read-only
 //   - Output tools can write (for saving the review)
-const sourceTools = createFileTools(sourceStore, AGENT_ID);
+const sourceTools = createFileTools(sourceStore, SOURCE_AGENT_ID);
 const outputTools = createFileTools(outputStore, AGENT_ID);
 
 // Build a combined toolset with clear naming
 const tools: Record<string, any> = {};
 
-// Source tools: rename for clarity
+// Source tools: keep only read-only operations
 for (const [name, tool] of Object.entries(sourceTools)) {
   // Keep read-only tools from source, skip write/delete
   if (name === 'read_file' || name === 'list_directory' || name === 'grep_file' || name === 'find_files') {

--- a/demos/code-reviewer/index.ts
+++ b/demos/code-reviewer/index.ts
@@ -1,0 +1,270 @@
+/**
+ * Demo: Automated Code Reviewer
+ *
+ * Reads source files from a directory and produces a structured
+ * code review report covering security, bugs, readability, and
+ * best practices.
+ *
+ * Usage:
+ *   npm start /path/to/project
+ *   npm start                    # reviews current directory
+ *
+ * Run: npm start
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+  createAgent,
+  createFileTools,
+  type AgentHooks,
+} from 'agent-do';
+import { FilesystemMemoryStore } from 'agent-do/stores/filesystem';
+import { createAnthropic } from '@ai-sdk/anthropic';
+
+// ═══════════════════════════════════════════════
+//  Configuration
+// ═══════════════════════════════════════════════
+
+const MODEL_ID = 'claude-sonnet-4-6';
+const AGENT_ID = 'reviewer';
+const OUTPUT_DIR = '.data/reviews';
+
+// ═══════════════════════════════════════════════
+//  Setup
+// ═══════════════════════════════════════════════
+
+const apiKey = process.env.ANTHROPIC_API_KEY;
+if (!apiKey) {
+  console.error('Error: ANTHROPIC_API_KEY environment variable is required.');
+  console.error('  export ANTHROPIC_API_KEY=sk-ant-...');
+  process.exit(1);
+}
+
+// Target directory from args or cwd
+const targetDir = path.resolve(process.argv[2] || process.cwd());
+
+if (!fs.existsSync(targetDir)) {
+  console.error(`Error: Directory not found: ${targetDir}`);
+  process.exit(1);
+}
+
+if (!fs.statSync(targetDir).isDirectory()) {
+  console.error(`Error: Not a directory: ${targetDir}`);
+  process.exit(1);
+}
+
+console.log('');
+console.log('='.repeat(55));
+console.log('  Automated Code Reviewer');
+console.log('='.repeat(55));
+console.log('');
+console.log(`  Target:  ${targetDir}`);
+console.log(`  Model:   ${MODEL_ID}`);
+console.log(`  Mode:    READ-ONLY`);
+console.log('');
+
+// ═══════════════════════════════════════════════
+//  Read-only filesystem store for the source code
+// ═══════════════════════════════════════════════
+
+// The review target is mounted read-only -- the agent cannot modify the code
+const sourceStore = new FilesystemMemoryStore(targetDir, { readOnly: true });
+
+// A writable store for saving the review output
+const outputStore = new FilesystemMemoryStore(OUTPUT_DIR);
+fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+
+// Combine both into tools:
+//   - Source code tools are read-only (prefixed with source_)
+//   - Output tools can write (for saving the review)
+const sourceTools = createFileTools(sourceStore, AGENT_ID);
+const outputTools = createFileTools(outputStore, AGENT_ID);
+
+// Build a combined toolset with clear naming
+const tools: Record<string, any> = {};
+
+// Source tools: rename for clarity
+for (const [name, tool] of Object.entries(sourceTools)) {
+  // Keep read-only tools from source, skip write/delete
+  if (name === 'read_file' || name === 'list_directory' || name === 'grep_file' || name === 'find_files') {
+    tools[name] = tool;
+  }
+}
+
+// Output tools: add write capability with a distinct name
+tools['save_review'] = outputTools['write_file'];
+
+// ═══════════════════════════════════════════════
+//  Lifecycle hooks for progress logging
+// ═══════════════════════════════════════════════
+
+let filesRead = 0;
+let toolCalls = 0;
+
+const hooks: AgentHooks = {
+  onPreToolUse: async (event) => {
+    toolCalls++;
+    if (event.toolName === 'read_file') {
+      filesRead++;
+      const args = event.args as { path: string };
+      console.log(`  [reading] ${args.path}`);
+    } else if (event.toolName === 'find_files') {
+      console.log('  [scanning] Discovering project structure...');
+    } else if (event.toolName === 'list_directory') {
+      const args = event.args as { path?: string };
+      console.log(`  [listing] ${args.path || '.'}`);
+    } else if (event.toolName === 'grep_file') {
+      const args = event.args as { pattern: string };
+      console.log(`  [searching] Pattern: "${args.pattern}"`);
+    } else if (event.toolName === 'save_review') {
+      const args = event.args as { path: string };
+      console.log(`  [saving] Review to ${args.path}`);
+    }
+    return { decision: 'allow' };
+  },
+
+  onStepStart: async (event) => {
+    if (event.step === 0) {
+      console.log('  Analyzing code...');
+      console.log('');
+    }
+    return { decision: 'continue' };
+  },
+
+  onUsage: async (record) => {
+    console.log(`  [usage] step ${record.step}: ${record.inputTokens.toLocaleString()} in + ${record.outputTokens.toLocaleString()} out ($${record.estimatedCost.toFixed(4)})`);
+  },
+
+  onComplete: async (event) => {
+    console.log('');
+    console.log('-'.repeat(55));
+    console.log('  Review complete');
+    console.log(`    Files read:  ${filesRead}`);
+    console.log(`    Tool calls:  ${toolCalls}`);
+    console.log(`    Steps:       ${event.totalSteps}`);
+    console.log(`    Tokens:      ${(event.usage.totalInputTokens + event.usage.totalOutputTokens).toLocaleString()}`);
+    console.log(`    Cost:        $${event.usage.totalCost.toFixed(4)}`);
+    console.log('-'.repeat(55));
+  },
+};
+
+// ═══════════════════════════════════════════════
+//  Create the reviewer agent
+// ═══════════════════════════════════════════════
+
+const agent = createAgent({
+  id: AGENT_ID,
+  name: 'Code Reviewer',
+  model: createAnthropic({ apiKey })(MODEL_ID) as any,
+  systemPrompt: `You are an expert code reviewer. You analyze source code for issues across several categories.
+
+Your review process:
+1. First, use find_files to discover the project structure
+2. Read the key source files (prioritize .ts, .js, .py, .go, .rs, .java, .tsx, .jsx files)
+3. Skip node_modules, .git, dist, build, and other generated directories
+4. Analyze each file for issues
+5. Produce a structured review report
+6. Save the review using save_review
+
+Your review should cover:
+
+## Security
+- Injection vulnerabilities (SQL, XSS, command injection)
+- Authentication and authorization issues
+- Hardcoded secrets or credentials
+- Unsafe deserialization
+- Path traversal risks
+
+## Bugs & Logic Errors
+- Null/undefined handling
+- Off-by-one errors
+- Race conditions
+- Unhandled error cases
+- Type coercion issues
+
+## Code Quality
+- Readability and naming conventions
+- Code duplication
+- Function length and complexity
+- Dead code
+- Missing error handling
+
+## Best Practices
+- Dependency management
+- Configuration management
+- Logging and observability
+- Testing coverage (if tests exist)
+- Documentation
+
+Format your review as a markdown document with clear severity levels:
+- **CRITICAL**: Security vulnerabilities or bugs that could cause data loss
+- **WARNING**: Issues that should be fixed but are not immediately dangerous
+- **SUGGESTION**: Improvements for readability, maintainability, or performance
+
+For each issue, include:
+- File path and line reference (approximate is fine)
+- Description of the issue
+- Suggested fix or approach
+
+End with a summary section listing counts by severity.`,
+  tools,
+  maxIterations: 15,
+  hooks,
+  usage: { enabled: true },
+});
+
+// ═══════════════════════════════════════════════
+//  Run the review
+// ═══════════════════════════════════════════════
+
+const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+const reviewFilename = `review-${timestamp}.md`;
+
+const task = `Review the code in this project directory.
+
+Explore the file structure, read the important source files, and produce a comprehensive code review.
+
+After completing your review, save it using save_review with path "${reviewFilename}".
+
+Focus on the most impactful findings. If there are many files, prioritize the core source files over configuration and boilerplate.`;
+
+console.log('-'.repeat(55));
+console.log('');
+
+// Stream for real-time output
+let finalText = '';
+
+for await (const event of agent.stream(task)) {
+  switch (event.type) {
+    case 'text':
+      finalText += event.content;
+      break;
+
+    case 'done':
+      break;
+
+    case 'error':
+      console.log(`  [error] ${event.content}`);
+      break;
+
+    // tool-call and tool-result handled by hooks
+  }
+}
+
+// Print the final summary
+console.log('');
+console.log('='.repeat(55));
+console.log('  Review Summary');
+console.log('='.repeat(55));
+console.log('');
+console.log(finalText);
+console.log('');
+
+const reviewPath = path.join(OUTPUT_DIR, AGENT_ID, reviewFilename);
+if (fs.existsSync(reviewPath)) {
+  console.log(`  Full review saved to: ${reviewPath}`);
+} else {
+  console.log(`  Review output directory: ${OUTPUT_DIR}`);
+}
+console.log('');

--- a/demos/code-reviewer/index.ts
+++ b/demos/code-reviewer/index.ts
@@ -70,10 +70,11 @@ console.log('');
 
 // The review target is mounted read-only -- the agent cannot modify the code.
 // FilesystemMemoryStore scopes to {baseDir}/{agentId}/, so we use the parent
-// directory as baseDir and the directory name as agentId. This way
-// read_file("src/index.ts") reads from the actual target directory.
-const sourceStore = new FilesystemMemoryStore(path.dirname(targetDir), { readOnly: true });
-const SOURCE_AGENT_ID = path.basename(targetDir);
+// Use targetDir as baseDir with '.' as agentId — read_file("src/index.ts")
+// resolves to targetDir/src/index.ts. Path traversal (../) is blocked by
+// FilesystemMemoryStore's containment check against baseDir.
+const sourceStore = new FilesystemMemoryStore(targetDir, { readOnly: true });
+const SOURCE_AGENT_ID = '.';
 
 // A writable store for saving the review output
 const outputStore = new FilesystemMemoryStore(OUTPUT_DIR);

--- a/demos/code-reviewer/package-lock.json
+++ b/demos/code-reviewer/package-lock.json
@@ -1,0 +1,660 @@
+{
+  "name": "agent-do-demo-code-reviewer",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "agent-do-demo-code-reviewer",
+      "dependencies": {
+        "agent-do": "file:../../"
+      },
+      "devDependencies": {
+        "@ai-sdk/anthropic": "^3.0.0",
+        "tsx": "^4.0.0"
+      }
+    },
+    "../..": {
+      "version": "0.1.0",
+      "dependencies": {
+        "ai": "^6.0.0",
+        "zod": "^3.23.0"
+      },
+      "devDependencies": {
+        "@types/node": "^25.6.0",
+        "typedoc": "^0.28.0",
+        "typedoc-plugin-markdown": "^4.4.0",
+        "typescript": "^5.5.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@ai-sdk/anthropic": {
+      "version": "3.0.69",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.69.tgz",
+      "integrity": "sha512-LshR7X3pFugY0o41G2VKTmg1XoGpSl7uoYWfzk6zjVZLhCfeFiwgpOga+eTV4XY1VVpZwKVqRnkDbIL7K2eH5g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.23.tgz",
+      "integrity": "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/agent-do": {
+      "resolved": "../..",
+      "link": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
+      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "dev": true,
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/demos/code-reviewer/package.json
+++ b/demos/code-reviewer/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "agent-do-demo-code-reviewer",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx index.ts"
+  },
+  "dependencies": {
+    "agent-do": "file:../../"
+  },
+  "devDependencies": {
+    "@ai-sdk/anthropic": "^3.0.0",
+    "tsx": "^4.0.0"
+  }
+}

--- a/demos/research-team/.gitignore
+++ b/demos/research-team/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.data/

--- a/demos/research-team/README.md
+++ b/demos/research-team/README.md
@@ -1,0 +1,59 @@
+# Multi-Agent Research Pipeline
+
+A multi-agent orchestrator where a Master agent coordinates a Researcher and Writer to produce a polished research report on any topic.
+
+## What it does
+
+- **Master agent** -- Receives a topic and breaks it into research and writing tasks.
+- **Researcher agent** -- Gathers information and key facts about the topic.
+- **Writer agent** -- Takes research output and drafts a polished, structured report.
+- **Real-time progress** -- Logs which agent is active and what tools they are calling.
+- **File output** -- Saves the final report to `.data/reports/` as a markdown file.
+
+## How to run
+
+```bash
+# Install dependencies
+npm install
+
+# Set your API key
+export ANTHROPIC_API_KEY=sk-ant-...
+
+# Run with a topic (passed as argument or prompted)
+npm start "Rust programming language"
+npm start "the history of the internet"
+npm start  # prompts for a topic interactively
+```
+
+## What to expect
+
+1. The master agent receives the topic.
+2. Progress logs show delegation: "Master delegating to Researcher...", "Researcher working...", etc.
+3. The researcher returns findings to the master.
+4. The master delegates writing to the writer agent.
+5. The writer drafts a structured report.
+6. The master saves the report to `.data/reports/`.
+7. The final report is printed to the console.
+
+## Architecture
+
+```
+User (topic)
+  |
+  v
+Master Agent (claude-sonnet-4-6)
+  |--- delegate_task("researcher", "Research X...")
+  |      |
+  |      v
+  |    Researcher Agent (claude-haiku-4-5)
+  |      returns findings
+  |
+  |--- delegate_task("writer", "Write a report using...")
+  |      |
+  |      v
+  |    Writer Agent (claude-haiku-4-5)
+  |      returns polished report
+  |
+  v
+Final report saved to .data/reports/
+```

--- a/demos/research-team/README.md
+++ b/demos/research-team/README.md
@@ -8,12 +8,15 @@ A multi-agent orchestrator where a Master agent coordinates a Researcher and Wri
 - **Researcher agent** -- Gathers information and key facts about the topic.
 - **Writer agent** -- Takes research output and drafts a polished, structured report.
 - **Real-time progress** -- Logs which agent is active and what tools they are calling.
-- **File output** -- Saves the final report to `.data/reports/` as a markdown file.
+- **File output** -- Saves the final report to `.data/master/reports/` as a markdown file (scoped under the master agent's ID by `FilesystemMemoryStore`).
 
 ## How to run
 
 ```bash
-# Install dependencies
+# Install repo root dependencies first (if not already done)
+# (cd ../.. && npm install)
+
+# Install demo dependencies
 npm install
 
 # Set your API key
@@ -32,7 +35,7 @@ npm start  # prompts for a topic interactively
 3. The researcher returns findings to the master.
 4. The master delegates writing to the writer agent.
 5. The writer drafts a structured report.
-6. The master saves the report to `.data/reports/`.
+6. The master saves the report to `.data/master/reports/`.
 7. The final report is printed to the console.
 
 ## Architecture
@@ -55,5 +58,5 @@ Master Agent (claude-sonnet-4-6)
   |      returns polished report
   |
   v
-Final report saved to .data/reports/
+Final report saved to .data/master/reports/
 ```

--- a/demos/research-team/index.ts
+++ b/demos/research-team/index.ts
@@ -1,0 +1,261 @@
+/**
+ * Demo: Multi-Agent Research Pipeline
+ *
+ * A master agent coordinates a Researcher and Writer to produce
+ * a polished research report on any topic.
+ *
+ * Usage:
+ *   npm start "Rust programming language"
+ *   npm start                              # prompts for a topic
+ *
+ * Run: npm start
+ */
+
+import * as readline from 'node:readline';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+  createOrchestrator,
+  createFileTools,
+} from 'agent-do';
+import { FilesystemMemoryStore } from 'agent-do/stores/filesystem';
+import { createAnthropic } from '@ai-sdk/anthropic';
+
+// ═══════════════════════════════════════════════
+//  Configuration
+// ═══════════════════════════════════════════════
+
+const DATA_DIR = '.data';
+const REPORTS_DIR = path.join(DATA_DIR, 'reports');
+const MASTER_MODEL = 'claude-sonnet-4-6';
+const WORKER_MODEL = 'claude-haiku-4-5';
+
+// ═══════════════════════════════════════════════
+//  Setup
+// ═══════════════════════════════════════════════
+
+const apiKey = process.env.ANTHROPIC_API_KEY;
+if (!apiKey) {
+  console.error('Error: ANTHROPIC_API_KEY environment variable is required.');
+  console.error('  export ANTHROPIC_API_KEY=sk-ant-...');
+  process.exit(1);
+}
+
+// Ensure reports directory exists
+fs.mkdirSync(REPORTS_DIR, { recursive: true });
+
+const provider = createAnthropic({ apiKey });
+
+// Persistent filesystem store for the master (to save reports)
+const store = new FilesystemMemoryStore(DATA_DIR);
+const masterFileTools = createFileTools(store, 'master');
+
+// ═══════════════════════════════════════════════
+//  Build the orchestrator
+// ═══════════════════════════════════════════════
+
+console.log('');
+console.log('='.repeat(55));
+console.log('  Multi-Agent Research Pipeline');
+console.log('='.repeat(55));
+console.log('');
+console.log('  Agents:');
+console.log(`    Master:     ${MASTER_MODEL} (coordinates work)`);
+console.log(`    Researcher: ${WORKER_MODEL} (gathers information)`);
+console.log(`    Writer:     ${WORKER_MODEL} (drafts the report)`);
+console.log('');
+
+const orchestrator = createOrchestrator({
+  master: {
+    id: 'master',
+    name: 'Master',
+    model: provider(MASTER_MODEL) as any,
+    systemPrompt: `You are a master agent coordinating a research pipeline.
+
+Your workflow:
+1. Receive a topic from the user
+2. Delegate research to the "researcher" agent with a clear research brief
+3. Review the research results
+4. Delegate writing to the "writer" agent, passing the research findings and asking for a structured report
+5. Save the final report using write_file to "reports/<topic-slug>.md"
+
+Available workers:
+- researcher: Gathers comprehensive information, key facts, history, and current state of a topic
+- writer: Takes research notes and produces a polished, well-structured markdown report
+
+Always delegate to both workers. Do not write the report yourself.
+Save the final report to a file before responding.`,
+    tools: masterFileTools,
+    maxIterations: 8,
+    hooks: {
+      onPreToolUse: async (event) => {
+        if (event.toolName === 'delegate_task') {
+          const args = event.args as { agentId: string; task: string };
+          const taskPreview = args.task.length > 80
+            ? args.task.slice(0, 80) + '...'
+            : args.task;
+          console.log('');
+          console.log(`  >> Master delegating to ${args.agentId.toUpperCase()}`);
+          console.log(`     Task: "${taskPreview}"`);
+          console.log(`     ${args.agentId === 'researcher' ? 'Researcher working...' : 'Writer drafting...'}`);
+        } else if (event.toolName === 'write_file') {
+          const args = event.args as { path: string };
+          console.log(`  >> Master saving report to ${args.path}`);
+        }
+        return { decision: 'allow' };
+      },
+      onPostToolUse: async (event) => {
+        if (event.toolName === 'delegate_task') {
+          const args = event.args as { agentId: string };
+          const resultStr = String(event.result);
+          const preview = resultStr.length > 100
+            ? resultStr.slice(0, 100) + '...'
+            : resultStr;
+          console.log(`     ${args.agentId === 'researcher' ? 'Researcher' : 'Writer'} finished (${event.durationMs}ms)`);
+          console.log(`     Result preview: ${preview}`);
+        }
+      },
+      onUsage: async (record) => {
+        console.log(`  [master-usage] step ${record.step}: ${record.inputTokens.toLocaleString()} in + ${record.outputTokens.toLocaleString()} out ($${record.estimatedCost.toFixed(4)})`);
+      },
+      onComplete: async (event) => {
+        console.log('');
+        console.log('-'.repeat(55));
+        console.log('  Pipeline complete');
+        console.log(`    Steps:  ${event.totalSteps}`);
+        console.log(`    Tokens: ${(event.usage.totalInputTokens + event.usage.totalOutputTokens).toLocaleString()}`);
+        console.log(`    Cost:   $${event.usage.totalCost.toFixed(4)}`);
+        console.log('-'.repeat(55));
+      },
+    },
+    usage: { enabled: true },
+  },
+  workers: [
+    {
+      id: 'researcher',
+      name: 'Researcher',
+      model: provider(WORKER_MODEL) as any,
+      systemPrompt: `You are a research specialist. When given a topic, provide comprehensive research including:
+
+- Overview and definition
+- Key history and milestones
+- Current state and recent developments
+- Major players, tools, or organizations involved
+- Strengths, weaknesses, and common criticisms
+- Future outlook and trends
+
+Be thorough but concise. Present findings as structured notes with clear headings.
+Cite specific facts, dates, and numbers where possible.`,
+      maxIterations: 3,
+    },
+    {
+      id: 'writer',
+      name: 'Writer',
+      model: provider(WORKER_MODEL) as any,
+      systemPrompt: `You are a writing specialist. When given research notes, produce a polished markdown report with:
+
+- A clear title (# heading)
+- An executive summary (2-3 sentences)
+- Well-organized sections with ## headings
+- Key takeaways or conclusions at the end
+
+Write in a clear, professional tone. Use bullet points for lists of facts.
+The report should be self-contained and readable without the original research notes.`,
+      maxIterations: 3,
+    },
+  ],
+});
+
+// ═══════════════════════════════════════════════
+//  Get the topic
+// ═══════════════════════════════════════════════
+
+async function getTopic(): Promise<string> {
+  // Check command line args (skip node and script path)
+  const args = process.argv.slice(2);
+  if (args.length > 0) {
+    return args.join(' ');
+  }
+
+  // Prompt interactively
+  return new Promise((resolve) => {
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+    rl.question('  Enter a research topic: ', (answer) => {
+      rl.close();
+      resolve(answer.trim());
+    });
+  });
+}
+
+// ═══════════════════════════════════════════════
+//  Run the pipeline
+// ═══════════════════════════════════════════════
+
+const topic = await getTopic();
+
+if (!topic) {
+  console.error('  Error: No topic provided.');
+  process.exit(1);
+}
+
+console.log('');
+console.log('='.repeat(55));
+console.log(`  Researching: "${topic}"`);
+console.log('='.repeat(55));
+
+const task = `Research and write a comprehensive report about: ${topic}
+
+Steps:
+1. Delegate research to the researcher agent
+2. Delegate writing to the writer agent, passing the research results
+3. Save the final report to reports/${topic.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '')}.md
+4. Return a brief summary of the report`;
+
+// Stream events for real-time progress
+let finalText = '';
+let currentStep = -1;
+
+for await (const event of orchestrator.stream(task)) {
+  switch (event.type) {
+    case 'thinking':
+      if (event.step !== undefined && event.step !== currentStep) {
+        currentStep = event.step;
+        console.log(`\n  -- Master step ${currentStep + 1} --`);
+      }
+      break;
+
+    case 'tool-call':
+      // Delegation logging handled by hooks above
+      if (event.toolName !== 'delegate_task' && event.toolName !== 'write_file') {
+        console.log(`  [tool-call] ${event.toolName}`);
+      }
+      break;
+
+    case 'tool-result':
+      // Results logging handled by hooks above
+      break;
+
+    case 'text':
+      finalText += event.content;
+      break;
+
+    case 'done':
+      break;
+
+    case 'error':
+      console.log(`  [error] ${event.content}`);
+      break;
+  }
+}
+
+// Print the final summary
+console.log('');
+console.log('='.repeat(55));
+console.log('  Final Summary');
+console.log('='.repeat(55));
+console.log('');
+console.log(finalText);
+console.log('');

--- a/demos/research-team/index.ts
+++ b/demos/research-team/index.ts
@@ -12,8 +12,6 @@
  */
 
 import * as readline from 'node:readline';
-import * as fs from 'node:fs';
-import * as path from 'node:path';
 import {
   createOrchestrator,
   createFileTools,
@@ -26,7 +24,6 @@ import { createAnthropic } from '@ai-sdk/anthropic';
 // ═══════════════════════════════════════════════
 
 const DATA_DIR = '.data';
-const REPORTS_DIR = path.join(DATA_DIR, 'reports');
 const MASTER_MODEL = 'claude-sonnet-4-6';
 const WORKER_MODEL = 'claude-haiku-4-5';
 
@@ -40,9 +37,6 @@ if (!apiKey) {
   console.error('  export ANTHROPIC_API_KEY=sk-ant-...');
   process.exit(1);
 }
-
-// Ensure reports directory exists
-fs.mkdirSync(REPORTS_DIR, { recursive: true });
 
 const provider = createAnthropic({ apiKey });
 

--- a/demos/research-team/package-lock.json
+++ b/demos/research-team/package-lock.json
@@ -1,0 +1,660 @@
+{
+  "name": "agent-do-demo-research-team",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "agent-do-demo-research-team",
+      "dependencies": {
+        "agent-do": "file:../../"
+      },
+      "devDependencies": {
+        "@ai-sdk/anthropic": "^3.0.0",
+        "tsx": "^4.0.0"
+      }
+    },
+    "../..": {
+      "version": "0.1.0",
+      "dependencies": {
+        "ai": "^6.0.0",
+        "zod": "^3.23.0"
+      },
+      "devDependencies": {
+        "@types/node": "^25.6.0",
+        "typedoc": "^0.28.0",
+        "typedoc-plugin-markdown": "^4.4.0",
+        "typescript": "^5.5.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@ai-sdk/anthropic": {
+      "version": "3.0.69",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.69.tgz",
+      "integrity": "sha512-LshR7X3pFugY0o41G2VKTmg1XoGpSl7uoYWfzk6zjVZLhCfeFiwgpOga+eTV4XY1VVpZwKVqRnkDbIL7K2eH5g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.23.tgz",
+      "integrity": "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/agent-do": {
+      "resolved": "../..",
+      "link": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
+      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "dev": true,
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/demos/research-team/package.json
+++ b/demos/research-team/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "agent-do-demo-research-team",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx index.ts"
+  },
+  "dependencies": {
+    "agent-do": "file:../../"
+  },
+  "devDependencies": {
+    "@ai-sdk/anthropic": "^3.0.0",
+    "tsx": "^4.0.0"
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #2 — Create comprehensive end-to-end demos in a demos/ folder.

### Three demos

**1. `demos/assistant/`** — Interactive CLI Assistant
- Persistent filesystem memory
- Multi-turn conversation history
- File tools, streaming output, usage tracking
- readline loop with session summary on exit

**2. `demos/research-team/`** — Multi-Agent Research Pipeline
- Master + Researcher + Writer via createOrchestrator
- Real-time progress showing which agent is working
- Saves final report to filesystem

**3. `demos/code-reviewer/`** — Automated Code Review
- readOnly FilesystemMemoryStore (can't modify source)
- Structured severity levels (CRITICAL/WARNING/SUGGESTION)
- Saves review report as markdown

### Infrastructure
- Each demo uses `"agent-do": "file:../../"` — imports look public but resolve locally
- Own package.json, README.md, .gitignore
- Top-level demos/README.md

### CLAUDE.md updated
- Added demos to project structure
- New rule: verify demos on API changes
- Demos vs Examples table
- Testing strategy section

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` — 111 tests pass
- [x] All three demos install cleanly (`npm install`)
- [x] No `@chaos` references


🤖 Generated with [Claude Code](https://claude.com/claude-code)