### PR TITLE
System prompt builder with templates, sections, and variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,6 +629,19 @@ const result = await agent.run('Weather in London?');
 | `FileEntry` | File/directory entry from `list()` |
 | `ConversationMessage` | User/assistant message for conversation history |
 | `Orchestrator` / `OrchestratorConfig` | Multi-agent orchestration types |
+| `BuildSystemPromptOptions` | Options for the prompt builder |
+| `SectionFn` | Function that returns a prompt section string |
+| `PromptTemplate` | Named template with ordered section list |
+
+### Prompt exports (`agent-do/prompts`)
+
+| Export | Type | Description |
+|--------|------|-------------|
+| `buildSystemPrompt` | function | Compose a system prompt from templates, sections, and variables |
+| `interpolate` | function | Simple `{{variable}}` replacement |
+| `builtinTemplates` | object | Preconfigured templates: assistant, coder, researcher, reviewer, writer, planner |
+| `builtinSections` | object | Reusable sections: identity, memoryManagement, fileTools, efficiency, etc. |
+| `roleSections` | object | Role-specific sections: codingApproach, researchApproach, etc. |
 
 ### Store exports (`agent-do/stores`)
 
@@ -661,6 +674,7 @@ The [`examples/`](examples/) directory contains runnable examples:
 | 9 | [`09-skills.ts`](examples/09-skills.ts) | Skills system |
 | 10 | [`10-testing.ts`](examples/10-testing.ts) | Testing with createMockModel |
 | 11 | [`11-filesystem-store.ts`](examples/11-filesystem-store.ts) | Persistent filesystem storage — explore the created files |
+| 12 | [`12-prompt-builder.ts`](examples/12-prompt-builder.ts) | Composable system prompts from templates + sections + variables |
 
 Run any example: `npx tsx examples/01-basic-agent.ts`
 

--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ The generated tools are:
 |------|-------------|
 | `read_file` | Read a file's contents |
 | `write_file` | Write content to a file (creates parent dirs) |
+| `edit_file` | Find-and-replace in a file (match must be unique) |
 | `list_directory` | List files and directories at a path |
 | `delete_file` | Delete a file |
 | `grep_file` | Search for a text pattern across files |

--- a/examples/12-prompt-builder.ts
+++ b/examples/12-prompt-builder.ts
@@ -1,0 +1,123 @@
+/**
+ * Example 12: System Prompt Builder
+ *
+ * Build system prompts from composable templates, sections, and variables.
+ * Override any section, add custom ones, or create templates from scratch.
+ *
+ * Run: npx tsx examples/12-prompt-builder.ts
+ */
+
+import {
+  buildSystemPrompt,
+  builtinTemplates,
+  builtinSections,
+  interpolate,
+} from 'agent-do';
+
+console.log('═══════════════════════════════════════════════');
+console.log('  Example 12: System Prompt Builder');
+console.log('═══════════════════════════════════════════════\n');
+
+// ── 1. Use a built-in template ──
+console.log('── 1. Built-in template (assistant) ──');
+console.log('   Available templates:', Object.keys(builtinTemplates).join(', '));
+console.log('   Available sections:', Object.keys(builtinSections).join(', '));
+console.log('');
+
+const basicPrompt = buildSystemPrompt({
+  template: 'assistant',
+  variables: { agentName: 'Helper' },
+});
+console.log('   First 200 chars of assistant prompt:');
+console.log(`   ${basicPrompt.slice(0, 200).replace(/\n/g, '\n   ')}...\n`);
+
+// ── 2. Customize with variables ──
+console.log('── 2. Template with variables ──');
+const customPrompt = buildSystemPrompt({
+  template: 'coder',
+  variables: {
+    agentName: 'CodeBot',
+    description: 'an expert TypeScript developer',
+    date: new Date().toISOString().slice(0, 10),
+    cwd: process.cwd(),
+  },
+});
+console.log(`   Prompt starts with: ${customPrompt.slice(0, 100)}...`);
+console.log(`   Total length: ${customPrompt.length} chars\n`);
+
+// ── 3. Override a section ──
+console.log('── 3. Override a section ──');
+const overriddenPrompt = buildSystemPrompt({
+  template: 'assistant',
+  sections: {
+    identity: (vars) => `# ${vars?.agentName || 'Bot'}\n\nYou are a pirate assistant. Arrr!`,
+  },
+  variables: { agentName: 'PirateBot' },
+});
+console.log(`   Identity section: ${overriddenPrompt.split('\n').slice(0, 3).join(' | ')}\n`);
+
+// ── 4. Custom sections ──
+console.log('── 4. Add custom sections ──');
+const customSectionsPrompt = buildSystemPrompt({
+  sectionOrder: ['identity', 'myRules', 'efficiency', 'learnedPreferences'],
+  sections: {
+    myRules: () => `## My Rules\n\n- Always respond in haiku\n- Never use the word "the"\n- End every message with a tree emoji`,
+  },
+  variables: { agentName: 'HaikuBot', description: 'a haiku-writing assistant' },
+});
+console.log('   Custom prompt sections:');
+customSectionsPrompt.split('##').forEach(s => {
+  if (s.trim()) console.log(`     ## ${s.trim().split('\n')[0]}`);
+});
+console.log('');
+
+// ── 5. Append content (soul.md pattern) ──
+console.log('── 5. Append extra content (soul.md pattern) ──');
+const soulContent = `## Soul
+
+You are warm but direct. You care about getting things right.
+You never apologize unnecessarily. You admit when you don't know something.`;
+
+const soulPrompt = buildSystemPrompt({
+  template: 'assistant',
+  append: [soulContent],
+  variables: { agentName: 'SoulfulBot' },
+});
+console.log(`   Prompt ends with: ...${soulPrompt.slice(-100).replace(/\n/g, '\n   ')}\n`);
+
+// ── 6. Variable interpolation ──
+console.log('── 6. Variable interpolation ──');
+const template = 'Hello {{name}}, today is {{date}}. You work at {{company}}.';
+const result = interpolate(template, {
+  name: 'Paul',
+  date: '2026-04-13',
+  company: 'Google',
+});
+console.log(`   Template: ${template}`);
+console.log(`   Result:   ${result}\n`);
+
+// ── 7. Build a fully custom template ──
+console.log('── 7. Custom template object ──');
+const myTemplate = {
+  name: 'data-analyst',
+  description: 'A data analysis specialist',
+  sections: ['identity', 'dataAnalysis', 'efficiency', 'concise'],
+};
+
+const dataPrompt = buildSystemPrompt({
+  template: myTemplate,
+  sections: {
+    dataAnalysis: () => `## Data Analysis
+
+When analyzing data:
+1. Understand the data structure and types
+2. Look for patterns, outliers, and trends
+3. Present findings with charts when possible
+4. Always show your work and methodology`,
+  },
+  variables: { agentName: 'DataBot', description: 'a data analysis expert' },
+});
+console.log(`   Custom template "${myTemplate.name}" generated ${dataPrompt.length} chars`);
+console.log(`   Sections: ${myTemplate.sections.join(' → ')}\n`);
+
+console.log('✓ Done — prompts are fully composable and configurable.');

--- a/llms.txt
+++ b/llms.txt
@@ -28,7 +28,7 @@
 
 ## File Tools
 
-- `createFileTools(store: MemoryStore, agentId: string): ToolSet` — creates read_file, write_file, list_directory, delete_file, grep_file, find_files
+- `createFileTools(store: MemoryStore, agentId: string): ToolSet` — creates read_file, write_file, edit_file, list_directory, delete_file, grep_file, find_files
 
 ## Memory Stores
 

--- a/llms.txt
+++ b/llms.txt
@@ -81,3 +81,17 @@
 ## ConversationMessage
 
 - `{ role: 'user' | 'assistant', content: string }` — for passing conversation history
+
+## Prompt Builder (agent-do/prompts)
+
+- `buildSystemPrompt(options: BuildSystemPromptOptions): string` — compose a system prompt
+  - `options.template: string | PromptTemplate` — named template or custom template object
+  - `options.sectionOrder: string[]` — override section order
+  - `options.sections: Record<string, SectionFn>` — custom/override section functions
+  - `options.variables: Record<string, string>` — interpolated into sections
+  - `options.append: Array<string | SectionFn>` — content appended after sections
+  - `options.prepend: Array<string | SectionFn>` — content prepended before sections
+- `interpolate(template, variables): string` — {{variable}} replacement
+- `builtinTemplates` — assistant, coder, researcher, reviewer, writer, planner
+- `builtinSections` — identity, memoryManagement, fileTools, efficiency, concise, selfEditing, learnedPreferences, htmlGeneration, todoTracking, runtimeContext
+- `roleSections` — codingApproach, researchApproach, reviewApproach, writingApproach, planningApproach

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "./testing": "./src/testing/index.ts",
     "./stores": "./src/stores.ts",
     "./stores/in-memory": "./src/stores/in-memory.ts",
-    "./stores/filesystem": "./src/stores/filesystem.ts"
+    "./stores/filesystem": "./src/stores/filesystem.ts",
+    "./prompts": "./src/prompts/index.ts"
   },
   "scripts": {
     "build": "tsc",

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,3 +56,11 @@ export type { MemoryStore, FileEntry } from './stores.js';
 export { InMemoryMemoryStore } from './stores/in-memory.js';
 export { FilesystemMemoryStore } from './stores/filesystem.js';
 export type { FilesystemMemoryStoreOptions } from './types.js';
+
+// Prompt builder
+export { buildSystemPrompt, interpolate } from './prompts/builder.js';
+export { builtinSections } from './prompts/sections.js';
+export { builtinTemplates, roleSections } from './prompts/templates.js';
+export type { BuildSystemPromptOptions } from './prompts/builder.js';
+export type { SectionFn } from './prompts/sections.js';
+export type { PromptTemplate } from './prompts/templates.js';

--- a/src/prompts/builder.ts
+++ b/src/prompts/builder.ts
@@ -137,16 +137,17 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): strin
 
   // Merge section functions: builtins + role-specific + custom overrides
   // Only include own properties to avoid prototype pollution
-  const allSections: Record<string, SectionFn> = {};
+  // Use null-prototype object to prevent __proto__ pollution
+  const allSections: Record<string, SectionFn> = Object.create(null);
   for (const [k, v] of Object.entries(builtinSections)) {
-    if (Object.prototype.hasOwnProperty.call(builtinSections, k)) allSections[k] = v;
+    allSections[k] = v;
   }
   for (const [k, v] of Object.entries(roleSections)) {
-    if (Object.prototype.hasOwnProperty.call(roleSections, k)) allSections[k] = v;
+    allSections[k] = v;
   }
   if (customSections) {
     for (const [k, v] of Object.entries(customSections)) {
-      if (Object.prototype.hasOwnProperty.call(customSections, k)) allSections[k] = v;
+      allSections[k] = v;
     }
   }
 

--- a/src/prompts/builder.ts
+++ b/src/prompts/builder.ts
@@ -19,7 +19,7 @@ export interface BuildSystemPromptOptions {
   /**
    * Start with a named template (e.g. 'assistant', 'coder', 'researcher').
    * The template defines which sections to include and in what order.
-   * If not provided, you must specify `sections` explicitly.
+   * If not provided, defaults to ['identity', 'concise'] unless `sectionOrder` is set.
    */
   template?: string | PromptTemplate;
 
@@ -68,6 +68,12 @@ export interface BuildSystemPromptOptions {
    * Additional content prepended before all sections.
    */
   prepend?: Array<string | SectionFn>;
+
+  /**
+   * Called when a section key in the order list has no matching function.
+   * Defaults to silently skipping. Set to 'throw' to error on unknown sections.
+   */
+  onUnknownSection?: 'skip' | 'throw' | ((key: string) => void);
 }
 
 /**
@@ -111,12 +117,14 @@ export interface BuildSystemPromptOptions {
  * ```
  */
 export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): string {
-  const { template, sectionOrder, sections: customSections, variables, append, prepend } = options;
+  const { template, sectionOrder, sections: customSections, variables, append, prepend, onUnknownSection = 'skip' } = options;
 
-  // Resolve template
+  // Resolve template — use hasOwnProperty for safe lookup
   let resolvedTemplate: PromptTemplate | undefined;
   if (typeof template === 'string') {
-    resolvedTemplate = builtinTemplates[template];
+    resolvedTemplate = Object.prototype.hasOwnProperty.call(builtinTemplates, template)
+      ? builtinTemplates[template]
+      : undefined;
     if (!resolvedTemplate) {
       throw new Error(`Unknown template: "${template}". Available: ${Object.keys(builtinTemplates).join(', ')}`);
     }
@@ -128,11 +136,19 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): strin
   const order = sectionOrder || resolvedTemplate?.sections || ['identity', 'concise'];
 
   // Merge section functions: builtins + role-specific + custom overrides
-  const allSections: Record<string, SectionFn> = {
-    ...builtinSections,
-    ...roleSections,
-    ...(customSections || {}),
-  };
+  // Only include own properties to avoid prototype pollution
+  const allSections: Record<string, SectionFn> = {};
+  for (const [k, v] of Object.entries(builtinSections)) {
+    if (Object.prototype.hasOwnProperty.call(builtinSections, k)) allSections[k] = v;
+  }
+  for (const [k, v] of Object.entries(roleSections)) {
+    if (Object.prototype.hasOwnProperty.call(roleSections, k)) allSections[k] = v;
+  }
+  if (customSections) {
+    for (const [k, v] of Object.entries(customSections)) {
+      if (Object.prototype.hasOwnProperty.call(customSections, k)) allSections[k] = v;
+    }
+  }
 
   // Build the prompt
   const parts: string[] = [];
@@ -146,12 +162,16 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): strin
 
   // Sections
   for (const key of order) {
-    const fn = allSections[key];
-    if (fn) {
-      parts.push(fn(variables));
+    if (Object.prototype.hasOwnProperty.call(allSections, key)) {
+      parts.push(allSections[key]!(variables));
     } else {
-      // Unknown section — skip silently (might be a future section)
-      console.warn(`[buildSystemPrompt] Unknown section: "${key}" — skipping`);
+      // Unknown section
+      if (onUnknownSection === 'throw') {
+        throw new Error(`Unknown section: "${key}". Available: ${Object.keys(allSections).join(', ')}`);
+      } else if (typeof onUnknownSection === 'function') {
+        onUnknownSection(key);
+      }
+      // 'skip' — silently skip
     }
   }
 
@@ -166,9 +186,30 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): strin
 }
 
 /**
- * Simple variable interpolation for templates.
- * Replaces {{variableName}} with the value from the variables object.
+ * Variable interpolation for prompt templates.
+ *
+ * Replaces `{{variableName}}` with the value from the variables object.
+ * Supports `{{#if key}}...{{/if}}` conditional blocks.
+ *
+ * Empty string values are valid — only undefined/missing keys are kept as placeholders.
  */
 export function interpolate(template: string, variables: Record<string, string>): string {
-  return template.replace(/\{\{(\w+)\}\}/g, (_, key) => variables[key] || `{{${key}}}`);
+  // Handle {{#if key}}...{{/if}} blocks
+  let result = template.replace(
+    /\{\{#if\s+(\w+)\}\}([\s\S]*?)\{\{\/if\}\}/g,
+    (_, key: string, content: string) => {
+      const value = Object.prototype.hasOwnProperty.call(variables, key) ? variables[key] : undefined;
+      return value ? content : '';
+    },
+  );
+
+  // Handle {{variable}} replacements — use nullish check so '' is valid
+  result = result.replace(
+    /\{\{(\w+)\}\}/g,
+    (match, key: string) => {
+      return Object.prototype.hasOwnProperty.call(variables, key) ? variables[key]! : match;
+    },
+  );
+
+  return result;
 }

--- a/src/prompts/builder.ts
+++ b/src/prompts/builder.ts
@@ -194,12 +194,15 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): strin
  *
  * Empty string values are valid — only undefined/missing keys are kept as placeholders.
  */
-export function interpolate(template: string, variables: Record<string, string>): string {
+export function interpolate(template: string, variables?: Record<string, string> | null): string {
+  // Defensive: treat null/undefined variables as empty object
+  const vars = variables ?? {};
+
   // Handle {{#if key}}...{{/if}} blocks
   let result = template.replace(
     /\{\{#if\s+(\w+)\}\}([\s\S]*?)\{\{\/if\}\}/g,
     (_, key: string, content: string) => {
-      const value = Object.prototype.hasOwnProperty.call(variables, key) ? variables[key] : undefined;
+      const value = Object.prototype.hasOwnProperty.call(vars, key) ? vars[key] : undefined;
       return value ? content : '';
     },
   );
@@ -208,7 +211,7 @@ export function interpolate(template: string, variables: Record<string, string>)
   result = result.replace(
     /\{\{(\w+)\}\}/g,
     (match, key: string) => {
-      return Object.prototype.hasOwnProperty.call(variables, key) ? variables[key]! : match;
+      return Object.prototype.hasOwnProperty.call(vars, key) ? vars[key]! : match;
     },
   );
 

--- a/src/prompts/builder.ts
+++ b/src/prompts/builder.ts
@@ -1,0 +1,174 @@
+/**
+ * System Prompt Builder
+ *
+ * Composes a system prompt from:
+ * - A template (ordered list of section keys)
+ * - Sections (functions that return markdown)
+ * - Variables (interpolated into sections)
+ * - Additional content (soul.md, rules, custom text)
+ *
+ * Fully configurable — override any section, add custom ones, or skip the
+ * template entirely and provide your own section list.
+ */
+
+import type { SectionFn } from './sections.js';
+import { builtinSections } from './sections.js';
+import { builtinTemplates, roleSections, type PromptTemplate } from './templates.js';
+
+export interface BuildSystemPromptOptions {
+  /**
+   * Start with a named template (e.g. 'assistant', 'coder', 'researcher').
+   * The template defines which sections to include and in what order.
+   * If not provided, you must specify `sections` explicitly.
+   */
+  template?: string | PromptTemplate;
+
+  /**
+   * Override or extend the section order. If a template is provided,
+   * this replaces the template's section list entirely.
+   * If no template, this IS the section list.
+   */
+  sectionOrder?: string[];
+
+  /**
+   * Custom section functions. Merged with built-in sections.
+   * Use this to override built-in sections or add new ones.
+   *
+   * Example:
+   * ```ts
+   * sections: {
+   *   identity: (vars) => `# MyBot\nYou are MyBot, an expert in ${vars?.domain}.`,
+   *   myCustomSection: () => '## Custom\nMy custom instructions.',
+   * }
+   * ```
+   */
+  sections?: Record<string, SectionFn>;
+
+  /**
+   * Variables interpolated into sections. Passed to each section function.
+   *
+   * Common variables:
+   * - `agentName` — used by the identity section
+   * - `description` — agent description for identity
+   * - `date` — current date
+   * - `time` — current time
+   * - `cwd` — working directory
+   * - `userName` — user's name
+   */
+  variables?: Record<string, string>;
+
+  /**
+   * Additional content appended after all sections.
+   * Use for soul.md, rules files, or any extra instructions.
+   * Can be strings or functions that receive variables.
+   */
+  append?: Array<string | SectionFn>;
+
+  /**
+   * Additional content prepended before all sections.
+   */
+  prepend?: Array<string | SectionFn>;
+}
+
+/**
+ * Build a system prompt from a template, sections, and variables.
+ *
+ * @example
+ * ```ts
+ * import { buildSystemPrompt } from 'agent-do/prompts';
+ *
+ * // Use a built-in template with defaults
+ * const prompt = buildSystemPrompt({ template: 'assistant' });
+ *
+ * // Customize with variables
+ * const prompt = buildSystemPrompt({
+ *   template: 'coder',
+ *   variables: { agentName: 'CodeBot', date: '2026-04-13' },
+ * });
+ *
+ * // Override a section
+ * const prompt = buildSystemPrompt({
+ *   template: 'assistant',
+ *   sections: {
+ *     identity: () => '# MyAgent\nYou are a specialized assistant.',
+ *   },
+ * });
+ *
+ * // Full custom — no template
+ * const prompt = buildSystemPrompt({
+ *   sectionOrder: ['identity', 'myRules', 'efficiency'],
+ *   sections: {
+ *     myRules: () => '## Rules\n- Always respond in haiku',
+ *   },
+ *   variables: { agentName: 'HaikuBot' },
+ * });
+ *
+ * // Append a soul.md file
+ * const prompt = buildSystemPrompt({
+ *   template: 'assistant',
+ *   append: [fs.readFileSync('soul.md', 'utf-8')],
+ * });
+ * ```
+ */
+export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): string {
+  const { template, sectionOrder, sections: customSections, variables, append, prepend } = options;
+
+  // Resolve template
+  let resolvedTemplate: PromptTemplate | undefined;
+  if (typeof template === 'string') {
+    resolvedTemplate = builtinTemplates[template];
+    if (!resolvedTemplate) {
+      throw new Error(`Unknown template: "${template}". Available: ${Object.keys(builtinTemplates).join(', ')}`);
+    }
+  } else if (template) {
+    resolvedTemplate = template;
+  }
+
+  // Determine section order
+  const order = sectionOrder || resolvedTemplate?.sections || ['identity', 'concise'];
+
+  // Merge section functions: builtins + role-specific + custom overrides
+  const allSections: Record<string, SectionFn> = {
+    ...builtinSections,
+    ...roleSections,
+    ...(customSections || {}),
+  };
+
+  // Build the prompt
+  const parts: string[] = [];
+
+  // Prepend
+  if (prepend) {
+    for (const item of prepend) {
+      parts.push(typeof item === 'function' ? item(variables) : item);
+    }
+  }
+
+  // Sections
+  for (const key of order) {
+    const fn = allSections[key];
+    if (fn) {
+      parts.push(fn(variables));
+    } else {
+      // Unknown section — skip silently (might be a future section)
+      console.warn(`[buildSystemPrompt] Unknown section: "${key}" — skipping`);
+    }
+  }
+
+  // Append
+  if (append) {
+    for (const item of append) {
+      parts.push(typeof item === 'function' ? item(variables) : item);
+    }
+  }
+
+  return parts.join('\n\n');
+}
+
+/**
+ * Simple variable interpolation for templates.
+ * Replaces {{variableName}} with the value from the variables object.
+ */
+export function interpolate(template: string, variables: Record<string, string>): string {
+  return template.replace(/\{\{(\w+)\}\}/g, (_, key) => variables[key] || `{{${key}}}`);
+}

--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Prompt builder — composable system prompts from templates, sections, and variables.
+ *
+ * @example
+ * ```ts
+ * import { buildSystemPrompt, builtinTemplates, builtinSections } from 'agent-do/prompts';
+ *
+ * const prompt = buildSystemPrompt({
+ *   template: 'assistant',
+ *   variables: { agentName: 'MyBot', date: '2026-04-13' },
+ * });
+ * ```
+ */
+
+export { buildSystemPrompt, interpolate, type BuildSystemPromptOptions } from './builder.js';
+export { builtinSections, type SectionFn } from './sections.js';
+export { builtinTemplates, roleSections, type PromptTemplate } from './templates.js';

--- a/src/prompts/sections.ts
+++ b/src/prompts/sections.ts
@@ -37,7 +37,6 @@ export const fileTools: SectionFn = () => `## File Tools
 You have file tools for reading and writing your private storage:
 - **read_file** — Read a file
 - **write_file** — Write to a file (creates parent dirs)
-- **edit_file** — Find-and-replace in a file
 - **list_directory** — List files and directories
 - **delete_file** — Delete a file
 - **grep_file** — Search files for a pattern

--- a/src/prompts/sections.ts
+++ b/src/prompts/sections.ts
@@ -37,6 +37,7 @@ export const fileTools: SectionFn = () => `## File Tools
 You have file tools for reading and writing your private storage:
 - **read_file** — Read a file
 - **write_file** — Write to a file (creates parent dirs)
+- **edit_file** — Find-and-replace in a file (match must be unique)
 - **list_directory** — List files and directories
 - **delete_file** — Delete a file
 - **grep_file** — Search files for a pattern

--- a/src/prompts/sections.ts
+++ b/src/prompts/sections.ts
@@ -1,0 +1,124 @@
+/**
+ * Built-in prompt sections — reusable building blocks for system prompts.
+ *
+ * Each section is a function that takes optional variables and returns
+ * a markdown string. Users can override or extend any section.
+ */
+
+export type SectionFn = (vars?: Record<string, string>) => string;
+
+/** Core identity — who the agent is */
+export const identity: SectionFn = (vars) => `# ${vars?.agentName || 'Agent'}
+
+You are **${vars?.agentName || 'Agent'}**, ${vars?.description || 'a helpful AI assistant'}.`;
+
+/** Memory management instructions */
+export const memoryManagement: SectionFn = () => `## Memory Management
+
+Your private storage has specific places for different kinds of information:
+
+- **Facts about the user** (name, role, location, interests) → Write to \`memories/user.md\`
+- **Facts about people** the user mentions → Write to \`people/firstname.md\`
+- **Ideas** → Write to \`ideas/\`
+- **Tasks and reminders** → Update \`TODO.md\` with checkbox items
+- **Preferences** about how you should behave → Add to the Learned Preferences section at the bottom of your system instructions
+
+The key distinction: "My name is Paul" is a **fact** → \`memories/user.md\`. "Be more concise" is a **preference** → Learned Preferences.
+
+After each interaction, consider — and ACTUALLY DO these updates:
+1. Did the user share a fact? **Save it NOW.**
+2. Did the user express a preference? **Record it NOW.**
+3. Did the user mention a task? **Add to TODO.md NOW.**
+4. Did you complete a task? **Mark it done NOW.**`;
+
+/** File tool guidelines */
+export const fileTools: SectionFn = () => `## File Tools
+
+You have file tools for reading and writing your private storage:
+- **read_file** — Read a file
+- **write_file** — Write to a file (creates parent dirs)
+- **edit_file** — Find-and-replace in a file
+- **list_directory** — List files and directories
+- **delete_file** — Delete a file
+- **grep_file** — Search files for a pattern
+- **find_files** — Find files by name pattern`;
+
+/** Efficiency instructions */
+export const efficiency: SectionFn = () => `## Efficiency
+
+Use the MINIMUM number of tool calls to get the job done.
+
+- "My name is Paul" = ONE tool call: write_file to memories/user.md. Done.
+- "What is my name?" = ONE tool call: read_file from memories/user.md. Then answer.
+- Do NOT chain unnecessary reads, lists, or searches. Go straight to the answer.`;
+
+/** Response style */
+export const concise: SectionFn = () => `## Response Style
+
+- Be concise but thorough
+- Lead with the answer, then explain if needed
+- Use bullet points for lists of 3+
+- Ask clarifying questions when intent is ambiguous`;
+
+/** Self-editing instructions */
+export const selfEditing: SectionFn = () => `## Self-Editing
+
+You can update your own instructions. But only for **preferences and behavioral instructions**, not facts:
+- The user tells you a style preference ("be more concise", "use bullet points")
+- The user corrects your behavior ("don't apologize so much")
+- You develop a new workflow worth remembering
+
+Facts go in \`memories/\`. Preferences go in Learned Preferences.`;
+
+/** Learned preferences section (grows over time) */
+export const learnedPreferences: SectionFn = () => `## Learned Preferences
+
+(This section grows as you learn about the user's preferred interaction style)`;
+
+/** HTML generation order */
+export const htmlGeneration: SectionFn = () => `## HTML Generation
+
+When generating HTML content, always write in this order:
+1. **HTML structure first** — all DOM elements, classes, IDs
+2. **CSS styles second** — now you know what elements to style
+3. **JavaScript last** — DOM and styles are ready for scripts`;
+
+/** TODO tracking */
+export const todoTracking: SectionFn = () => `## TODO Tracking
+
+Keep TODO.md as a simple checklist. Update it actively:
+
+\`\`\`markdown
+## Active
+- [ ] Task description
+- [ ] Another task
+
+## Done
+- [x] Completed task
+\`\`\`
+
+If the user says "I should update the tests" — that's a TODO. Add it NOW.`;
+
+/** Runtime context with dynamic variables */
+export const runtimeContext: SectionFn = (vars) => {
+  const parts: string[] = ['## Runtime Context'];
+  if (vars?.date) parts.push(`- **Date:** ${vars.date}`);
+  if (vars?.time) parts.push(`- **Time:** ${vars.time}`);
+  if (vars?.cwd) parts.push(`- **Working directory:** ${vars.cwd}`);
+  if (vars?.userName) parts.push(`- **User:** ${vars.userName}`);
+  return parts.join('\n');
+};
+
+/** All built-in sections */
+export const builtinSections: Record<string, SectionFn> = {
+  identity,
+  memoryManagement,
+  fileTools,
+  efficiency,
+  concise,
+  selfEditing,
+  learnedPreferences,
+  htmlGeneration,
+  todoTracking,
+  runtimeContext,
+};

--- a/src/prompts/templates.ts
+++ b/src/prompts/templates.ts
@@ -1,0 +1,128 @@
+/**
+ * Preconfigured prompt templates for common agent roles.
+ *
+ * Each template is a list of section names that get composed
+ * into a full system prompt. Users can override any section
+ * or add custom ones.
+ */
+
+import type { SectionFn } from './sections.js';
+
+/** A template is an ordered list of section keys */
+export interface PromptTemplate {
+  name: string;
+  description: string;
+  sections: string[];
+}
+
+export const assistant: PromptTemplate = {
+  name: 'assistant',
+  description: 'General-purpose helpful assistant',
+  sections: ['identity', 'concise', 'memoryManagement', 'fileTools', 'efficiency', 'todoTracking', 'selfEditing', 'learnedPreferences'],
+};
+
+export const coder: PromptTemplate = {
+  name: 'coder',
+  description: 'Coding-focused agent — writes, debugs, and reviews code',
+  sections: ['identity', 'codingApproach', 'concise', 'memoryManagement', 'fileTools', 'efficiency', 'htmlGeneration', 'selfEditing', 'learnedPreferences'],
+};
+
+export const researcher: PromptTemplate = {
+  name: 'researcher',
+  description: 'Research-focused agent — finds and synthesizes information',
+  sections: ['identity', 'researchApproach', 'concise', 'memoryManagement', 'fileTools', 'efficiency', 'selfEditing', 'learnedPreferences'],
+};
+
+export const reviewer: PromptTemplate = {
+  name: 'reviewer',
+  description: 'Code review agent — catches bugs, security issues, and suggests improvements',
+  sections: ['identity', 'reviewApproach', 'concise', 'memoryManagement', 'fileTools', 'selfEditing', 'learnedPreferences'],
+};
+
+export const writer: PromptTemplate = {
+  name: 'writer',
+  description: 'Writing-focused agent — drafts content, edits, matches voice',
+  sections: ['identity', 'writingApproach', 'concise', 'memoryManagement', 'fileTools', 'selfEditing', 'learnedPreferences'],
+};
+
+export const planner: PromptTemplate = {
+  name: 'planner',
+  description: 'Planning agent — organizes tasks, tracks priorities, manages deadlines',
+  sections: ['identity', 'planningApproach', 'concise', 'memoryManagement', 'fileTools', 'todoTracking', 'selfEditing', 'learnedPreferences'],
+};
+
+/** Role-specific sections (not in the generic sections.ts) */
+export const roleSections: Record<string, SectionFn> = {
+  codingApproach: () => `## Coding Approach
+
+1. **Understand** — Read existing code and context before writing
+2. **Plan** — Outline the approach before implementing
+3. **Implement** — Write clean, well-typed code
+4. **Test** — Consider edge cases and suggest tests
+5. **Review** — Check for bugs, performance, and maintainability
+
+Guidelines:
+- Write TypeScript by default unless the context suggests otherwise
+- Keep functions small and focused
+- Handle errors properly — no silent failures
+- Match the user's existing code style`,
+
+  researchApproach: () => `## Research Approach
+
+1. **Gather** — Find information from multiple sources
+2. **Synthesize** — Combine findings into structured summaries
+3. **Evaluate** — Assess reliability, note conflicts
+4. **Present** — Show findings clearly, then save to memory
+5. **Track** — Save research to memories/ for future reference
+
+Guidelines:
+- Always cite sources when available
+- Distinguish between facts, claims, and speculation
+- Note when information might be outdated
+- Present findings: summary first, then details`,
+
+  reviewApproach: () => `## Review Approach
+
+1. **Understand** — Read goals and context before reviewing
+2. **Analyze** — Look for bugs, security issues, missing edge cases
+3. **Evaluate** — Assess clarity, maintainability, standards adherence
+4. **Suggest** — Provide specific, actionable improvements
+5. **Prioritize** — Classify: CRITICAL (bugs/security) vs WARNING vs SUGGESTION
+
+Guidelines:
+- Explain WHY something is a problem, not just that it is
+- Provide specific fixes, not vague suggestions
+- Be constructive — acknowledge good work
+- Track patterns — flag systemic issues`,
+
+  writingApproach: () => `## Writing Approach
+
+- Learn the user's voice from their existing writing
+- Start with structure (outline), then fill in content
+- Be direct — avoid filler words and unnecessary qualifiers
+- Never use em dashes unless the user explicitly does
+- Adapt format to the audience and medium`,
+
+  planningApproach: () => `## Planning Approach
+
+1. **Capture** — Record tasks, deadlines, commitments in TODO.md immediately
+2. **Prioritize** — Help focus on what matters most
+3. **Coordinate** — Track dependencies between tasks
+4. **Remind** — Surface upcoming deadlines and overdue items
+5. **Review** — Periodically suggest reprioritization
+
+Guidelines:
+- Always confirm deadlines explicitly — don't assume
+- Keep TODO.md as the single source of truth
+- Break large tasks into concrete, actionable steps`,
+};
+
+/** All built-in templates */
+export const builtinTemplates: Record<string, PromptTemplate> = {
+  assistant,
+  coder,
+  researcher,
+  reviewer,
+  writer,
+  planner,
+};

--- a/src/tools/file-tools.ts
+++ b/src/tools/file-tools.ts
@@ -56,6 +56,34 @@ export function createFileTools(store: MemoryStore, agentId: string): ToolSet {
       },
     }),
 
+    edit_file: tool({
+      description: 'Edit a file by replacing an exact string match. The old_string must appear exactly once in the file.',
+      inputSchema: s(
+        z.object({
+          path: z.string().describe('The file path to edit'),
+          old_string: z.string().describe('The exact text to find and replace'),
+          new_string: z.string().describe('The replacement text'),
+        }),
+      ),
+      execute: async ({ path, old_string, new_string }: { path: string; old_string: string; new_string: string }) => {
+        try {
+          const content = await store.read(agentId, path);
+          if (!content.includes(old_string)) {
+            return `Error: old_string not found in ${path}`;
+          }
+          const occurrences = content.split(old_string).length - 1;
+          if (occurrences > 1) {
+            return `Error: old_string found ${occurrences} times in ${path} — must be unique. Provide more context to match exactly once.`;
+          }
+          const updated = content.replace(old_string, new_string);
+          await store.write(agentId, path, updated);
+          return `Successfully edited ${path}`;
+        } catch (err) {
+          return `Error: ${err instanceof Error ? err.message : String(err)}`;
+        }
+      },
+    }),
+
     list_directory: tool({
       description: 'List files and directories at the given path. Returns names and types.',
       inputSchema: s(

--- a/tests/file-tools.test.ts
+++ b/tests/file-tools.test.ts
@@ -25,6 +25,7 @@ describe('createFileTools', () => {
     const tools = getTools();
     expect(Object.keys(tools).sort()).toEqual([
       'delete_file',
+      'edit_file',
       'find_files',
       'grep_file',
       'list_directory',
@@ -92,5 +93,62 @@ describe('createFileTools', () => {
     expect(result).toContain('a.md');
     expect(result).toContain('sub');
     expect(result).toContain('b.md');
+  });
+
+  it('edit_file replaces unique match', async () => {
+    await store.write(agentId, 'doc.md', '# Title\n\nHello world\n\nGoodbye');
+    const result = await execute('edit_file', {
+      path: 'doc.md',
+      old_string: 'Hello world',
+      new_string: 'Hello universe',
+    });
+    expect(result).toContain('Successfully edited');
+    const content = await store.read(agentId, 'doc.md');
+    expect(content).toContain('Hello universe');
+    expect(content).not.toContain('Hello world');
+  });
+
+  it('edit_file rejects when old_string not found', async () => {
+    await store.write(agentId, 'doc.md', 'some content');
+    const result = await execute('edit_file', {
+      path: 'doc.md',
+      old_string: 'nonexistent text',
+      new_string: 'replacement',
+    });
+    expect(result).toContain('not found');
+  });
+
+  it('edit_file rejects when old_string appears multiple times', async () => {
+    await store.write(agentId, 'doc.md', 'foo bar foo baz foo');
+    const result = await execute('edit_file', {
+      path: 'doc.md',
+      old_string: 'foo',
+      new_string: 'qux',
+    });
+    expect(result).toContain('3 times');
+    expect(result).toContain('must be unique');
+    // File should be unchanged
+    const content = await store.read(agentId, 'doc.md');
+    expect(content).toBe('foo bar foo baz foo');
+  });
+
+  it('edit_file returns error for missing file', async () => {
+    const result = await execute('edit_file', {
+      path: 'nonexistent.md',
+      old_string: 'x',
+      new_string: 'y',
+    });
+    expect(result).toContain('Error:');
+  });
+
+  it('creates all expected tools including edit_file', () => {
+    const toolNames = Object.keys(getTools());
+    expect(toolNames).toContain('read_file');
+    expect(toolNames).toContain('write_file');
+    expect(toolNames).toContain('edit_file');
+    expect(toolNames).toContain('list_directory');
+    expect(toolNames).toContain('delete_file');
+    expect(toolNames).toContain('grep_file');
+    expect(toolNames).toContain('find_files');
   });
 });

--- a/tests/prompts.test.ts
+++ b/tests/prompts.test.ts
@@ -214,10 +214,77 @@ describe('buildSystemPrompt edge cases', () => {
     })).not.toThrow();
   });
 
-  it('fileTools section does not mention edit_file', () => {
+  it('fileTools section lists edit_file', () => {
     const result = builtinSections.fileTools();
-    expect(result).not.toContain('edit_file');
+    expect(result).toContain('edit_file');
     expect(result).toContain('read_file');
     expect(result).toContain('write_file');
+  });
+
+  it('prototype method names work as section keys (null-prototype map)', () => {
+    // Keys like 'toString', 'hasOwnProperty' would shadow Object.prototype
+    // on a normal {}, but Object.create(null) handles them safely
+    const prompt = buildSystemPrompt({
+      sectionOrder: ['toString', 'hasOwnProperty'],
+      sections: {
+        'toString': () => 'toString section',
+        'hasOwnProperty': () => 'hasOwn section',
+      },
+    });
+    expect(prompt).toContain('toString section');
+    expect(prompt).toContain('hasOwn section');
+  });
+
+  it('constructor key is handled safely', () => {
+    const prompt = buildSystemPrompt({
+      sectionOrder: ['constructor'],
+      sections: {
+        'constructor': () => 'constructor section',
+      },
+    });
+    expect(prompt).toContain('constructor section');
+  });
+
+  it('empty sectionOrder produces prompt from prepend/append only', () => {
+    const prompt = buildSystemPrompt({
+      sectionOrder: [],
+      prepend: ['before'],
+      append: ['after'],
+    });
+    expect(prompt).toBe('before\n\nafter');
+  });
+
+  it('all builtin templates produce non-empty prompts', () => {
+    for (const name of Object.keys(builtinTemplates)) {
+      const prompt = buildSystemPrompt({ template: name });
+      expect(prompt.length).toBeGreaterThan(100);
+    }
+  });
+});
+
+describe('interpolate advanced', () => {
+  it('{{#if}} with nested variable replacement', () => {
+    const tmpl = '{{#if name}}Hello {{name}}, welcome!{{/if}}';
+    expect(interpolate(tmpl, { name: 'Paul' })).toBe('Hello Paul, welcome!');
+  });
+
+  it('{{#if}} preserves content outside blocks', () => {
+    const tmpl = 'Start. {{#if show}}Middle.{{/if}} End.';
+    expect(interpolate(tmpl, { show: 'yes' })).toBe('Start. Middle. End.');
+    expect(interpolate(tmpl, {})).toBe('Start.  End.');
+  });
+
+  it('handles multiline {{#if}} blocks', () => {
+    const tmpl = '{{#if bio}}Bio:\n{{bio}}\nEnd bio.{{/if}}';
+    expect(interpolate(tmpl, { bio: 'I am a developer.' })).toBe('Bio:\nI am a developer.\nEnd bio.');
+    expect(interpolate(tmpl, {})).toBe('');
+  });
+
+  it('multiple variables in one line', () => {
+    expect(interpolate('{{a}}-{{b}}-{{c}}', { a: '1', b: '2', c: '3' })).toBe('1-2-3');
+  });
+
+  it('same variable used multiple times', () => {
+    expect(interpolate('{{x}} and {{x}} again', { x: 'hi' })).toBe('hi and hi again');
   });
 });

--- a/tests/prompts.test.ts
+++ b/tests/prompts.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from 'vitest';
+import { buildSystemPrompt, interpolate } from '../src/prompts/builder.js';
+import { builtinSections } from '../src/prompts/sections.js';
+import { builtinTemplates } from '../src/prompts/templates.js';
+
+describe('buildSystemPrompt', () => {
+  it('builds from a named template', () => {
+    const prompt = buildSystemPrompt({ template: 'assistant' });
+    expect(prompt).toContain('# Agent');
+    expect(prompt).toContain('Memory Management');
+    expect(prompt).toContain('Efficiency');
+  });
+
+  it('injects variables into sections', () => {
+    const prompt = buildSystemPrompt({
+      template: 'assistant',
+      variables: { agentName: 'TestBot', description: 'a test agent' },
+    });
+    expect(prompt).toContain('# TestBot');
+    expect(prompt).toContain('a test agent');
+  });
+
+  it('allows overriding a section', () => {
+    const prompt = buildSystemPrompt({
+      template: 'assistant',
+      sections: {
+        identity: () => '# CustomBot\nI am custom.',
+      },
+    });
+    expect(prompt).toContain('# CustomBot');
+    expect(prompt).toContain('I am custom.');
+    expect(prompt).not.toContain('# Agent');
+  });
+
+  it('allows custom section order without template', () => {
+    const prompt = buildSystemPrompt({
+      sectionOrder: ['identity', 'efficiency'],
+      variables: { agentName: 'MinimalBot' },
+    });
+    expect(prompt).toContain('# MinimalBot');
+    expect(prompt).toContain('Efficiency');
+    expect(prompt).not.toContain('Memory Management');
+  });
+
+  it('appends extra content', () => {
+    const prompt = buildSystemPrompt({
+      template: 'assistant',
+      append: ['## Extra Rules\nAlways be kind.'],
+    });
+    expect(prompt).toContain('## Extra Rules');
+    expect(prompt).toContain('Always be kind.');
+  });
+
+  it('prepends extra content', () => {
+    const prompt = buildSystemPrompt({
+      template: 'assistant',
+      prepend: ['## Preamble\nThis comes first.'],
+    });
+    const preambleIdx = prompt.indexOf('## Preamble');
+    const identityIdx = prompt.indexOf('# Agent');
+    expect(preambleIdx).toBeLessThan(identityIdx);
+  });
+
+  it('append supports functions', () => {
+    const prompt = buildSystemPrompt({
+      template: 'assistant',
+      append: [(vars) => `Today is ${vars?.date || 'unknown'}.`],
+      variables: { date: '2026-04-13' },
+    });
+    expect(prompt).toContain('Today is 2026-04-13.');
+  });
+
+  it('adds custom sections', () => {
+    const prompt = buildSystemPrompt({
+      sectionOrder: ['identity', 'myCustom'],
+      sections: {
+        myCustom: () => '## My Custom Section\nDo custom things.',
+      },
+    });
+    expect(prompt).toContain('## My Custom Section');
+  });
+
+  it('throws for unknown template name', () => {
+    expect(() => buildSystemPrompt({ template: 'nonexistent' })).toThrow('Unknown template');
+  });
+
+  it('accepts a custom template object', () => {
+    const prompt = buildSystemPrompt({
+      template: {
+        name: 'custom',
+        description: 'A custom template',
+        sections: ['identity', 'efficiency'],
+      },
+      variables: { agentName: 'CustomAgent' },
+    });
+    expect(prompt).toContain('# CustomAgent');
+    expect(prompt).toContain('Efficiency');
+  });
+
+  it('sectionOrder overrides template sections', () => {
+    const prompt = buildSystemPrompt({
+      template: 'assistant',
+      sectionOrder: ['identity'], // only identity, skip everything else
+    });
+    expect(prompt).toContain('# Agent');
+    expect(prompt).not.toContain('Memory Management');
+  });
+
+  it('runtimeContext section includes variables', () => {
+    const prompt = buildSystemPrompt({
+      sectionOrder: ['runtimeContext'],
+      variables: { date: '2026-04-13', cwd: '/home/user', userName: 'Paul' },
+    });
+    expect(prompt).toContain('2026-04-13');
+    expect(prompt).toContain('/home/user');
+    expect(prompt).toContain('Paul');
+  });
+});
+
+describe('builtinTemplates', () => {
+  it('has all expected templates', () => {
+    expect(Object.keys(builtinTemplates)).toEqual(
+      expect.arrayContaining(['assistant', 'coder', 'researcher', 'reviewer', 'writer', 'planner'])
+    );
+  });
+
+  it('each template has sections', () => {
+    for (const [name, tmpl] of Object.entries(builtinTemplates)) {
+      expect(tmpl.sections.length).toBeGreaterThan(0);
+      expect(tmpl.name).toBe(name);
+    }
+  });
+});
+
+describe('builtinSections', () => {
+  it('has all expected sections', () => {
+    const keys = Object.keys(builtinSections);
+    expect(keys).toContain('identity');
+    expect(keys).toContain('memoryManagement');
+    expect(keys).toContain('fileTools');
+    expect(keys).toContain('efficiency');
+    expect(keys).toContain('concise');
+    expect(keys).toContain('selfEditing');
+    expect(keys).toContain('learnedPreferences');
+  });
+
+  it('each section returns a string', () => {
+    for (const fn of Object.values(builtinSections)) {
+      const result = fn();
+      expect(typeof result).toBe('string');
+      expect(result.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('interpolate', () => {
+  it('replaces variables', () => {
+    expect(interpolate('Hello {{name}}!', { name: 'World' })).toBe('Hello World!');
+  });
+
+  it('handles multiple variables', () => {
+    expect(interpolate('{{a}} and {{b}}', { a: 'X', b: 'Y' })).toBe('X and Y');
+  });
+
+  it('preserves unknown variables', () => {
+    expect(interpolate('{{known}} {{unknown}}', { known: 'yes' })).toBe('yes {{unknown}}');
+  });
+
+  it('handles empty variables', () => {
+    expect(interpolate('no vars here', {})).toBe('no vars here');
+  });
+});

--- a/tests/prompts.test.ts
+++ b/tests/prompts.test.ts
@@ -169,4 +169,55 @@ describe('interpolate', () => {
   it('handles empty variables', () => {
     expect(interpolate('no vars here', {})).toBe('no vars here');
   });
+
+  it('treats empty string as a valid value (not missing)', () => {
+    expect(interpolate('value={{key}}', { key: '' })).toBe('value=');
+  });
+
+  it('handles {{#if}} conditional blocks', () => {
+    const tmpl = '{{#if name}}Hello {{name}}!{{/if}}';
+    expect(interpolate(tmpl, { name: 'Paul' })).toBe('Hello Paul!');
+    expect(interpolate(tmpl, {})).toBe('');
+  });
+
+  it('handles {{#if}} with empty value (treated as falsy)', () => {
+    expect(interpolate('{{#if x}}yes{{/if}}', { x: '' })).toBe('');
+  });
+
+  it('handles multiple {{#if}} blocks', () => {
+    const tmpl = '{{#if a}}A{{/if}} {{#if b}}B{{/if}}';
+    expect(interpolate(tmpl, { a: 'yes', b: 'yes' })).toBe('A B');
+    expect(interpolate(tmpl, { a: 'yes' })).toBe('A ');
+  });
+});
+
+describe('buildSystemPrompt edge cases', () => {
+  it('onUnknownSection throw mode', () => {
+    expect(() => buildSystemPrompt({
+      sectionOrder: ['nonexistent'],
+      onUnknownSection: 'throw',
+    })).toThrow('Unknown section');
+  });
+
+  it('onUnknownSection callback mode', () => {
+    const unknown: string[] = [];
+    buildSystemPrompt({
+      sectionOrder: ['identity', 'nope', 'also_nope'],
+      onUnknownSection: (key) => unknown.push(key),
+    });
+    expect(unknown).toEqual(['nope', 'also_nope']);
+  });
+
+  it('onUnknownSection skip mode (default) does not throw', () => {
+    expect(() => buildSystemPrompt({
+      sectionOrder: ['identity', 'nonexistent'],
+    })).not.toThrow();
+  });
+
+  it('fileTools section does not mention edit_file', () => {
+    const result = builtinSections.fileTools();
+    expect(result).not.toContain('edit_file');
+    expect(result).toContain('read_file');
+    expect(result).toContain('write_file');
+  });
 });

--- a/tests/prompts.test.ts
+++ b/tests/prompts.test.ts
@@ -288,3 +288,184 @@ describe('interpolate advanced', () => {
     expect(interpolate('{{x}} and {{x}} again', { x: 'hi' })).toBe('hi and hi again');
   });
 });
+
+describe('interpolate defensive — null/undefined/edge cases', () => {
+  it('handles null variables without throwing', () => {
+    expect(interpolate('Hello {{name}}!', null)).toBe('Hello {{name}}!');
+  });
+
+  it('handles undefined variables without throwing', () => {
+    expect(interpolate('Hello {{name}}!', undefined)).toBe('Hello {{name}}!');
+  });
+
+  it('handles null variables with {{#if}} blocks', () => {
+    const tmpl = '{{#if name}}Hello {{name}}!{{/if}} Done.';
+    expect(interpolate(tmpl, null)).toBe(' Done.');
+  });
+
+  it('handles undefined variables with {{#if}} blocks', () => {
+    const tmpl = '{{#if name}}Hello {{name}}!{{/if}} Done.';
+    expect(interpolate(tmpl, undefined)).toBe(' Done.');
+  });
+
+  it('handles empty template string', () => {
+    expect(interpolate('', { name: 'Paul' })).toBe('');
+    expect(interpolate('', null)).toBe('');
+    expect(interpolate('', {})).toBe('');
+  });
+
+  it('handles template with no placeholders', () => {
+    expect(interpolate('plain text', { name: 'Paul' })).toBe('plain text');
+    expect(interpolate('plain text', null)).toBe('plain text');
+  });
+
+  it('handles variable value containing curly braces', () => {
+    expect(interpolate('{{x}}', { x: '{{y}}' })).toBe('{{y}}');
+  });
+
+  it('handles variable value containing regex special chars', () => {
+    expect(interpolate('{{x}}', { x: 'a.*b+c?(d)' })).toBe('a.*b+c?(d)');
+  });
+
+  it('preserves partial/malformed placeholders', () => {
+    expect(interpolate('{{', {})).toBe('{{');
+    expect(interpolate('}}', {})).toBe('}}');
+    expect(interpolate('{name}', { name: 'Paul' })).toBe('{name}');
+    expect(interpolate('{{ name }}', { name: 'Paul' })).toBe('{{ name }}');
+  });
+
+  it('handles prototype property names as keys safely', () => {
+    expect(interpolate('{{toString}}', { toString: 'safe' })).toBe('safe');
+    expect(interpolate('{{constructor}}', { constructor: 'safe' })).toBe('safe');
+    expect(interpolate('{{hasOwnProperty}}', { hasOwnProperty: 'safe' })).toBe('safe');
+  });
+
+  it('does not resolve prototype methods when key is absent', () => {
+    // toString exists on Object.prototype — should NOT resolve it
+    expect(interpolate('{{toString}}', {})).toBe('{{toString}}');
+    expect(interpolate('{{constructor}}', {})).toBe('{{constructor}}');
+  });
+
+  it('{{#if}} with prototype property names', () => {
+    expect(interpolate('{{#if toString}}yes{{/if}}', { toString: 'val' })).toBe('yes');
+    expect(interpolate('{{#if toString}}yes{{/if}}', {})).toBe('');
+  });
+
+  it('handles adjacent placeholders', () => {
+    expect(interpolate('{{a}}{{b}}', { a: 'x', b: 'y' })).toBe('xy');
+  });
+
+  it('handles variable with newlines in value', () => {
+    expect(interpolate('{{x}}', { x: 'line1\nline2' })).toBe('line1\nline2');
+  });
+
+  it('handles nested {{#if}} blocks (inner not supported — treated as literals)', () => {
+    // The regex is non-greedy, so nested blocks won't work as expected.
+    // This test documents the behavior — inner {{/if}} closes the outer block.
+    const tmpl = '{{#if a}}outer {{#if b}}inner{{/if}} rest{{/if}}';
+    // The first {{/if}} closes the outer block
+    const result = interpolate(tmpl, { a: 'yes', b: 'yes' });
+    expect(result).toContain('outer');
+  });
+
+  it('handles {{#if}} with only whitespace key', () => {
+    // \w+ won't match spaces, so this should pass through unchanged
+    expect(interpolate('{{#if }}text{{/if}}', {})).toBe('{{#if }}text{{/if}}');
+  });
+});
+
+describe('buildSystemPrompt defensive', () => {
+  it('works with no options at all', () => {
+    const prompt = buildSystemPrompt();
+    expect(typeof prompt).toBe('string');
+    expect(prompt.length).toBeGreaterThan(0);
+  });
+
+  it('works with empty options object', () => {
+    const prompt = buildSystemPrompt({});
+    expect(typeof prompt).toBe('string');
+    expect(prompt.length).toBeGreaterThan(0);
+  });
+
+  it('handles variables as undefined', () => {
+    const prompt = buildSystemPrompt({
+      template: 'assistant',
+      variables: undefined,
+    });
+    expect(prompt).toContain('# Agent');
+  });
+
+  it('handles empty append and prepend arrays', () => {
+    const prompt = buildSystemPrompt({
+      template: 'assistant',
+      append: [],
+      prepend: [],
+    });
+    expect(prompt).toContain('# Agent');
+  });
+
+  it('handles sections that return empty strings', () => {
+    const prompt = buildSystemPrompt({
+      sectionOrder: ['empty', 'identity'],
+      sections: { empty: () => '' },
+    });
+    expect(prompt).toContain('# Agent');
+  });
+
+  it('section functions receive undefined vars when no variables provided', () => {
+    let receivedVars: unknown = 'sentinel';
+    buildSystemPrompt({
+      sectionOrder: ['test'],
+      sections: {
+        test: (vars) => {
+          receivedVars = vars;
+          return 'ok';
+        },
+      },
+    });
+    expect(receivedVars).toBeUndefined();
+  });
+
+  it('section functions receive variables when provided', () => {
+    let receivedVars: unknown;
+    buildSystemPrompt({
+      sectionOrder: ['test'],
+      sections: {
+        test: (vars) => {
+          receivedVars = vars;
+          return 'ok';
+        },
+      },
+      variables: { key: 'val' },
+    });
+    expect(receivedVars).toEqual({ key: 'val' });
+  });
+
+  it('append function receives undefined vars when no variables', () => {
+    let receivedVars: unknown = 'sentinel';
+    buildSystemPrompt({
+      sectionOrder: [],
+      append: [(vars) => {
+        receivedVars = vars;
+        return 'appended';
+      }],
+    });
+    expect(receivedVars).toBeUndefined();
+  });
+
+  it('duplicate section keys in order — renders section twice', () => {
+    const prompt = buildSystemPrompt({
+      sectionOrder: ['identity', 'identity'],
+      variables: { agentName: 'DupeBot' },
+    });
+    const matches = prompt.match(/# DupeBot/g);
+    expect(matches?.length).toBe(2);
+  });
+
+  it('custom template object with empty sections array', () => {
+    const prompt = buildSystemPrompt({
+      template: { name: 'empty', description: 'nothing', sections: [] },
+    });
+    expect(prompt).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #5 — System prompt builder with templates, variables, and composable sub-prompts.

### What it does

`buildSystemPrompt()` composes system prompts from reusable, configurable pieces:

```ts
import { buildSystemPrompt } from 'agent-do/prompts';

// Use a built-in template
const prompt = buildSystemPrompt({ template: 'assistant' });

// With variables
const prompt = buildSystemPrompt({
  template: 'coder',
  variables: { agentName: 'CodeBot', date: '2026-04-13' },
});

// Override a section
const prompt = buildSystemPrompt({
  template: 'assistant',
  sections: { identity: () => '# MyBot\nCustom identity.' },
});

// Fully custom
const prompt = buildSystemPrompt({
  sectionOrder: ['identity', 'myRules', 'efficiency'],
  sections: { myRules: () => '## Rules\n- Always respond in haiku' },
  variables: { agentName: 'HaikuBot' },
  append: [soulMdContent],
});
```

### Components

**6 built-in templates:** assistant, coder, researcher, reviewer, writer, planner

**10 built-in sections:** identity, memoryManagement, fileTools, efficiency, concise, selfEditing, learnedPreferences, htmlGeneration, todoTracking, runtimeContext

**5 role-specific sections:** codingApproach, researchApproach, reviewApproach, writingApproach, planningApproach

Everything is a function `(vars?) => string` — fully overridable.

### Key decisions per issue discussion
- Soul.md is just another section/append — not a separate concept
- Sections are configurable functions, not hardcoded strings
- Templates are just ordered lists of section keys
- Users define their own sections and templates freely

## Test plan
- [x] 20 new tests (131 total)
- [x] `npx tsc --noEmit` passes
- [x] Example 12 demonstrates all features
- [x] README and llms.txt updated


🤖 Generated with [Claude Code](https://claude.com/claude-code)