### PR TITLE
Add eval framework with 13 assertion types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,11 @@ src/
   orchestrator.ts   — multi-agent orchestration (master + workers)
   testing/
     index.ts        — createMockModel() for testing
+  eval/
+    index.ts        — eval framework exports
+    types.ts        — eval types (assertions, cases, results)
+    assertions.ts   — assertion evaluators (13 types)
+    runner.ts       — eval runner (defineEval, runEvals)
   index.ts          — all exports
 
 tests/              — vitest unit tests (one file per module)
@@ -99,12 +104,14 @@ Use `createMockModel()` with multi-step response sequences to test:
 - Hooks firing in the right order
 - Permission system blocking/allowing correctly
 
-### Eval Framework (future)
+### Eval Framework (agent-do/eval)
 For evaluating agent quality (not just correctness):
-- Define eval cases: input prompt + expected behavior
-- Run against real models with scoring criteria
-- Track quality metrics over time
-- Compare across model providers
+- `defineEval()` + `runEvals()` for structured eval suites
+- 13 assertion types: contains, not-contains, regex, json-schema, tool-called, tool-not-called, tool-args, file-exists, file-contains, max-steps, max-cost, llm-rubric, custom
+- Multi-provider comparison via `options.providers`
+- LLM-as-judge via `llm-rubric` assertion
+- Output formats: console, json, csv, silent
+- Each case gets isolated memory store
 
 ## Key Design Decisions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,13 @@ src/
     types.ts        — eval types (assertions, cases, results)
     assertions.ts   — assertion evaluators (13 types)
     runner.ts       — eval runner (defineEval, runEvals)
+  cli.ts            — CLI entry point (npx agent-do)
+  cli/
+    args.ts         — argument parser + stdin reader
+    prompt.ts       — prompt mode (one-shot + interactive)
+    script.ts       — script mode (npx agent-do run)
+    eval-cmd.ts     — eval mode (npx agent-do eval)
+    resolve-model.ts — dynamic provider/model resolution
   index.ts          — all exports
 
 tests/              — vitest unit tests (one file per module)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,11 @@ src/
   orchestrator.ts   — multi-agent orchestration (master + workers)
   testing/
     index.ts        — createMockModel() for testing
+  eval/
+    index.ts        — eval framework exports
+    types.ts        — eval types (assertions, cases, results)
+    assertions.ts   — assertion evaluators (13 types)
+    runner.ts       — eval runner (defineEval, runEvals)
   index.ts          — all exports
 
 tests/              — vitest unit tests (one file per module)
@@ -99,12 +104,14 @@ Use `createMockModel()` with multi-step response sequences to test:
 - Hooks firing in the right order
 - Permission system blocking/allowing correctly
 
-### Eval Framework (future)
+### Eval Framework (agent-do/eval)
 For evaluating agent quality (not just correctness):
-- Define eval cases: input prompt + expected behavior
-- Run against real models with scoring criteria
-- Track quality metrics over time
-- Compare across model providers
+- `defineEval()` + `runEvals()` for structured eval suites
+- 13 assertion types: contains, not-contains, regex, json-schema, tool-called, tool-not-called, tool-args, file-exists, file-contains, max-steps, max-cost, llm-rubric, custom
+- Multi-provider comparison via `options.providers`
+- LLM-as-judge via `llm-rubric` assertion
+- Output formats: console, json, csv, silent
+- Each case gets isolated memory store
 
 ## Key Design Decisions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,13 @@ src/
     types.ts        — eval types (assertions, cases, results)
     assertions.ts   — assertion evaluators (13 types)
     runner.ts       — eval runner (defineEval, runEvals)
+  cli.ts            — CLI entry point (npx agent-do)
+  cli/
+    args.ts         — argument parser + stdin reader
+    prompt.ts       — prompt mode (one-shot + interactive)
+    script.ts       — script mode (npx agent-do run)
+    eval-cmd.ts     — eval mode (npx agent-do eval)
+    resolve-model.ts — dynamic provider/model resolution
   index.ts          — all exports
 
 tests/              — vitest unit tests (one file per module)

--- a/README.md
+++ b/README.md
@@ -23,6 +23,69 @@ npm install agent-do
 
 Peer dependency: `ai` (Vercel AI SDK v6+).
 
+## CLI
+
+Run agents from the command line with zero config:
+
+```bash
+# One-shot task
+npx agent-do "What is TypeScript?"
+
+# Pipe content as context
+cat README.md | npx agent-do "Summarize this"
+
+# Pipe + prompt merged
+echo "function add(a, b) { return a + b }" | npx agent-do "Review this code"
+
+# Interactive chat
+npx agent-do
+
+# Choose provider and model
+npx agent-do --provider google --model gemini-2.5-flash "Hello"
+
+# Run a custom agent script (.js files, or .ts with tsx loader)
+npx agent-do run my-agent.js "Do something"
+
+# Run eval cases
+npx agent-do eval evals/basic.ts
+
+# Compare providers
+npx agent-do eval evals/ --compare anthropic,google,openai --output json
+```
+
+### CLI options
+
+```
+npx agent-do [options] [prompt]          One-shot or interactive
+npx agent-do run <file> [task]           Run agent script
+npx agent-do eval <file|dir> [options]   Run evals
+
+Options:
+  --provider <name>      anthropic | google | openai | ollama (default: anthropic)
+  --model <id>           Model ID (default: provider-specific)
+  --system <prompt>      System prompt
+  --memory <dir>         Memory directory (default: .agent-do/)
+  --read-only            No filesystem writes
+  --max-iterations <n>   Max loop iterations (default: 20)
+  --no-tools             Disable file tools
+  --verbose              Show tool calls
+  --json                 JSON output
+  --output <fmt>         console | json | csv (eval only)
+  --compare <providers>  Compare providers (eval only, comma-separated)
+  --concurrency <n>      Parallel eval cases (default: 1)
+```
+
+### Piping
+
+Piped stdin is merged with the command-line prompt:
+
+| stdin | prompt | result |
+|-------|--------|--------|
+| no | `"Hello"` | Task: `"Hello"` |
+| `"context"` | no | Task: `"context"` |
+| `"context"` | `"Summarize"` | Task: `"Summarize\n\n---\n\ncontext"` |
+| no | no | Interactive mode |
+
 ## Quick Start
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Provider-agnostic autonomous agent loop for JavaScript. Built on the [Vercel AI 
 - **Permission system** -- accept-all, deny-all, or ask mode with per-tool overrides
 - **Usage tracking** -- built-in cost estimation for 50+ models with per-run and per-day spending limits
 - **Testable** -- `createMockModel()` returns a mock `LanguageModel` with predetermined responses
+- **Eval framework** -- `defineEval()` + `runEvals()` to measure agent quality with 13 assertion types, LLM-as-judge, and multi-provider comparison
 
 ## Install
 
@@ -584,6 +585,110 @@ const result = await agent.run('Weather in London?');
 | `inputTokensPerCall` | `10` | Simulated input tokens per call |
 | `outputTokensPerCall` | `20` | Simulated output tokens per call |
 
+## Eval Framework
+
+Define eval cases to measure agent quality, compare providers, and catch regressions.
+
+```ts
+import { defineEval, runEvals } from 'agent-do/eval';
+import { createAnthropic } from '@ai-sdk/anthropic';
+
+const anthropic = createAnthropic();
+
+const suite = defineEval({
+  name: 'my-assistant-eval',
+  model: anthropic('claude-haiku-4-5'),
+  systemPrompt: 'You are a helpful assistant.',
+  cases: [
+    {
+      name: 'knows capitals',
+      input: 'What is the capital of France?',
+      assert: [
+        { type: 'contains', value: 'Paris' },
+        { type: 'not-contains', value: 'London' },
+      ],
+    },
+    {
+      name: 'saves notes correctly',
+      input: 'Save a note that my name is Alice.',
+      assert: [
+        { type: 'tool-called', tool: 'write_file' },
+        { type: 'file-contains', path: 'memories/user.md', value: 'Alice' },
+        { type: 'max-steps', max: 5 },
+        { type: 'max-cost', maxUsd: 0.05 },
+      ],
+    },
+  ],
+});
+
+const result = await runEvals(suite);
+// Console output:  ✓ PASS  knows capitals  ($0.0012, 800ms, 1 steps)
+//                  ✓ PASS  saves notes correctly  ($0.0035, 2100ms, 2 steps)
+```
+
+### Assertion types
+
+| Type | Description |
+|------|-------------|
+| `contains` | Response text contains a string |
+| `not-contains` | Response does NOT contain a string |
+| `regex` | Response matches a regex pattern |
+| `json-schema` | Response is valid JSON matching a schema |
+| `tool-called` | A specific tool was called during execution |
+| `tool-not-called` | A specific tool was NOT called |
+| `tool-args` | Tool was called with specific arguments (partial match) |
+| `file-exists` | A file was created in the memory store |
+| `file-contains` | A file in the store contains a string |
+| `max-steps` | Agent completed in N or fewer steps |
+| `max-cost` | Agent completed within a cost budget (USD) |
+| `llm-rubric` | Another LLM scores the response against a rubric |
+| `custom` | Custom function receives the full result |
+
+### Multi-provider comparison
+
+```ts
+const result = await runEvals(suite, {
+  providers: [
+    { name: 'anthropic', model: anthropic('claude-sonnet-4-6') },
+    { name: 'google', model: google('gemini-2.5-flash') },
+    { name: 'openai', model: openai('gpt-4.1-mini') },
+  ],
+});
+// Prints a comparison table with pass rate, cost, and latency per provider
+```
+
+### LLM-as-judge
+
+```ts
+{
+  name: 'explains clearly',
+  input: 'Explain quantum computing to a 10 year old',
+  assert: [
+    {
+      type: 'llm-rubric',
+      rubric: 'The explanation should be simple, use analogies, avoid jargon.',
+      score: 'pass-fail', // or '1-5'
+    },
+  ],
+}
+```
+
+### Output formats
+
+```ts
+// Console output (default)
+await runEvals(suite);
+
+// JSON (for CI/dashboards)
+await runEvals(suite, { output: 'json' });
+
+// CSV (for spreadsheets)
+await runEvals(suite, { output: 'csv' });
+
+// Silent (programmatic use)
+const result = await runEvals(suite, { output: 'silent' });
+```
+
 ## API Reference
 
 ### Main exports (`agent-do`)
@@ -633,6 +738,19 @@ const result = await agent.run('Weather in London?');
 | `BuildSystemPromptOptions` | Options for the prompt builder |
 | `SectionFn` | Function that returns a prompt section string |
 | `PromptTemplate` | Named template with ordered section list |
+| `EvalSuiteConfig` | Eval suite definition (name, model, cases) |
+| `EvalCase` | Single eval test case (input, assertions) |
+| `Assertion` | Union of all assertion types |
+| `EvalResult` | Full eval result with provider breakdowns |
+| `CaseResult` | Result of a single eval case |
+
+### Eval exports (`agent-do/eval`)
+
+| Export | Type | Description |
+|--------|------|-------------|
+| `defineEval` | `(config: EvalSuiteConfig) => EvalSuiteConfig` | Define an eval suite (type-safe helper) |
+| `runEvals` | `(suite, options?) => Promise<EvalResult>` | Run an eval suite and return results |
+| `evaluateAssertion` | `(assertion, result, judgeModel?) => Promise<AssertionResult>` | Evaluate a single assertion |
 
 ### Prompt exports (`agent-do/prompts`)
 
@@ -676,6 +794,7 @@ The [`examples/`](examples/) directory contains runnable examples:
 | 10 | [`10-testing.ts`](examples/10-testing.ts) | Testing with createMockModel |
 | 11 | [`11-filesystem-store.ts`](examples/11-filesystem-store.ts) | Persistent filesystem storage — explore the created files |
 | 12 | [`12-prompt-builder.ts`](examples/12-prompt-builder.ts) | Composable system prompts from templates + sections + variables |
+| 13 | [`13-eval-framework.ts`](examples/13-eval-framework.ts) | Eval framework — define cases, assert quality, compare providers |
 
 Run any example: `npx tsx examples/01-basic-agent.ts`
 

--- a/examples/13-eval-framework.ts
+++ b/examples/13-eval-framework.ts
@@ -1,0 +1,82 @@
+/**
+ * Example 13: Eval Framework
+ *
+ * Demonstrates how to define eval cases, run them against a model,
+ * and check agent quality with assertions.
+ *
+ * Usage:
+ *   export ANTHROPIC_API_KEY=sk-ant-...
+ *   npx tsx examples/13-eval-framework.ts
+ */
+
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { defineEval, runEvals } from 'agent-do/eval';
+
+const anthropic = createAnthropic();
+
+const suite = defineEval({
+  name: 'basic-assistant-eval',
+  model: anthropic('claude-haiku-4-5'),
+  systemPrompt: 'You are a helpful assistant with access to file tools for note-taking.',
+  cases: [
+    // Phase 1: Basic text assertions
+    {
+      name: 'knows basic math',
+      input: 'What is 2 + 2? Reply with just the number.',
+      assert: [
+        { type: 'contains', value: '4' },
+        { type: 'not-contains', value: '5' },
+      ],
+    },
+    {
+      name: 'knows capitals',
+      input: 'What is the capital of France? Reply with just the city name.',
+      assert: [
+        { type: 'contains', value: 'Paris' },
+        { type: 'regex', pattern: 'Paris' },
+      ],
+    },
+
+    // Phase 2: Tool call assertions
+    {
+      name: 'saves a note using write_file',
+      input: 'Save a note that says "Meeting at 3pm" to meetings.md',
+      assert: [
+        { type: 'tool-called', tool: 'write_file' },
+        { type: 'tool-not-called', tool: 'delete_file' },
+        { type: 'file-exists', path: 'meetings.md' },
+        { type: 'file-contains', path: 'meetings.md', value: '3pm' },
+      ],
+    },
+
+    // Performance constraints
+    {
+      name: 'completes efficiently',
+      input: 'Say hello',
+      assert: [
+        { type: 'max-steps', max: 3 },
+        { type: 'max-cost', maxUsd: 0.05 },
+      ],
+    },
+
+    // Custom assertion
+    {
+      name: 'response is not too long',
+      input: 'What is TypeScript in one sentence?',
+      assert: [
+        {
+          type: 'custom',
+          name: 'under 500 chars',
+          fn: (result) => result.text.length < 500,
+        },
+      ],
+    },
+  ],
+});
+
+// Run and print results
+const result = await runEvals(suite);
+
+// Exit with code 1 if any case failed
+const anyFailed = result.providers.some(p => p.failed > 0);
+if (anyFailed) process.exit(1);

--- a/llms.txt
+++ b/llms.txt
@@ -95,3 +95,16 @@
 - `builtinTemplates` — assistant, coder, researcher, reviewer, writer, planner
 - `builtinSections` — identity, memoryManagement, fileTools, efficiency, concise, selfEditing, learnedPreferences, htmlGeneration, todoTracking, runtimeContext
 - `roleSections` — codingApproach, researchApproach, reviewApproach, writingApproach, planningApproach
+
+## Eval Framework (agent-do/eval)
+
+- `defineEval(config: EvalSuiteConfig): EvalSuiteConfig` — define an eval suite
+- `runEvals(suite, options?): Promise<EvalResult>` — run evals, return structured results
+- `evaluateAssertion(assertion, result, judgeModel?): Promise<AssertionResult>` — evaluate one assertion
+- Assertion types: contains, not-contains, regex, json-schema, tool-called, tool-not-called, tool-args, file-exists, file-contains, max-steps, max-cost, llm-rubric, custom
+- Output formats: console (default), json, csv, silent
+- Multi-provider comparison via `options.providers: Array<{ name, model }>`
+- LLM-as-judge via `llm-rubric` assertion with configurable score type (pass-fail or 1-5)
+- Custom assertions via `{ type: 'custom', name, fn: (result) => boolean }`
+- Each case gets isolated memory store — no state leaks between cases
+- `options.concurrency: number` — parallel case execution (default: 1)

--- a/llms.txt
+++ b/llms.txt
@@ -108,3 +108,21 @@
 - Custom assertions via `{ type: 'custom', name, fn: (result) => boolean }`
 - Each case gets isolated memory store — no state leaks between cases
 - `options.concurrency: number` — parallel case execution (default: 1)
+
+## CLI (npx agent-do)
+
+- `npx agent-do "prompt"` — one-shot task with default agent
+- `npx agent-do` — interactive chat REPL
+- `echo "context" | npx agent-do "prompt"` — pipe stdin as context, merged with prompt
+- `npx agent-do run <file>` — run a script exporting an Agent, AgentConfig, or simple config
+- `npx agent-do eval <file|dir>` — run eval cases from file or directory
+- `--provider <name>` — anthropic | google | openai | ollama (default: anthropic)
+- `--model <id>` — model ID (default: provider-specific)
+- `--system <prompt>` — system prompt
+- `--memory <dir>` — memory directory (default: .agent-do/)
+- `--read-only` — no filesystem writes
+- `--verbose` — show tool calls
+- `--json` — JSON output
+- `--compare <providers>` — eval: compare across providers (comma-separated)
+- `--output <format>` — eval: console | json | csv
+- `--concurrency <n>` — eval: parallel case execution

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "./stores": "./src/stores.ts",
     "./stores/in-memory": "./src/stores/in-memory.ts",
     "./stores/filesystem": "./src/stores/filesystem.ts",
-    "./prompts": "./src/prompts/index.ts"
+    "./prompts": "./src/prompts/index.ts",
+    "./eval": "./src/eval/index.ts"
   },
   "scripts": {
     "build": "tsc",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "bin": {
+    "agent-do": "./dist/src/cli.js"
+  },
   "exports": {
     ".": "./src/index.ts",
     "./testing": "./src/testing/index.ts",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+
+/**
+ * agent-do CLI
+ *
+ * Usage:
+ *   npx agent-do "prompt"                     One-shot task
+ *   npx agent-do                              Interactive chat
+ *   echo "prompt" | npx agent-do              Piped input
+ *   echo "context" | npx agent-do "prompt"    Piped context merged with prompt
+ *   npx agent-do run script.ts                Run a script that exports an agent
+ *   npx agent-do eval evals/basic.ts          Run eval cases
+ */
+
+import { parseArgs, type ParsedArgs } from './cli/args.js';
+import { runPromptMode } from './cli/prompt.js';
+import { runScriptMode } from './cli/script.js';
+import { runEvalMode } from './cli/eval-cmd.js';
+
+async function main(): Promise<void> {
+  let args: ParsedArgs;
+  try {
+    args = parseArgs(process.argv.slice(2));
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+
+  try {
+    switch (args.command) {
+      case 'prompt':
+        await runPromptMode(args);
+        break;
+      case 'run':
+        await runScriptMode(args);
+        break;
+      case 'eval':
+        await runEvalMode(args);
+        break;
+    }
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+}
+
+function printHelp(): void {
+  console.log(`
+agent-do — run AI agents from the command line
+
+Usage:
+  npx agent-do [options] [prompt]          One-shot task or interactive chat
+  npx agent-do run <file>                  Run a script that exports an agent
+  npx agent-do eval <file|dir> [options]   Run eval cases
+
+Piping:
+  echo "context" | npx agent-do "prompt"   Merge piped input with prompt
+  cat file.txt | npx agent-do "Summarize"  Pipe file contents as context
+
+Options:
+  --provider <name>      anthropic | google | openai | ollama (default: anthropic)
+  --model <id>           Model ID (default: provider-specific)
+  --system <prompt>      System prompt (default: "You are a helpful assistant.")
+  --memory <dir>         Memory directory (default: .agent-do/)
+  --read-only            No filesystem writes
+  --max-iterations <n>   Max loop iterations (default: 20)
+  --no-tools             Disable file tools
+  --verbose              Show thinking, tool calls, and per-step text (quiet by default)
+  --json                 Output as JSON
+  -h, --help             Show this help
+
+Eval options:
+  --output <format>      console | json | csv (default: console)
+  --compare <providers>  Compare across providers (comma-separated)
+  --concurrency <n>      Parallel case execution (default: 1)
+
+Environment:
+  ANTHROPIC_API_KEY      Required for Anthropic models
+  GOOGLE_GENERATIVE_AI_API_KEY   Required for Google models
+  OPENAI_API_KEY         Required for OpenAI models
+
+Examples:
+  npx agent-do "What is TypeScript?"
+  npx agent-do --provider google --model gemini-2.5-flash "Hello"
+  cat README.md | npx agent-do "Summarize this"
+  npx agent-do run my-agent.ts
+  npx agent-do eval evals/basic.ts
+  npx agent-do eval evals/ --compare anthropic,google --output json
+`);
+}
+
+main();

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -1,0 +1,159 @@
+/**
+ * CLI argument parser.
+ *
+ * Zero-dependency argument parsing. Supports flags, options with values,
+ * and positional arguments.
+ */
+
+export interface ParsedArgs {
+  command: 'prompt' | 'run' | 'eval';
+  prompt?: string;
+  file?: string;
+  provider: string;
+  model?: string;
+  systemPrompt: string;
+  memoryDir: string;
+  readOnly: boolean;
+  maxIterations: number;
+  noTools: boolean;
+  verbose: boolean;
+  json: boolean;
+  help: boolean;
+  // Eval-specific
+  output: 'console' | 'json' | 'csv';
+  compare?: string[];
+  concurrency: number;
+}
+
+/**
+ * Parse CLI arguments into a structured object.
+ *
+ * Handles subcommands (run, eval), flags, and options.
+ * Remaining positional args become the prompt.
+ */
+export function parseArgs(argv: string[]): ParsedArgs {
+  const args: ParsedArgs = {
+    command: 'prompt',
+    provider: 'anthropic',
+    systemPrompt: 'You are a helpful assistant.',
+    memoryDir: '.agent-do',
+    readOnly: false,
+    maxIterations: 20,
+    noTools: false,
+    verbose: false,
+    json: false,
+    help: false,
+    output: 'console',
+    concurrency: 1,
+  };
+
+  const positional: string[] = [];
+  let i = 0;
+
+  // Check for subcommand
+  if (argv.length > 0) {
+    const first = argv[0];
+    if (first === 'run') {
+      args.command = 'run';
+      i = 1;
+    } else if (first === 'eval') {
+      args.command = 'eval';
+      i = 1;
+    }
+  }
+
+  while (i < argv.length) {
+    const arg = argv[i]!;
+
+    if (arg === '-h' || arg === '--help') {
+      args.help = true;
+    } else if (arg === '--provider') {
+      args.provider = requireValue(argv, ++i, '--provider');
+    } else if (arg === '--model') {
+      args.model = requireValue(argv, ++i, '--model');
+    } else if (arg === '--system') {
+      args.systemPrompt = requireValue(argv, ++i, '--system');
+    } else if (arg === '--memory') {
+      args.memoryDir = requireValue(argv, ++i, '--memory');
+    } else if (arg === '--read-only') {
+      args.readOnly = true;
+    } else if (arg === '--max-iterations') {
+      const val = requireValue(argv, ++i, '--max-iterations');
+      args.maxIterations = parseInt(val, 10);
+      if (isNaN(args.maxIterations) || args.maxIterations < 1) {
+        throw new Error('--max-iterations must be a positive integer');
+      }
+    } else if (arg === '--no-tools') {
+      args.noTools = true;
+    } else if (arg === '--verbose') {
+      args.verbose = true;
+    } else if (arg === '--json') {
+      args.json = true;
+    } else if (arg === '--output') {
+      const val = requireValue(argv, ++i, '--output');
+      if (val !== 'console' && val !== 'json' && val !== 'csv') {
+        throw new Error('--output must be console, json, or csv');
+      }
+      args.output = val;
+    } else if (arg === '--compare') {
+      const val = requireValue(argv, ++i, '--compare');
+      args.compare = val.split(',').map(s => s.trim()).filter(Boolean);
+    } else if (arg === '--concurrency') {
+      const val = requireValue(argv, ++i, '--concurrency');
+      args.concurrency = parseInt(val, 10);
+      if (isNaN(args.concurrency) || args.concurrency < 1) {
+        throw new Error('--concurrency must be a positive integer');
+      }
+    } else if (arg.startsWith('-')) {
+      throw new Error(`Unknown option: ${arg}. Use --help for usage.`);
+    } else {
+      positional.push(arg);
+    }
+
+    i++;
+  }
+
+  // Assign positional args based on command
+  if (args.command === 'run') {
+    if (positional.length === 0) {
+      throw new Error('Usage: npx agent-do run <file>');
+    }
+    args.file = positional[0];
+    args.prompt = positional.slice(1).join(' ') || undefined;
+  } else if (args.command === 'eval') {
+    if (positional.length === 0 && !args.help) {
+      throw new Error('Usage: npx agent-do eval <file|dir>');
+    }
+    args.file = positional[0];
+  } else {
+    // prompt mode — all positional args become the prompt
+    if (positional.length > 0) {
+      args.prompt = positional.join(' ');
+    }
+  }
+
+  return args;
+}
+
+function requireValue(argv: string[], index: number, flag: string): string {
+  if (index >= argv.length || argv[index]!.startsWith('-')) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return argv[index]!;
+}
+
+/**
+ * Read stdin if it's being piped (non-TTY).
+ * Returns the piped content or undefined if stdin is a TTY.
+ */
+export async function readStdin(): Promise<string | undefined> {
+  if (process.stdin.isTTY) return undefined;
+
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk as Buffer);
+  }
+
+  const content = Buffer.concat(chunks).toString('utf-8').trim();
+  return content || undefined;
+}

--- a/src/cli/eval-cmd.ts
+++ b/src/cli/eval-cmd.ts
@@ -1,0 +1,116 @@
+/**
+ * Eval command — run eval cases from a file or directory.
+ *
+ * Usage:
+ *   npx agent-do eval evals/basic.ts
+ *   npx agent-do eval evals/
+ *   npx agent-do eval evals/basic.ts --compare anthropic,google
+ *   npx agent-do eval evals/basic.ts --output json
+ */
+
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import { pathToFileURL } from 'node:url';
+import type { ParsedArgs } from './args.js';
+import { resolveModel, resolveCompareProviders } from './resolve-model.js';
+import { runEvals } from '../eval/runner.js';
+import type { EvalSuiteConfig, RunEvalsOptions } from '../eval/types.js';
+
+export async function runEvalMode(args: ParsedArgs): Promise<void> {
+  if (!args.file) {
+    throw new Error('Usage: npx agent-do eval <file|dir>');
+  }
+
+  const target = path.resolve(args.file);
+  const suites = await loadSuites(target);
+
+  if (suites.length === 0) {
+    throw new Error(`No eval suites found in "${args.file}"`);
+  }
+
+  // Determine if CLI explicitly specifies a provider/model override
+  const hasCliModelOverride = !!args.model || args.provider !== 'anthropic';
+
+  let hasFailures = false;
+
+  for (const suite of suites) {
+    // Build per-suite options to preserve each suite's own model
+    const options: RunEvalsOptions = {
+      output: args.output,
+      concurrency: args.concurrency,
+    };
+
+    // Multi-provider comparison
+    if (args.compare && args.compare.length > 0) {
+      options.providers = await resolveCompareProviders(args.compare, args.model);
+    } else if (hasCliModelOverride) {
+      // CLI explicitly overrides provider/model — applies to all suites
+      options.model = await resolveModel(args.provider, args.model);
+    } else if (!suite.model) {
+      // Suite has no model — resolve default
+      options.model = await resolveModel(args.provider, args.model);
+    }
+    // else: suite has its own model and CLI didn't override — use suite's model
+
+    const result = await runEvals(suite, options);
+    if (result.providers.some(p => p.failed > 0)) {
+      hasFailures = true;
+    }
+  }
+
+  if (hasFailures) {
+    process.exit(1);
+  }
+}
+
+async function loadSuites(target: string): Promise<EvalSuiteConfig[]> {
+  const stat = await fs.promises.stat(target).catch(() => null);
+
+  if (!stat) {
+    throw new Error(`File or directory not found: ${target}`);
+  }
+
+  if (stat.isFile()) {
+    return [await loadSuiteFile(target)];
+  }
+
+  if (stat.isDirectory()) {
+    const files = await fs.promises.readdir(target);
+    const evalFiles = files.filter(f => /\.(ts|js|mjs|mts)$/.test(f));
+
+    if (evalFiles.length === 0) {
+      throw new Error(`No .ts or .js files found in "${target}"`);
+    }
+
+    const suites: EvalSuiteConfig[] = [];
+    for (const file of evalFiles.sort()) {
+      suites.push(await loadSuiteFile(path.join(target, file)));
+    }
+    return suites;
+  }
+
+  throw new Error(`"${target}" is not a file or directory`);
+}
+
+async function loadSuiteFile(filePath: string): Promise<EvalSuiteConfig> {
+  let mod: Record<string, unknown>;
+  try {
+    // Use file URL for cross-platform compatibility (Windows paths)
+    mod = await import(pathToFileURL(filePath).href);
+  } catch (err) {
+    throw new Error(
+      `Failed to import eval file "${filePath}": ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  const suite = (mod.default ?? mod) as EvalSuiteConfig;
+
+  if (!suite.name || !Array.isArray(suite.cases)) {
+    throw new Error(
+      `Eval file "${filePath}" must export a config with 'name' and 'cases'. ` +
+      `Use defineEval() from 'agent-do/eval'.`,
+    );
+  }
+
+  return suite;
+}

--- a/src/cli/prompt.ts
+++ b/src/cli/prompt.ts
@@ -1,0 +1,225 @@
+/**
+ * Prompt mode — one-shot task or interactive chat.
+ *
+ * Supports:
+ * - npx agent-do "prompt"           — one-shot
+ * - echo "ctx" | npx agent-do "p"   — piped context + prompt
+ * - cat file | npx agent-do         — piped as prompt
+ * - npx agent-do                    — interactive REPL
+ */
+
+import * as readline from 'node:readline';
+import type { ParsedArgs } from './args.js';
+import { readStdin } from './args.js';
+import { resolveModel } from './resolve-model.js';
+import { createAgent } from '../agent.js';
+import { createFileTools } from '../tools/file-tools.js';
+import { FilesystemMemoryStore } from '../stores/filesystem.js';
+import { InMemoryMemoryStore } from '../stores/in-memory.js';
+import type { ProgressEvent, ConversationMessage } from '../types.js';
+
+export async function runPromptMode(args: ParsedArgs): Promise<void> {
+  const model = await resolveModel(args.provider, args.model);
+
+  // Set up memory store
+  const store = args.noTools
+    ? new InMemoryMemoryStore()
+    : new FilesystemMemoryStore(args.memoryDir, { readOnly: args.readOnly });
+
+  const tools = args.noTools ? undefined : createFileTools(store, 'cli-agent');
+
+  const agent = createAgent({
+    id: 'cli-agent',
+    name: 'agent-do',
+    model,
+    systemPrompt: args.systemPrompt,
+    tools,
+    maxIterations: args.maxIterations,
+    permissions: { mode: 'accept-all' },
+    usage: { enabled: true },
+  });
+
+  // Read stdin if piped
+  const stdinContent = await readStdin();
+
+  // Build the task from prompt + stdin
+  const task = buildTask(args.prompt, stdinContent);
+
+  if (task) {
+    // One-shot mode
+    await runOneShot(agent, task, args);
+  } else {
+    // Interactive mode
+    await runInteractive(agent, args);
+  }
+}
+
+/**
+ * Merge piped stdin with command-line prompt.
+ *
+ * - Only prompt: use prompt as task
+ * - Only stdin: use stdin as task
+ * - Both: prompt becomes the instruction, stdin becomes context
+ * - Neither: null (interactive mode)
+ */
+function buildTask(prompt?: string, stdin?: string): string | null {
+  if (prompt && stdin) {
+    return `${prompt}\n\n---\n\n${stdin}`;
+  }
+  if (prompt) return prompt;
+  if (stdin) return stdin;
+  return null;
+}
+
+async function runOneShot(
+  agent: ReturnType<typeof createAgent>,
+  task: string,
+  args: ParsedArgs,
+): Promise<void> {
+  if (args.json) {
+    // JSON mode — collect everything, detect errors
+    const events: ProgressEvent[] = [];
+    let finalText = '';
+    let hasError = false;
+    let errorMessage = '';
+
+    for await (const event of agent.stream(task)) {
+      events.push(event);
+      if (event.type === 'done') finalText = event.content;
+      if (event.type === 'error') {
+        hasError = true;
+        errorMessage = event.content;
+      }
+    }
+
+    console.log(JSON.stringify({
+      text: finalText,
+      error: hasError ? errorMessage : undefined,
+      events: args.verbose ? events : undefined,
+    }, null, 2));
+
+    if (hasError) process.exit(1);
+    return;
+  }
+
+  // Streaming mode — quiet by default, only final answer printed
+  for await (const event of agent.stream(task)) {
+    switch (event.type) {
+      case 'thinking':
+        if (args.verbose) {
+          process.stdout.write(event.content);
+        }
+        break;
+      case 'tool-call':
+        if (args.verbose) {
+          console.log(`\n[tool] ${event.toolName}(${truncateArgs(event.toolArgs)})`);
+        }
+        break;
+      case 'tool-result':
+        if (args.verbose) {
+          console.log(`[result] ${truncate(String(event.toolResult), 200)}`);
+        }
+        break;
+      case 'text':
+        // Per-step text — only show in verbose mode to avoid intermediate outputs
+        if (args.verbose) {
+          console.log(event.content);
+        }
+        break;
+      case 'done':
+        // Final answer — always print
+        if (!args.verbose) {
+          process.stdout.write(event.content);
+        }
+        process.stdout.write('\n');
+        break;
+      case 'error':
+        console.error(`Error: ${event.content}`);
+        process.exit(1);
+        break;
+    }
+  }
+}
+
+async function runInteractive(
+  agent: ReturnType<typeof createAgent>,
+  args: ParsedArgs,
+): Promise<void> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  const history: ConversationMessage[] = [];
+
+  console.log('agent-do interactive mode. Type "exit" or Ctrl+C to quit.\n');
+
+  const askQuestion = (): Promise<string> => {
+    return new Promise((resolve) => {
+      rl.question('> ', (answer) => resolve(answer));
+    });
+  };
+
+  while (true) {
+    const input = await askQuestion();
+    const trimmed = input.trim();
+
+    if (!trimmed) continue;
+    if (trimmed === 'exit' || trimmed === 'quit') break;
+
+    // Pass only prior turns as history — streamAgentLoop appends the current
+    // user message from the task parameter, so adding it here would duplicate it
+    let response = '';
+    for await (const event of agent.stream(trimmed, undefined, history)) {
+      switch (event.type) {
+        case 'thinking':
+          if (args.verbose) {
+            process.stdout.write(event.content);
+          }
+          break;
+        case 'tool-call':
+          if (args.verbose) {
+            console.log(`\n[tool] ${event.toolName}(${truncateArgs(event.toolArgs)})`);
+          }
+          break;
+        case 'tool-result':
+          if (args.verbose) {
+            console.log(`[result] ${truncate(String(event.toolResult), 200)}`);
+          }
+          break;
+        case 'text':
+          if (args.verbose) {
+            console.log(event.content);
+          }
+          break;
+        case 'done':
+          response = event.content;
+          if (!args.verbose) {
+            process.stdout.write(response);
+          }
+          process.stdout.write('\n\n');
+          break;
+        case 'error':
+          console.error(`Error: ${event.content}\n`);
+          break;
+      }
+    }
+
+    // Add both turns to history AFTER the run completes
+    history.push({ role: 'user', content: trimmed });
+    if (response) {
+      history.push({ role: 'assistant', content: response });
+    }
+  }
+
+  rl.close();
+}
+
+function truncate(s: string, max: number): string {
+  return s.length > max ? s.slice(0, max) + '...' : s;
+}
+
+function truncateArgs(args: unknown): string {
+  const s = JSON.stringify(args);
+  return truncate(s, 100);
+}

--- a/src/cli/resolve-model.ts
+++ b/src/cli/resolve-model.ts
@@ -1,0 +1,86 @@
+/**
+ * Resolve a LanguageModel from provider name and model ID.
+ *
+ * Dynamically imports the provider SDK. Users must have the
+ * provider package installed and the API key set in env.
+ */
+
+import type { LanguageModel } from 'ai';
+
+const DEFAULT_MODELS: Record<string, string> = {
+  anthropic: 'claude-sonnet-4-6',
+  google: 'gemini-2.5-flash',
+  openai: 'gpt-4.1-mini',
+  ollama: 'llama3.2',
+};
+
+/**
+ * Resolve a model from a provider name and optional model ID.
+ * Dynamically imports the provider SDK — it must be installed.
+ */
+export async function resolveModel(
+  provider: string,
+  modelId?: string,
+): Promise<LanguageModel> {
+  const id = modelId ?? DEFAULT_MODELS[provider];
+  if (!id) {
+    throw new Error(
+      `Unknown provider "${provider}" and no --model specified. ` +
+      `Known providers: ${Object.keys(DEFAULT_MODELS).join(', ')}`,
+    );
+  }
+
+  switch (provider) {
+    case 'anthropic': {
+      const { createAnthropic } = await tryImport('@ai-sdk/anthropic', provider);
+      return createAnthropic()(id) as LanguageModel;
+    }
+    case 'google': {
+      const { createGoogleGenerativeAI } = await tryImport('@ai-sdk/google', provider);
+      return createGoogleGenerativeAI()(id) as LanguageModel;
+    }
+    case 'openai': {
+      const { createOpenAI } = await tryImport('@ai-sdk/openai', provider);
+      return createOpenAI()(id) as LanguageModel;
+    }
+    case 'ollama': {
+      // Use OpenAI-compatible endpoint for Ollama (consistent with examples)
+      const { createOpenAI } = await tryImport('@ai-sdk/openai', 'ollama (via @ai-sdk/openai)');
+      return createOpenAI({
+        baseURL: process.env.OLLAMA_BASE_URL ?? 'http://127.0.0.1:11434/v1',
+        apiKey: 'ollama',
+      })(id) as LanguageModel;
+    }
+    default:
+      throw new Error(
+        `Unknown provider "${provider}". ` +
+        `Available: ${Object.keys(DEFAULT_MODELS).join(', ')}`,
+      );
+  }
+}
+
+async function tryImport(pkg: string, provider: string): Promise<any> {
+  try {
+    return await import(pkg);
+  } catch {
+    throw new Error(
+      `Provider "${provider}" requires "${pkg}" to be installed.\n` +
+      `Run: npm install ${pkg}`,
+    );
+  }
+}
+
+/**
+ * Resolve models for comparison across multiple providers.
+ */
+export async function resolveCompareProviders(
+  providerNames: string[],
+  modelId?: string,
+): Promise<Array<{ name: string; model: LanguageModel }>> {
+  const results = [];
+  for (const name of providerNames) {
+    const model = await resolveModel(name, modelId);
+    results.push({ name, model });
+  }
+  return results;
+}

--- a/src/cli/script.ts
+++ b/src/cli/script.ts
@@ -1,0 +1,138 @@
+/**
+ * Script mode — run a JS/TS file that exports an agent.
+ *
+ * Usage: npx agent-do run my-agent.ts [task]
+ *
+ * The file can export:
+ * - An Agent instance (has .run() and .stream())
+ * - An AgentConfig object (has .model and .id)
+ * - A simple config object (has .systemPrompt, auto-resolves model)
+ *
+ * Note: .ts files require a TypeScript loader (tsx, ts-node).
+ * Run with: npx tsx node_modules/.bin/agent-do run script.ts
+ * Or use compiled .js files directly.
+ */
+
+import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import type { ParsedArgs } from './args.js';
+import { readStdin } from './args.js';
+import { resolveModel } from './resolve-model.js';
+import { createAgent } from '../agent.js';
+import { createFileTools } from '../tools/file-tools.js';
+import { FilesystemMemoryStore } from '../stores/filesystem.js';
+import type { Agent } from '../types.js';
+
+export async function runScriptMode(args: ParsedArgs): Promise<void> {
+  if (!args.file) {
+    throw new Error('Usage: npx agent-do run <file>');
+  }
+
+  const filePath = path.resolve(args.file);
+  let mod: Record<string, unknown>;
+  try {
+    // Use file URL for cross-platform compatibility (Windows paths)
+    mod = await import(pathToFileURL(filePath).href);
+  } catch (err) {
+    throw new Error(
+      `Failed to import "${args.file}": ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  const exported = (mod.default ?? mod) as Record<string, unknown>;
+
+  // Determine if it's an Agent instance, AgentConfig, or simple config
+  let agent: Agent;
+
+  if (typeof exported.run === 'function' && typeof exported.stream === 'function') {
+    // It's an Agent instance
+    agent = exported as unknown as Agent;
+  } else if (exported.model && exported.id) {
+    // It's an AgentConfig — create agent from it
+    agent = createAgent(exported as any);
+  } else if (exported.systemPrompt || exported.name) {
+    // Simple config — resolve model from provider/args
+    const model = await resolveModel(
+      (exported.provider as string) ?? args.provider,
+      (exported.model as string) ?? args.model,
+    );
+    const agentId = (exported.id as string) ?? 'script-agent';
+
+    // Respect --no-tools flag
+    let tools = undefined;
+    if (!args.noTools) {
+      const memDir = (exported.memory as string) ?? args.memoryDir;
+      const store = new FilesystemMemoryStore(memDir, { readOnly: args.readOnly });
+      tools = createFileTools(store, agentId);
+    }
+
+    agent = createAgent({
+      id: agentId,
+      name: (exported.name as string) ?? 'Script Agent',
+      model,
+      systemPrompt: (exported.systemPrompt as string) ?? args.systemPrompt,
+      tools,
+      maxIterations: (exported.maxIterations as number) ?? args.maxIterations,
+      permissions: { mode: 'accept-all' },
+      usage: { enabled: true },
+    });
+  } else {
+    throw new Error(
+      'Script must export an Agent instance, an AgentConfig (with model + id), ' +
+      'or a simple config (with systemPrompt or name).',
+    );
+  }
+
+  // Get the task
+  const stdinContent = await readStdin();
+  const task = buildTask(args.prompt, stdinContent);
+
+  if (!task) {
+    throw new Error(
+      'No task provided. Pass a prompt after the file: npx agent-do run script.ts "your task"',
+    );
+  }
+
+  // Run the agent — quiet by default, only final answer printed
+  for await (const event of agent.stream(task)) {
+    switch (event.type) {
+      case 'thinking':
+        if (args.verbose) {
+          process.stdout.write(event.content);
+        }
+        break;
+      case 'tool-call':
+        if (args.verbose) {
+          console.log(`\n[tool] ${event.toolName}(${JSON.stringify(event.toolArgs).slice(0, 100)})`);
+        }
+        break;
+      case 'tool-result':
+        if (args.verbose) {
+          console.log(`[result] ${String(event.toolResult).slice(0, 200)}`);
+        }
+        break;
+      case 'text':
+        if (args.verbose) {
+          console.log(event.content);
+        }
+        break;
+      case 'done':
+        if (!args.verbose) {
+          process.stdout.write(event.content);
+        }
+        process.stdout.write('\n');
+        break;
+      case 'error':
+        console.error(`Error: ${event.content}`);
+        process.exit(1);
+        break;
+    }
+  }
+}
+
+function buildTask(prompt?: string, stdin?: string): string | null {
+  if (prompt && stdin) return `${prompt}\n\n---\n\n${stdin}`;
+  if (prompt) return prompt;
+  if (stdin) return stdin;
+  return null;
+}

--- a/src/eval/assertions.ts
+++ b/src/eval/assertions.ts
@@ -213,12 +213,10 @@ function evaluateToolArgs(
     };
   }
 
-  // Check if any call has matching args (partial match)
+  // Check if any call has matching args (deep partial match)
   const passed = calls.some(call => {
     const actualArgs = call.args as Record<string, unknown>;
-    return Object.entries(expectedArgs).every(([key, value]) => {
-      return JSON.stringify(actualArgs[key]) === JSON.stringify(value);
-    });
+    return deepPartialMatch(actualArgs, expectedArgs);
   });
 
   return {
@@ -391,4 +389,34 @@ async function evaluateCustom(
 
 function truncate(s: string, max = 50): string {
   return s.length > max ? s.slice(0, max) + '...' : s;
+}
+
+/**
+ * Deep partial match — every key/value in `expected` must match in `actual`.
+ * Recurses into objects and arrays. Primitives compared with strict equality.
+ */
+function deepPartialMatch(actual: unknown, expected: unknown): boolean {
+  // Primitives — strict equality
+  if (expected === null || expected === undefined || typeof expected !== 'object') {
+    return actual === expected;
+  }
+
+  // Array match — expected array must match actual array element-by-element
+  if (Array.isArray(expected)) {
+    if (!Array.isArray(actual)) return false;
+    if (expected.length !== actual.length) return false;
+    return expected.every((item, i) => deepPartialMatch(actual[i], item));
+  }
+
+  // Object partial match — every key in expected must exist and match in actual
+  if (typeof actual !== 'object' || actual === null || Array.isArray(actual)) {
+    return false;
+  }
+
+  const actualObj = actual as Record<string, unknown>;
+  const expectedObj = expected as Record<string, unknown>;
+
+  return Object.keys(expectedObj).every(key =>
+    key in actualObj && deepPartialMatch(actualObj[key], expectedObj[key]),
+  );
 }

--- a/src/eval/assertions.ts
+++ b/src/eval/assertions.ts
@@ -1,0 +1,394 @@
+/**
+ * Assertion evaluation logic.
+ *
+ * Each assertion type has a corresponding evaluator that takes
+ * the CaseRunResult and returns an AssertionResult.
+ */
+
+import { generateText, type LanguageModel } from 'ai';
+import type {
+  Assertion,
+  AssertionResult,
+  CaseRunResult,
+} from './types.js';
+
+/**
+ * Evaluate a single assertion against a case run result.
+ */
+export async function evaluateAssertion(
+  assertion: Assertion,
+  result: CaseRunResult,
+  judgeModel?: LanguageModel,
+): Promise<AssertionResult> {
+  switch (assertion.type) {
+    case 'contains':
+      return evaluateContains(assertion.value, result.text);
+
+    case 'not-contains':
+      return evaluateNotContains(assertion.value, result.text);
+
+    case 'regex':
+      return evaluateRegex(assertion.pattern, assertion.flags, result.text);
+
+    case 'json-schema':
+      return evaluateJsonSchema(assertion.schema, result.text);
+
+    case 'tool-called':
+      return evaluateToolCalled(assertion.tool, result.toolCalls);
+
+    case 'tool-not-called':
+      return evaluateToolNotCalled(assertion.tool, result.toolCalls);
+
+    case 'tool-args':
+      return evaluateToolArgs(assertion.tool, assertion.args, result.toolCalls);
+
+    case 'file-exists':
+      return await evaluateFileExists(assertion.path, result.store, result.agentId);
+
+    case 'file-contains':
+      return await evaluateFileContains(assertion.path, assertion.value, result.store, result.agentId);
+
+    case 'max-steps':
+      return evaluateMaxSteps(assertion.max, result.steps);
+
+    case 'max-cost':
+      return evaluateMaxCost(assertion.maxUsd, result.cost);
+
+    case 'llm-rubric':
+      return await evaluateLlmRubric(
+        assertion.rubric,
+        assertion.score ?? 'pass-fail',
+        result.text,
+        assertion.judgeModel ?? judgeModel,
+      );
+
+    case 'custom':
+      return await evaluateCustom(assertion.name, assertion.fn, result);
+
+    default: {
+      const _exhaustive: never = assertion;
+      return { assertion: _exhaustive, passed: false, message: `Unknown assertion type` };
+    }
+  }
+}
+
+// ── Individual evaluators ──
+
+function evaluateContains(value: string, text: string): AssertionResult {
+  const passed = text.includes(value);
+  return {
+    assertion: { type: 'contains', value },
+    passed,
+    message: passed
+      ? `Response contains "${truncate(value)}"`
+      : `Response does not contain "${truncate(value)}"`,
+  };
+}
+
+function evaluateNotContains(value: string, text: string): AssertionResult {
+  const passed = !text.includes(value);
+  return {
+    assertion: { type: 'not-contains', value },
+    passed,
+    message: passed
+      ? `Response does not contain "${truncate(value)}"`
+      : `Response contains "${truncate(value)}" (should not)`,
+  };
+}
+
+function evaluateRegex(pattern: string, flags: string | undefined, text: string): AssertionResult {
+  let passed: boolean;
+  let message: string;
+  try {
+    const re = new RegExp(pattern, flags);
+    passed = re.test(text);
+    message = passed
+      ? `Response matches /${pattern}/${flags ?? ''}`
+      : `Response does not match /${pattern}/${flags ?? ''}`;
+  } catch (err) {
+    passed = false;
+    message = `Invalid regex /${pattern}/${flags ?? ''}: ${err instanceof Error ? err.message : String(err)}`;
+  }
+  return { assertion: { type: 'regex', pattern, flags }, passed, message };
+}
+
+function evaluateJsonSchema(schema: Record<string, unknown>, text: string): AssertionResult {
+  // Simple structural validation — checks type and required fields.
+  // Not a full JSON Schema validator; covers common use cases.
+  try {
+    const parsed = JSON.parse(text);
+    const errors = validateJsonStructure(parsed, schema, '');
+    const passed = errors.length === 0;
+    return {
+      assertion: { type: 'json-schema', schema },
+      passed,
+      message: passed
+        ? 'Response is valid JSON matching schema'
+        : `JSON schema validation failed: ${errors.join('; ')}`,
+    };
+  } catch {
+    return {
+      assertion: { type: 'json-schema', schema },
+      passed: false,
+      message: 'Response is not valid JSON',
+    };
+  }
+}
+
+function validateJsonStructure(
+  value: unknown,
+  schema: Record<string, unknown>,
+  path: string,
+): string[] {
+  const errors: string[] = [];
+  const expectedType = schema.type as string | undefined;
+
+  if (expectedType) {
+    const actualType = Array.isArray(value) ? 'array' : typeof value;
+    if (actualType !== expectedType) {
+      errors.push(`${path || 'root'}: expected ${expectedType}, got ${actualType}`);
+      return errors;
+    }
+  }
+
+  if (expectedType === 'object' && typeof value === 'object' && value !== null) {
+    const required = (schema.required ?? []) as string[];
+    for (const key of required) {
+      if (!(key in (value as Record<string, unknown>))) {
+        errors.push(`${path ? path + '.' : ''}${key}: required field missing`);
+      }
+    }
+    const properties = schema.properties as Record<string, Record<string, unknown>> | undefined;
+    if (properties) {
+      for (const [key, propSchema] of Object.entries(properties)) {
+        if (key in (value as Record<string, unknown>)) {
+          errors.push(...validateJsonStructure((value as Record<string, unknown>)[key], propSchema, `${path ? path + '.' : ''}${key}`));
+        }
+      }
+    }
+  }
+
+  return errors;
+}
+
+function evaluateToolCalled(
+  toolName: string,
+  toolCalls: CaseRunResult['toolCalls'],
+): AssertionResult {
+  const passed = toolCalls.some(tc => tc.toolName === toolName);
+  return {
+    assertion: { type: 'tool-called', tool: toolName },
+    passed,
+    message: passed
+      ? `Tool "${toolName}" was called`
+      : `Tool "${toolName}" was not called. Called: ${toolCalls.map(tc => tc.toolName).join(', ') || '(none)'}`,
+  };
+}
+
+function evaluateToolNotCalled(
+  toolName: string,
+  toolCalls: CaseRunResult['toolCalls'],
+): AssertionResult {
+  const passed = !toolCalls.some(tc => tc.toolName === toolName);
+  return {
+    assertion: { type: 'tool-not-called', tool: toolName },
+    passed,
+    message: passed
+      ? `Tool "${toolName}" was not called`
+      : `Tool "${toolName}" was called (should not have been)`,
+  };
+}
+
+function evaluateToolArgs(
+  toolName: string,
+  expectedArgs: Record<string, unknown>,
+  toolCalls: CaseRunResult['toolCalls'],
+): AssertionResult {
+  const calls = toolCalls.filter(tc => tc.toolName === toolName);
+  if (calls.length === 0) {
+    return {
+      assertion: { type: 'tool-args', tool: toolName, args: expectedArgs },
+      passed: false,
+      message: `Tool "${toolName}" was not called`,
+    };
+  }
+
+  // Check if any call has matching args (partial match)
+  const passed = calls.some(call => {
+    const actualArgs = call.args as Record<string, unknown>;
+    return Object.entries(expectedArgs).every(([key, value]) => {
+      return JSON.stringify(actualArgs[key]) === JSON.stringify(value);
+    });
+  });
+
+  return {
+    assertion: { type: 'tool-args', tool: toolName, args: expectedArgs },
+    passed,
+    message: passed
+      ? `Tool "${toolName}" was called with expected args`
+      : `Tool "${toolName}" was called but args did not match. Got: ${JSON.stringify(calls.map(c => c.args))}`,
+  };
+}
+
+async function evaluateFileExists(
+  path: string,
+  store: import('../stores.js').MemoryStore,
+  agentId: string,
+): Promise<AssertionResult> {
+  try {
+    const exists = await store.exists(agentId, path);
+    return {
+      assertion: { type: 'file-exists', path },
+      passed: exists,
+      message: exists
+        ? `File "${path}" exists`
+        : `File "${path}" does not exist`,
+    };
+  } catch {
+    return {
+      assertion: { type: 'file-exists', path },
+      passed: false,
+      message: `Error checking if file "${path}" exists`,
+    };
+  }
+}
+
+async function evaluateFileContains(
+  path: string,
+  value: string,
+  store: import('../stores.js').MemoryStore,
+  agentId: string,
+): Promise<AssertionResult> {
+  try {
+    const content = await store.read(agentId, path);
+    const passed = content.includes(value);
+    return {
+      assertion: { type: 'file-contains', path, value },
+      passed,
+      message: passed
+        ? `File "${path}" contains "${truncate(value)}"`
+        : `File "${path}" does not contain "${truncate(value)}"`,
+    };
+  } catch {
+    return {
+      assertion: { type: 'file-contains', path, value },
+      passed: false,
+      message: `File "${path}" does not exist or could not be read`,
+    };
+  }
+}
+
+function evaluateMaxSteps(max: number, actual: number): AssertionResult {
+  const passed = actual <= max;
+  return {
+    assertion: { type: 'max-steps', max },
+    passed,
+    message: passed
+      ? `Completed in ${actual} steps (max: ${max})`
+      : `Took ${actual} steps (max: ${max})`,
+  };
+}
+
+function evaluateMaxCost(maxUsd: number, actual: number): AssertionResult {
+  const passed = actual <= maxUsd;
+  return {
+    assertion: { type: 'max-cost', maxUsd },
+    passed,
+    message: passed
+      ? `Cost $${actual.toFixed(4)} (max: $${maxUsd.toFixed(4)})`
+      : `Cost $${actual.toFixed(4)} exceeds max $${maxUsd.toFixed(4)}`,
+  };
+}
+
+async function evaluateLlmRubric(
+  rubric: string,
+  scoreType: 'pass-fail' | '1-5',
+  text: string,
+  model?: LanguageModel,
+): Promise<AssertionResult> {
+  if (!model) {
+    return {
+      assertion: { type: 'llm-rubric', rubric, score: scoreType },
+      passed: false,
+      message: 'No judge model available for llm-rubric assertion. Provide a model in the eval suite or assertion.',
+    };
+  }
+
+  const scorePrompt = scoreType === 'pass-fail'
+    ? `Respond with exactly "PASS" or "FAIL" on the first line, followed by a brief explanation.`
+    : `Respond with a score from 1 to 5 on the first line (where 5 is best), followed by a brief explanation.`;
+
+  try {
+    const result = await generateText({
+      model,
+      messages: [
+        {
+          role: 'user',
+          content: `You are evaluating an AI assistant's response against a rubric.
+
+## Rubric
+${rubric}
+
+## Response to evaluate
+${text}
+
+## Instructions
+${scorePrompt}`,
+        },
+      ],
+    });
+
+    const judgeResponse = result.text.trim();
+    const firstLine = judgeResponse.split('\n')[0]?.trim().toUpperCase() ?? '';
+
+    if (scoreType === 'pass-fail') {
+      const passed = firstLine === 'PASS';
+      return {
+        assertion: { type: 'llm-rubric', rubric, score: scoreType },
+        passed,
+        message: `LLM judge: ${judgeResponse.slice(0, 200)}`,
+      };
+    } else {
+      const score = parseInt(firstLine, 10);
+      const passed = !isNaN(score) && score >= 3;
+      return {
+        assertion: { type: 'llm-rubric', rubric, score: scoreType },
+        passed,
+        message: `LLM judge score: ${score}/5 — ${judgeResponse.slice(0, 200)}`,
+      };
+    }
+  } catch (err) {
+    return {
+      assertion: { type: 'llm-rubric', rubric, score: scoreType },
+      passed: false,
+      message: `LLM judge error: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+
+async function evaluateCustom(
+  name: string,
+  fn: (result: CaseRunResult) => boolean | Promise<boolean>,
+  result: CaseRunResult,
+): Promise<AssertionResult> {
+  try {
+    const passed = await fn(result);
+    return {
+      assertion: { type: 'custom', name, fn },
+      passed,
+      message: passed ? `Custom "${name}": passed` : `Custom "${name}": failed`,
+    };
+  } catch (err) {
+    return {
+      assertion: { type: 'custom', name, fn },
+      passed: false,
+      message: `Custom "${name}" threw: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+
+// ── Helpers ──
+
+function truncate(s: string, max = 50): string {
+  return s.length > max ? s.slice(0, max) + '...' : s;
+}

--- a/src/eval/index.ts
+++ b/src/eval/index.ts
@@ -1,0 +1,37 @@
+/**
+ * Eval framework for agent-do.
+ *
+ * Define eval cases, run them against real or mock models,
+ * and score agent quality with assertions.
+ */
+
+export { defineEval, runEvals } from './runner.js';
+export { evaluateAssertion } from './assertions.js';
+
+export type {
+  // Assertions
+  Assertion,
+  ContainsAssertion,
+  NotContainsAssertion,
+  RegexAssertion,
+  JsonSchemaAssertion,
+  ToolCalledAssertion,
+  ToolNotCalledAssertion,
+  ToolArgsAssertion,
+  FileExistsAssertion,
+  FileContainsAssertion,
+  MaxStepsAssertion,
+  MaxCostAssertion,
+  LlmRubricAssertion,
+  CustomAssertion,
+  // Cases and suites
+  EvalCase,
+  EvalSuiteConfig,
+  RunEvalsOptions,
+  // Results
+  CaseRunResult,
+  AssertionResult,
+  CaseResult,
+  ProviderResult,
+  EvalResult,
+} from './types.js';

--- a/src/eval/runner.ts
+++ b/src/eval/runner.ts
@@ -129,38 +129,22 @@ async function runProviderEvals(
       totalCost += caseResult.cost;
     }
   } else {
-    // Parallel with concurrency limit
-    const pending = [...suite.cases];
-    const running: Promise<void>[] = [];
+    // Parallel with concurrency limit — worker pattern
+    let nextCaseIndex = 0;
+    const workerCount = Math.min(concurrency, suite.cases.length);
+    const workers = Array.from({ length: workerCount }, async () => {
+      while (!options.signal?.aborted) {
+        const currentIndex = nextCaseIndex++;
+        if (currentIndex >= suite.cases.length) break;
 
-    while (pending.length > 0 || running.length > 0) {
-      if (options.signal?.aborted) break;
-
-      while (running.length < concurrency && pending.length > 0) {
-        const evalCase = pending.shift()!;
-        const promise = runCase(suite, evalCase, provider, options).then(caseResult => {
-          cases.push(caseResult);
-          totalCost += caseResult.cost;
-        });
-        running.push(promise);
+        const evalCase = suite.cases[currentIndex]!;
+        const caseResult = await runCase(suite, evalCase, provider, options);
+        cases.push(caseResult);
+        totalCost += caseResult.cost;
       }
+    });
 
-      if (running.length > 0) {
-        await Promise.race(running);
-        // Remove settled promises
-        const settled: number[] = [];
-        for (let i = 0; i < running.length; i++) {
-          const status = await Promise.race([
-            running[i]!.then(() => 'settled' as const),
-            Promise.resolve('pending' as const),
-          ]);
-          if (status === 'settled') settled.push(i);
-        }
-        for (let i = settled.length - 1; i >= 0; i--) {
-          running.splice(settled[i]!, 1);
-        }
-      }
-    }
+    await Promise.all(workers);
   }
 
   const passed = cases.filter(c => c.passed).length;
@@ -198,15 +182,19 @@ async function runCase(
   const totalCost = runResults.reduce((sum, r) => sum + r.cost, 0);
   const totalDuration = runResults.reduce((sum, r) => sum + r.durationMs, 0);
 
+  // Surface assertions from the first failing run (or first run if all passed)
+  const representativeRun = runResults.find(r => !r.passed) ?? runResults[0];
+
   return {
     name: evalCase.name,
     input: evalCase.input,
     passed: allPassed,
-    assertions: runResults[0]?.assertions ?? [],
+    assertions: representativeRun?.assertions ?? [],
     cost: totalCost,
     durationMs: totalDuration,
     steps: Math.max(...runResults.map(r => r.steps)),
-    text: runResults[runResults.length - 1]?.text ?? '',
+    text: representativeRun?.text ?? '',
+    error: representativeRun?.error,
     runs: runResults,
   };
 }
@@ -231,15 +219,16 @@ async function runSingleCase(
   const baseTools = suite.tools ?? createFileTools(store, agentId);
   const wrappedTools = wrapToolsForCapture(baseTools, toolCalls);
 
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeout);
+  const parentAbortHandler = () => controller.abort();
+
+  // Also respect parent signal
+  if (options.signal) {
+    options.signal.addEventListener('abort', parentAbortHandler, { once: true });
+  }
+
   try {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), timeout);
-
-    // Also respect parent signal
-    if (options.signal) {
-      options.signal.addEventListener('abort', () => controller.abort(), { once: true });
-    }
-
     const result = await runAgentLoop(
       {
         id: agentId,
@@ -261,8 +250,6 @@ async function runSingleCase(
       evalCase.history,
     );
 
-    clearTimeout(timeoutId);
-
     const caseRunResult: CaseRunResult = {
       text: result.text,
       steps: result.steps,
@@ -281,15 +268,19 @@ async function runSingleCase(
       provider.model,
     );
 
+    // Aborted runs always fail — partial output should not produce false positives
+    const aborted = result.aborted;
+
     return {
       name: evalCase.name,
       input: evalCase.input,
-      passed: assertions.every(a => a.passed),
+      passed: !aborted && assertions.every(a => a.passed),
       assertions,
       cost: caseRunResult.cost,
       durationMs: caseRunResult.durationMs,
       steps: caseRunResult.steps,
       text: caseRunResult.text,
+      error: aborted ? 'Agent run was aborted (timeout or signal).' : undefined,
     };
   } catch (err) {
     return {
@@ -303,6 +294,11 @@ async function runSingleCase(
       text: '',
       error: err instanceof Error ? err.message : String(err),
     };
+  } finally {
+    clearTimeout(timeoutId);
+    if (options.signal) {
+      options.signal.removeEventListener('abort', parentAbortHandler);
+    }
   }
 }
 
@@ -322,13 +318,25 @@ function wrapToolsForCapture(
     wrapped[name] = {
       ...toolDef,
       execute: async (args: unknown, context: unknown) => {
-        const result = await (originalExecute as Function)(args, context);
-        captured.push({
+        // Record the call attempt before execution so tool-called assertions
+        // work even if the tool throws
+        const entry = {
           toolName: name,
           args: (args ?? {}) as Record<string, unknown>,
-          result,
-        });
-        return result;
+          result: undefined as unknown,
+        };
+        captured.push(entry);
+
+        try {
+          const result = await (originalExecute as Function)(args, context);
+          entry.result = result;
+          return result;
+        } catch (error) {
+          entry.result = error instanceof Error
+            ? { error: error.name, message: error.message }
+            : { error: 'unknown', message: String(error) };
+          throw error;
+        }
       },
     };
   }

--- a/src/eval/runner.ts
+++ b/src/eval/runner.ts
@@ -1,0 +1,450 @@
+/**
+ * Eval runner — executes eval suites and collects results.
+ *
+ * Handles running agent loops, collecting tool calls, evaluating
+ * assertions, and producing structured results.
+ */
+
+import type { LanguageModel } from 'ai';
+import type {
+  EvalSuiteConfig,
+  EvalCase,
+  CaseRunResult,
+  CaseResult,
+  ProviderResult,
+  EvalResult,
+  RunEvalsOptions,
+} from './types.js';
+import { evaluateAssertion } from './assertions.js';
+import { runAgentLoop } from '../loop.js';
+import { createFileTools } from '../tools/file-tools.js';
+import { InMemoryMemoryStore } from '../stores/in-memory.js';
+import type { MemoryStore } from '../stores.js';
+
+const DEFAULT_TIMEOUT = 60_000;
+const DEFAULT_AGENT_ID = 'eval-agent';
+
+/**
+ * Define an eval suite. This is a type-safe helper that returns
+ * the config unchanged — useful for editor autocompletion.
+ */
+export function defineEval(config: EvalSuiteConfig): EvalSuiteConfig {
+  return config;
+}
+
+/**
+ * Run an eval suite and return structured results.
+ *
+ * Supports single-provider runs and multi-provider comparison.
+ * Each case gets a fresh memory store for isolation.
+ */
+export async function runEvals(
+  suite: EvalSuiteConfig,
+  options: RunEvalsOptions = {},
+): Promise<EvalResult> {
+  const { output = 'console', signal } = options;
+
+  // Determine provider list
+  const providers = resolveProviders(suite, options);
+
+  const result: EvalResult = {
+    name: suite.name,
+    timestamp: new Date().toISOString(),
+    providers: [],
+  };
+
+  for (const provider of providers) {
+    if (signal?.aborted) break;
+
+    const providerResult = await runProviderEvals(suite, provider, options);
+    result.providers.push(providerResult);
+  }
+
+  // Format output
+  if (output === 'console') {
+    printConsoleReport(result);
+  } else if (output === 'json') {
+    console.log(JSON.stringify(result, null, 2));
+  } else if (output === 'csv') {
+    console.log(formatCsv(result));
+  }
+  // 'silent' — no output
+
+  return result;
+}
+
+// ── Internal ──
+
+interface ResolvedProvider {
+  name: string;
+  model: LanguageModel;
+}
+
+function resolveProviders(
+  suite: EvalSuiteConfig,
+  options: RunEvalsOptions,
+): ResolvedProvider[] {
+  // Multi-provider comparison
+  if (options.providers && options.providers.length > 0) {
+    return options.providers.map(p => ({
+      name: p.name,
+      model: p.model,
+    }));
+  }
+
+  // Single model override
+  const model = options.model ?? suite.model;
+  if (!model) {
+    throw new Error(
+      `No model provided. Set model in the eval suite config or pass it via runEvals options.`,
+    );
+  }
+
+  const name = getModelName(model);
+  return [{ name, model }];
+}
+
+function getModelName(model: LanguageModel): string {
+  if (typeof model === 'string') return model;
+  return (model as { modelId?: string }).modelId ?? 'unknown';
+}
+
+async function runProviderEvals(
+  suite: EvalSuiteConfig,
+  provider: ResolvedProvider,
+  options: RunEvalsOptions,
+): Promise<ProviderResult> {
+  const startTime = Date.now();
+  const cases: CaseResult[] = [];
+  let totalCost = 0;
+
+  const concurrency = options.concurrency ?? 1;
+
+  if (concurrency <= 1) {
+    // Sequential
+    for (const evalCase of suite.cases) {
+      if (options.signal?.aborted) break;
+      const caseResult = await runCase(suite, evalCase, provider, options);
+      cases.push(caseResult);
+      totalCost += caseResult.cost;
+    }
+  } else {
+    // Parallel with concurrency limit
+    const pending = [...suite.cases];
+    const running: Promise<void>[] = [];
+
+    while (pending.length > 0 || running.length > 0) {
+      if (options.signal?.aborted) break;
+
+      while (running.length < concurrency && pending.length > 0) {
+        const evalCase = pending.shift()!;
+        const promise = runCase(suite, evalCase, provider, options).then(caseResult => {
+          cases.push(caseResult);
+          totalCost += caseResult.cost;
+        });
+        running.push(promise);
+      }
+
+      if (running.length > 0) {
+        await Promise.race(running);
+        // Remove settled promises
+        const settled: number[] = [];
+        for (let i = 0; i < running.length; i++) {
+          const status = await Promise.race([
+            running[i]!.then(() => 'settled' as const),
+            Promise.resolve('pending' as const),
+          ]);
+          if (status === 'settled') settled.push(i);
+        }
+        for (let i = settled.length - 1; i >= 0; i--) {
+          running.splice(settled[i]!, 1);
+        }
+      }
+    }
+  }
+
+  const passed = cases.filter(c => c.passed).length;
+  return {
+    provider: provider.name,
+    model: getModelName(provider.model),
+    totalCases: cases.length,
+    passed,
+    failed: cases.length - passed,
+    totalCost,
+    durationMs: Date.now() - startTime,
+    cases,
+  };
+}
+
+async function runCase(
+  suite: EvalSuiteConfig,
+  evalCase: EvalCase,
+  provider: ResolvedProvider,
+  options: RunEvalsOptions,
+): Promise<CaseResult> {
+  const runs = evalCase.runs ?? 1;
+
+  if (runs <= 1) {
+    return runSingleCase(suite, evalCase, provider, options);
+  }
+
+  // Multi-run: run N times, report aggregate
+  const runResults: CaseResult[] = [];
+  for (let i = 0; i < runs; i++) {
+    runResults.push(await runSingleCase(suite, evalCase, provider, options));
+  }
+
+  const allPassed = runResults.every(r => r.passed);
+  const totalCost = runResults.reduce((sum, r) => sum + r.cost, 0);
+  const totalDuration = runResults.reduce((sum, r) => sum + r.durationMs, 0);
+
+  return {
+    name: evalCase.name,
+    input: evalCase.input,
+    passed: allPassed,
+    assertions: runResults[0]?.assertions ?? [],
+    cost: totalCost,
+    durationMs: totalDuration,
+    steps: Math.max(...runResults.map(r => r.steps)),
+    text: runResults[runResults.length - 1]?.text ?? '',
+    runs: runResults,
+  };
+}
+
+async function runSingleCase(
+  suite: EvalSuiteConfig,
+  evalCase: EvalCase,
+  provider: ResolvedProvider,
+  options: RunEvalsOptions,
+): Promise<CaseResult> {
+  const startTime = Date.now();
+  const timeout = evalCase.timeout ?? DEFAULT_TIMEOUT;
+
+  // Fresh store per case for isolation
+  const store: MemoryStore = options.createStore?.() ?? new InMemoryMemoryStore();
+  const agentId = DEFAULT_AGENT_ID;
+
+  // Collect tool calls
+  const toolCalls: CaseRunResult['toolCalls'] = [];
+
+  // Create tools — wrap to capture tool calls
+  const baseTools = suite.tools ?? createFileTools(store, agentId);
+  const wrappedTools = wrapToolsForCapture(baseTools, toolCalls);
+
+  try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+    // Also respect parent signal
+    if (options.signal) {
+      options.signal.addEventListener('abort', () => controller.abort(), { once: true });
+    }
+
+    const result = await runAgentLoop(
+      {
+        id: agentId,
+        name: `eval-${suite.name}`,
+        model: provider.model,
+        systemPrompt: suite.systemPrompt,
+        tools: wrappedTools,
+        maxIterations: suite.maxIterations ?? 20,
+        hooks: suite.hooks,
+        permissions: suite.permissions ?? { mode: 'accept-all' },
+        usage: {
+          enabled: true,
+          pricing: suite.pricing,
+        },
+        signal: controller.signal,
+      },
+      evalCase.input,
+      evalCase.context,
+      evalCase.history,
+    );
+
+    clearTimeout(timeoutId);
+
+    const caseRunResult: CaseRunResult = {
+      text: result.text,
+      steps: result.steps,
+      cost: result.usage.totalCost,
+      durationMs: Date.now() - startTime,
+      toolCalls,
+      store,
+      agentId,
+      aborted: result.aborted,
+    };
+
+    // Evaluate assertions
+    const assertions = await evaluateAllAssertions(
+      evalCase.assert,
+      caseRunResult,
+      provider.model,
+    );
+
+    return {
+      name: evalCase.name,
+      input: evalCase.input,
+      passed: assertions.every(a => a.passed),
+      assertions,
+      cost: caseRunResult.cost,
+      durationMs: caseRunResult.durationMs,
+      steps: caseRunResult.steps,
+      text: caseRunResult.text,
+    };
+  } catch (err) {
+    return {
+      name: evalCase.name,
+      input: evalCase.input,
+      passed: false,
+      assertions: [],
+      cost: 0,
+      durationMs: Date.now() - startTime,
+      steps: 0,
+      text: '',
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+function wrapToolsForCapture(
+  tools: import('ai').ToolSet,
+  captured: CaseRunResult['toolCalls'],
+): import('ai').ToolSet {
+  const wrapped: import('ai').ToolSet = {};
+
+  for (const [name, toolDef] of Object.entries(tools)) {
+    if (!toolDef || !toolDef.execute) {
+      wrapped[name] = toolDef;
+      continue;
+    }
+
+    const originalExecute = toolDef.execute;
+    wrapped[name] = {
+      ...toolDef,
+      execute: async (args: unknown, context: unknown) => {
+        const result = await (originalExecute as Function)(args, context);
+        captured.push({
+          toolName: name,
+          args: (args ?? {}) as Record<string, unknown>,
+          result,
+        });
+        return result;
+      },
+    };
+  }
+
+  return wrapped;
+}
+
+async function evaluateAllAssertions(
+  assertions: EvalCase['assert'],
+  result: CaseRunResult,
+  judgeModel?: LanguageModel,
+) {
+  const results = [];
+  for (const assertion of assertions) {
+    results.push(await evaluateAssertion(assertion, result, judgeModel));
+  }
+  return results;
+}
+
+// ── Reporters ──
+
+function printConsoleReport(result: EvalResult): void {
+  console.log(`\n${'═'.repeat(60)}`);
+  console.log(`  Eval: ${result.name}`);
+  console.log(`  Time: ${result.timestamp}`);
+  console.log(`${'═'.repeat(60)}\n`);
+
+  for (const provider of result.providers) {
+    if (result.providers.length > 1) {
+      console.log(`── ${provider.provider} (${provider.model}) ──`);
+    }
+
+    for (const c of provider.cases) {
+      const icon = c.passed ? '✓' : '✗';
+      const status = c.passed ? 'PASS' : 'FAIL';
+      console.log(`  ${icon} ${status}  ${c.name}  ($${c.cost.toFixed(4)}, ${c.durationMs}ms, ${c.steps} steps)`);
+
+      if (!c.passed) {
+        if (c.error) {
+          console.log(`         Error: ${c.error}`);
+        }
+        for (const a of c.assertions) {
+          if (!a.passed) {
+            console.log(`         ✗ ${a.message}`);
+          }
+        }
+      }
+
+      if (c.runs && c.runs.length > 1) {
+        const passedRuns = c.runs.filter(r => r.passed).length;
+        console.log(`         Runs: ${passedRuns}/${c.runs.length} passed`);
+      }
+    }
+
+    console.log();
+    console.log(`  Total: ${provider.totalCases} cases, ${provider.passed} passed, ${provider.failed} failed`);
+    console.log(`  Cost:  $${provider.totalCost.toFixed(4)}`);
+    console.log(`  Time:  ${provider.durationMs}ms`);
+    console.log();
+  }
+
+  // Comparison table for multi-provider
+  if (result.providers.length > 1) {
+    printComparisonTable(result);
+  }
+}
+
+function printComparisonTable(result: EvalResult): void {
+  console.log(`── Comparison ──`);
+  console.log();
+
+  // Header
+  const providers = result.providers;
+  const nameWidth = Math.max(20, ...providers.map(p => p.provider.length + p.model.length + 3));
+  const header = `  ${'Provider'.padEnd(nameWidth)}  Pass  Fail  Cost       Time`;
+  console.log(header);
+  console.log(`  ${'─'.repeat(header.length - 2)}`);
+
+  for (const p of providers) {
+    const name = `${p.provider} (${p.model})`;
+    console.log(
+      `  ${name.padEnd(nameWidth)}  ${String(p.passed).padStart(4)}  ${String(p.failed).padStart(4)}  $${p.totalCost.toFixed(4).padStart(8)}  ${String(p.durationMs).padStart(6)}ms`,
+    );
+  }
+  console.log();
+}
+
+function formatCsv(result: EvalResult): string {
+  const lines: string[] = [
+    'timestamp,provider,model,case,passed,cost_usd,duration_ms,steps,error',
+  ];
+
+  for (const provider of result.providers) {
+    for (const c of provider.cases) {
+      lines.push(
+        [
+          result.timestamp,
+          csvEscape(provider.provider),
+          csvEscape(provider.model),
+          csvEscape(c.name),
+          c.passed,
+          c.cost.toFixed(6),
+          c.durationMs,
+          c.steps,
+          csvEscape(c.error ?? ''),
+        ].join(','),
+      );
+    }
+  }
+
+  return lines.join('\n');
+}
+
+function csvEscape(s: string): string {
+  if (s.includes(',') || s.includes('"') || s.includes('\n')) {
+    return `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
+}

--- a/src/eval/types.ts
+++ b/src/eval/types.ts
@@ -128,7 +128,7 @@ export interface EvalSuiteConfig {
   name: string;
   /** Description. */
   description?: string;
-  /** The model to use. Can be overridden per-case or via runEvals options. */
+  /** The model to use. Can be overridden via runEvals options. */
   model?: LanguageModel;
   /** System prompt for the agent. */
   systemPrompt?: string;

--- a/src/eval/types.ts
+++ b/src/eval/types.ts
@@ -1,0 +1,234 @@
+/**
+ * Eval framework types.
+ *
+ * Defines the shapes for eval suites, cases, assertions, and results.
+ */
+
+import type { LanguageModel, ToolSet } from 'ai';
+import type { AgentHooks, ConversationMessage, PermissionConfig, PricingTable } from '../types.js';
+import type { MemoryStore } from '../stores.js';
+
+// ── Assertions ──
+
+export interface ContainsAssertion {
+  type: 'contains';
+  value: string;
+}
+
+export interface NotContainsAssertion {
+  type: 'not-contains';
+  value: string;
+}
+
+export interface RegexAssertion {
+  type: 'regex';
+  pattern: string;
+  flags?: string;
+}
+
+export interface JsonSchemaAssertion {
+  type: 'json-schema';
+  schema: Record<string, unknown>;
+}
+
+export interface ToolCalledAssertion {
+  type: 'tool-called';
+  tool: string;
+}
+
+export interface ToolNotCalledAssertion {
+  type: 'tool-not-called';
+  tool: string;
+}
+
+export interface ToolArgsAssertion {
+  type: 'tool-args';
+  tool: string;
+  /** Partial match — every key/value in args must appear in the actual tool call args. */
+  args: Record<string, unknown>;
+}
+
+export interface FileExistsAssertion {
+  type: 'file-exists';
+  path: string;
+}
+
+export interface FileContainsAssertion {
+  type: 'file-contains';
+  path: string;
+  value: string;
+}
+
+export interface MaxStepsAssertion {
+  type: 'max-steps';
+  max: number;
+}
+
+export interface MaxCostAssertion {
+  type: 'max-cost';
+  /** Maximum cost in USD. */
+  maxUsd: number;
+}
+
+export interface LlmRubricAssertion {
+  type: 'llm-rubric';
+  rubric: string;
+  /** 'pass-fail' returns boolean. '1-5' returns a numeric score (pass if >= 3). */
+  score?: 'pass-fail' | '1-5';
+  /** Model to use as judge. If not provided, uses the eval's model. */
+  judgeModel?: LanguageModel;
+}
+
+export interface CustomAssertion {
+  type: 'custom';
+  /** Name for display purposes. */
+  name: string;
+  /** Function that receives the case result and returns pass/fail. */
+  fn: (result: CaseRunResult) => boolean | Promise<boolean>;
+}
+
+export type Assertion =
+  | ContainsAssertion
+  | NotContainsAssertion
+  | RegexAssertion
+  | JsonSchemaAssertion
+  | ToolCalledAssertion
+  | ToolNotCalledAssertion
+  | ToolArgsAssertion
+  | FileExistsAssertion
+  | FileContainsAssertion
+  | MaxStepsAssertion
+  | MaxCostAssertion
+  | LlmRubricAssertion
+  | CustomAssertion;
+
+// ── Eval Case ──
+
+export interface EvalCase {
+  /** Human-readable name for the test case. */
+  name: string;
+  /** The task/prompt to send to the agent. */
+  input: string;
+  /** Optional context passed as the second arg to agent.run(). */
+  context?: string;
+  /** Optional conversation history. */
+  history?: ConversationMessage[];
+  /** Assertions to check against the result. */
+  assert: Assertion[];
+  /** How many times to run this case (for non-determinism). Defaults to 1. */
+  runs?: number;
+  /** Timeout in ms for this case. Defaults to 60000. */
+  timeout?: number;
+}
+
+// ── Eval Suite ──
+
+export interface EvalSuiteConfig {
+  /** Name of the eval suite. */
+  name: string;
+  /** Description. */
+  description?: string;
+  /** The model to use. Can be overridden per-case or via runEvals options. */
+  model?: LanguageModel;
+  /** System prompt for the agent. */
+  systemPrompt?: string;
+  /** Tools for the agent. If not provided, file tools backed by an in-memory store are created. */
+  tools?: ToolSet;
+  /** Max iterations for the agent loop. Defaults to 20. */
+  maxIterations?: number;
+  /** Hooks. */
+  hooks?: AgentHooks;
+  /** Permission config. */
+  permissions?: PermissionConfig;
+  /** Pricing table for cost tracking. */
+  pricing?: PricingTable;
+  /** The eval cases. */
+  cases: EvalCase[];
+}
+
+// ── Run Options ──
+
+export interface RunEvalsOptions {
+  /** Override the model for all cases. */
+  model?: LanguageModel;
+  /** Run across multiple providers for comparison. */
+  providers?: Array<{
+    name: string;
+    model: LanguageModel;
+  }>;
+  /** Output format. Defaults to 'console'. */
+  output?: 'console' | 'json' | 'csv' | 'silent';
+  /** Custom memory store factory. Called once per case. Defaults to InMemoryMemoryStore. */
+  createStore?: () => MemoryStore;
+  /** Abort signal. */
+  signal?: AbortSignal;
+  /** Concurrency — how many cases to run in parallel. Defaults to 1 (sequential). */
+  concurrency?: number;
+}
+
+// ── Results ──
+
+/** Intermediate result from running a single case (before assertions). */
+export interface CaseRunResult {
+  /** The agent's text response. */
+  text: string;
+  /** Total steps taken. */
+  steps: number;
+  /** Total cost in USD. */
+  cost: number;
+  /** Duration in milliseconds. */
+  durationMs: number;
+  /** Tool calls made during execution. */
+  toolCalls: Array<{
+    toolName: string;
+    args: Record<string, unknown>;
+    result: unknown;
+  }>;
+  /** The memory store state after execution. */
+  store: MemoryStore;
+  /** Agent ID used. */
+  agentId: string;
+  /** Whether the run was aborted. */
+  aborted: boolean;
+}
+
+/** Result of a single assertion. */
+export interface AssertionResult {
+  assertion: Assertion;
+  passed: boolean;
+  message: string;
+}
+
+/** Result of a single eval case. */
+export interface CaseResult {
+  name: string;
+  input: string;
+  passed: boolean;
+  assertions: AssertionResult[];
+  cost: number;
+  durationMs: number;
+  steps: number;
+  text: string;
+  error?: string;
+  /** For multi-run cases, individual run results. */
+  runs?: CaseResult[];
+}
+
+/** Result of a full eval suite for one provider. */
+export interface ProviderResult {
+  provider: string;
+  model: string;
+  totalCases: number;
+  passed: number;
+  failed: number;
+  totalCost: number;
+  durationMs: number;
+  cases: CaseResult[];
+}
+
+/** Full eval result (may contain multiple providers for comparison). */
+export interface EvalResult {
+  name: string;
+  timestamp: string;
+  providers: ProviderResult[];
+}

--- a/tests/cli-args.test.ts
+++ b/tests/cli-args.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from 'vitest';
+import { parseArgs } from '../src/cli/args.js';
+
+describe('parseArgs', () => {
+  it('defaults to prompt command with no args', () => {
+    const args = parseArgs([]);
+    expect(args.command).toBe('prompt');
+    expect(args.prompt).toBeUndefined();
+    expect(args.provider).toBe('anthropic');
+    expect(args.maxIterations).toBe(20);
+  });
+
+  it('parses a simple prompt', () => {
+    const args = parseArgs(['Hello', 'world']);
+    expect(args.command).toBe('prompt');
+    expect(args.prompt).toBe('Hello world');
+  });
+
+  it('parses quoted prompt', () => {
+    const args = parseArgs(['What is TypeScript?']);
+    expect(args.prompt).toBe('What is TypeScript?');
+  });
+
+  it('recognizes run subcommand', () => {
+    const args = parseArgs(['run', 'my-agent.ts']);
+    expect(args.command).toBe('run');
+    expect(args.file).toBe('my-agent.ts');
+  });
+
+  it('recognizes run subcommand with task', () => {
+    const args = parseArgs(['run', 'script.ts', 'do', 'something']);
+    expect(args.command).toBe('run');
+    expect(args.file).toBe('script.ts');
+    expect(args.prompt).toBe('do something');
+  });
+
+  it('recognizes eval subcommand', () => {
+    const args = parseArgs(['eval', 'evals/basic.ts']);
+    expect(args.command).toBe('eval');
+    expect(args.file).toBe('evals/basic.ts');
+  });
+
+  it('parses --provider', () => {
+    const args = parseArgs(['--provider', 'google', 'hello']);
+    expect(args.provider).toBe('google');
+    expect(args.prompt).toBe('hello');
+  });
+
+  it('parses --model', () => {
+    const args = parseArgs(['--model', 'gpt-4o', 'hello']);
+    expect(args.model).toBe('gpt-4o');
+  });
+
+  it('parses --system', () => {
+    const args = parseArgs(['--system', 'Be brief.', 'hello']);
+    expect(args.systemPrompt).toBe('Be brief.');
+  });
+
+  it('parses --memory', () => {
+    const args = parseArgs(['--memory', '/tmp/data', 'hello']);
+    expect(args.memoryDir).toBe('/tmp/data');
+  });
+
+  it('parses --read-only', () => {
+    const args = parseArgs(['--read-only', 'hello']);
+    expect(args.readOnly).toBe(true);
+  });
+
+  it('parses --max-iterations', () => {
+    const args = parseArgs(['--max-iterations', '5', 'hello']);
+    expect(args.maxIterations).toBe(5);
+  });
+
+  it('parses --no-tools', () => {
+    const args = parseArgs(['--no-tools', 'hello']);
+    expect(args.noTools).toBe(true);
+  });
+
+  it('parses --verbose', () => {
+    const args = parseArgs(['--verbose', 'hello']);
+    expect(args.verbose).toBe(true);
+  });
+
+  it('parses --json', () => {
+    const args = parseArgs(['--json', 'hello']);
+    expect(args.json).toBe(true);
+  });
+
+  it('parses --help', () => {
+    const args = parseArgs(['--help']);
+    expect(args.help).toBe(true);
+  });
+
+  it('parses -h as help', () => {
+    const args = parseArgs(['-h']);
+    expect(args.help).toBe(true);
+  });
+
+  // Eval-specific
+  it('parses --output for eval', () => {
+    const args = parseArgs(['eval', 'file.ts', '--output', 'json']);
+    expect(args.output).toBe('json');
+  });
+
+  it('parses --output csv', () => {
+    const args = parseArgs(['eval', 'file.ts', '--output', 'csv']);
+    expect(args.output).toBe('csv');
+  });
+
+  it('parses --compare', () => {
+    const args = parseArgs(['eval', 'file.ts', '--compare', 'anthropic,google,openai']);
+    expect(args.compare).toEqual(['anthropic', 'google', 'openai']);
+  });
+
+  it('parses --concurrency', () => {
+    const args = parseArgs(['eval', 'file.ts', '--concurrency', '4']);
+    expect(args.concurrency).toBe(4);
+  });
+
+  // Error cases
+  it('throws on unknown option', () => {
+    expect(() => parseArgs(['--unknown'])).toThrow('Unknown option');
+  });
+
+  it('throws when --provider has no value', () => {
+    expect(() => parseArgs(['--provider'])).toThrow('requires a value');
+  });
+
+  it('throws when --max-iterations is not a number', () => {
+    expect(() => parseArgs(['--max-iterations', 'abc'])).toThrow('positive integer');
+  });
+
+  it('throws when --max-iterations is zero', () => {
+    expect(() => parseArgs(['--max-iterations', '0'])).toThrow('positive integer');
+  });
+
+  it('throws when --output is invalid', () => {
+    expect(() => parseArgs(['eval', 'f.ts', '--output', 'xml'])).toThrow('must be console, json, or csv');
+  });
+
+  it('throws when run has no file', () => {
+    expect(() => parseArgs(['run'])).toThrow('Usage');
+  });
+
+  it('throws when eval has no file (and no --help)', () => {
+    expect(() => parseArgs(['eval'])).toThrow('Usage');
+  });
+
+  it('eval with --help does not throw', () => {
+    const args = parseArgs(['eval', '--help']);
+    expect(args.help).toBe(true);
+  });
+
+  // Combined options
+  it('handles multiple flags together', () => {
+    const args = parseArgs([
+      '--provider', 'openai',
+      '--model', 'gpt-4o',
+      '--verbose',
+      '--read-only',
+      '--max-iterations', '10',
+      'Summarize this',
+    ]);
+    expect(args.provider).toBe('openai');
+    expect(args.model).toBe('gpt-4o');
+    expect(args.verbose).toBe(true);
+    expect(args.readOnly).toBe(true);
+    expect(args.maxIterations).toBe(10);
+    expect(args.prompt).toBe('Summarize this');
+  });
+
+  it('flags before and after prompt', () => {
+    const args = parseArgs(['--verbose', 'hello', 'world']);
+    expect(args.verbose).toBe(true);
+    expect(args.prompt).toBe('hello world');
+  });
+});

--- a/tests/eval-assertions.test.ts
+++ b/tests/eval-assertions.test.ts
@@ -187,6 +187,48 @@ describe('tool-args assertion', () => {
     expect(r.passed).toBe(false);
     expect(r.message).toContain('was not called');
   });
+
+  it('deep partial match — nested objects', async () => {
+    const r = await evaluateAssertion(
+      { type: 'tool-args', tool: 'api_call', args: { config: { timeout: 5000 } } },
+      makeResult({
+        toolCalls: [{
+          toolName: 'api_call',
+          args: { config: { timeout: 5000, retries: 3 }, url: 'http://x' },
+          result: 'ok',
+        }],
+      }),
+    );
+    expect(r.passed).toBe(true);
+  });
+
+  it('deep partial match — array values', async () => {
+    const r = await evaluateAssertion(
+      { type: 'tool-args', tool: 'query', args: { tags: ['a', 'b'] } },
+      makeResult({
+        toolCalls: [{
+          toolName: 'query',
+          args: { tags: ['a', 'b'], limit: 10 },
+          result: 'ok',
+        }],
+      }),
+    );
+    expect(r.passed).toBe(true);
+  });
+
+  it('deep partial match fails on different nested value', async () => {
+    const r = await evaluateAssertion(
+      { type: 'tool-args', tool: 'api_call', args: { config: { timeout: 9999 } } },
+      makeResult({
+        toolCalls: [{
+          toolName: 'api_call',
+          args: { config: { timeout: 5000 } },
+          result: 'ok',
+        }],
+      }),
+    );
+    expect(r.passed).toBe(false);
+  });
 });
 
 describe('file-exists assertion', () => {

--- a/tests/eval-assertions.test.ts
+++ b/tests/eval-assertions.test.ts
@@ -1,0 +1,331 @@
+import { describe, it, expect } from 'vitest';
+import { evaluateAssertion } from '../src/eval/assertions.js';
+import type { CaseRunResult, Assertion } from '../src/eval/types.js';
+import { InMemoryMemoryStore } from '../src/stores/in-memory.js';
+
+function makeResult(overrides: Partial<CaseRunResult> = {}): CaseRunResult {
+  return {
+    text: overrides.text ?? 'Hello world',
+    steps: overrides.steps ?? 1,
+    cost: overrides.cost ?? 0.001,
+    durationMs: overrides.durationMs ?? 100,
+    toolCalls: overrides.toolCalls ?? [],
+    store: overrides.store ?? new InMemoryMemoryStore(),
+    agentId: overrides.agentId ?? 'test-agent',
+    aborted: overrides.aborted ?? false,
+  };
+}
+
+describe('contains assertion', () => {
+  it('passes when text contains value', async () => {
+    const r = await evaluateAssertion({ type: 'contains', value: 'Hello' }, makeResult());
+    expect(r.passed).toBe(true);
+  });
+
+  it('fails when text does not contain value', async () => {
+    const r = await evaluateAssertion({ type: 'contains', value: 'Goodbye' }, makeResult());
+    expect(r.passed).toBe(false);
+    expect(r.message).toContain('does not contain');
+  });
+
+  it('is case-sensitive', async () => {
+    const r = await evaluateAssertion({ type: 'contains', value: 'hello' }, makeResult({ text: 'Hello' }));
+    expect(r.passed).toBe(false);
+  });
+});
+
+describe('not-contains assertion', () => {
+  it('passes when text does not contain value', async () => {
+    const r = await evaluateAssertion({ type: 'not-contains', value: 'Goodbye' }, makeResult());
+    expect(r.passed).toBe(true);
+  });
+
+  it('fails when text contains value', async () => {
+    const r = await evaluateAssertion({ type: 'not-contains', value: 'Hello' }, makeResult());
+    expect(r.passed).toBe(false);
+  });
+});
+
+describe('regex assertion', () => {
+  it('passes when text matches pattern', async () => {
+    const r = await evaluateAssertion({ type: 'regex', pattern: 'Hello \\w+' }, makeResult());
+    expect(r.passed).toBe(true);
+  });
+
+  it('fails when text does not match', async () => {
+    const r = await evaluateAssertion({ type: 'regex', pattern: '^Goodbye' }, makeResult());
+    expect(r.passed).toBe(false);
+  });
+
+  it('supports flags', async () => {
+    const r = await evaluateAssertion({ type: 'regex', pattern: 'hello', flags: 'i' }, makeResult());
+    expect(r.passed).toBe(true);
+  });
+
+  it('handles invalid regex gracefully', async () => {
+    const r = await evaluateAssertion({ type: 'regex', pattern: '[invalid' }, makeResult());
+    expect(r.passed).toBe(false);
+    expect(r.message).toContain('Invalid regex');
+  });
+});
+
+describe('json-schema assertion', () => {
+  it('passes for valid JSON matching schema', async () => {
+    const r = await evaluateAssertion(
+      {
+        type: 'json-schema',
+        schema: { type: 'object', required: ['name'], properties: { name: { type: 'string' } } },
+      },
+      makeResult({ text: '{"name": "Alice"}' }),
+    );
+    expect(r.passed).toBe(true);
+  });
+
+  it('fails for missing required field', async () => {
+    const r = await evaluateAssertion(
+      { type: 'json-schema', schema: { type: 'object', required: ['name'] } },
+      makeResult({ text: '{"age": 30}' }),
+    );
+    expect(r.passed).toBe(false);
+    expect(r.message).toContain('name');
+  });
+
+  it('fails for wrong type', async () => {
+    const r = await evaluateAssertion(
+      { type: 'json-schema', schema: { type: 'array' } },
+      makeResult({ text: '{"a": 1}' }),
+    );
+    expect(r.passed).toBe(false);
+  });
+
+  it('fails for invalid JSON', async () => {
+    const r = await evaluateAssertion(
+      { type: 'json-schema', schema: { type: 'object' } },
+      makeResult({ text: 'not json' }),
+    );
+    expect(r.passed).toBe(false);
+    expect(r.message).toContain('not valid JSON');
+  });
+});
+
+describe('tool-called assertion', () => {
+  it('passes when tool was called', async () => {
+    const r = await evaluateAssertion(
+      { type: 'tool-called', tool: 'write_file' },
+      makeResult({ toolCalls: [{ toolName: 'write_file', args: { path: 'a.md' }, result: 'ok' }] }),
+    );
+    expect(r.passed).toBe(true);
+  });
+
+  it('fails when tool was not called', async () => {
+    const r = await evaluateAssertion(
+      { type: 'tool-called', tool: 'write_file' },
+      makeResult({ toolCalls: [{ toolName: 'read_file', args: {}, result: '' }] }),
+    );
+    expect(r.passed).toBe(false);
+    expect(r.message).toContain('read_file');
+  });
+
+  it('fails with empty tool calls', async () => {
+    const r = await evaluateAssertion(
+      { type: 'tool-called', tool: 'write_file' },
+      makeResult(),
+    );
+    expect(r.passed).toBe(false);
+    expect(r.message).toContain('(none)');
+  });
+});
+
+describe('tool-not-called assertion', () => {
+  it('passes when tool was not called', async () => {
+    const r = await evaluateAssertion(
+      { type: 'tool-not-called', tool: 'delete_file' },
+      makeResult({ toolCalls: [{ toolName: 'read_file', args: {}, result: '' }] }),
+    );
+    expect(r.passed).toBe(true);
+  });
+
+  it('fails when tool was called', async () => {
+    const r = await evaluateAssertion(
+      { type: 'tool-not-called', tool: 'delete_file' },
+      makeResult({ toolCalls: [{ toolName: 'delete_file', args: {}, result: '' }] }),
+    );
+    expect(r.passed).toBe(false);
+  });
+});
+
+describe('tool-args assertion', () => {
+  it('passes with matching args (partial match)', async () => {
+    const r = await evaluateAssertion(
+      { type: 'tool-args', tool: 'write_file', args: { path: 'test.md' } },
+      makeResult({
+        toolCalls: [{
+          toolName: 'write_file',
+          args: { path: 'test.md', content: 'hello' },
+          result: 'ok',
+        }],
+      }),
+    );
+    expect(r.passed).toBe(true);
+  });
+
+  it('fails with non-matching args', async () => {
+    const r = await evaluateAssertion(
+      { type: 'tool-args', tool: 'write_file', args: { path: 'other.md' } },
+      makeResult({
+        toolCalls: [{ toolName: 'write_file', args: { path: 'test.md' }, result: 'ok' }],
+      }),
+    );
+    expect(r.passed).toBe(false);
+  });
+
+  it('fails when tool was not called', async () => {
+    const r = await evaluateAssertion(
+      { type: 'tool-args', tool: 'write_file', args: { path: 'x' } },
+      makeResult(),
+    );
+    expect(r.passed).toBe(false);
+    expect(r.message).toContain('was not called');
+  });
+});
+
+describe('file-exists assertion', () => {
+  it('passes when file exists', async () => {
+    const store = new InMemoryMemoryStore();
+    await store.write('test-agent', 'test.md', 'content');
+    const r = await evaluateAssertion(
+      { type: 'file-exists', path: 'test.md' },
+      makeResult({ store }),
+    );
+    expect(r.passed).toBe(true);
+  });
+
+  it('fails when file does not exist', async () => {
+    const r = await evaluateAssertion(
+      { type: 'file-exists', path: 'missing.md' },
+      makeResult(),
+    );
+    expect(r.passed).toBe(false);
+  });
+});
+
+describe('file-contains assertion', () => {
+  it('passes when file contains value', async () => {
+    const store = new InMemoryMemoryStore();
+    await store.write('test-agent', 'test.md', 'Hello Alice');
+    const r = await evaluateAssertion(
+      { type: 'file-contains', path: 'test.md', value: 'Alice' },
+      makeResult({ store }),
+    );
+    expect(r.passed).toBe(true);
+  });
+
+  it('fails when file does not contain value', async () => {
+    const store = new InMemoryMemoryStore();
+    await store.write('test-agent', 'test.md', 'Hello Bob');
+    const r = await evaluateAssertion(
+      { type: 'file-contains', path: 'test.md', value: 'Alice' },
+      makeResult({ store }),
+    );
+    expect(r.passed).toBe(false);
+  });
+
+  it('fails when file does not exist', async () => {
+    const r = await evaluateAssertion(
+      { type: 'file-contains', path: 'missing.md', value: 'anything' },
+      makeResult(),
+    );
+    expect(r.passed).toBe(false);
+  });
+});
+
+describe('max-steps assertion', () => {
+  it('passes when within limit', async () => {
+    const r = await evaluateAssertion({ type: 'max-steps', max: 5 }, makeResult({ steps: 3 }));
+    expect(r.passed).toBe(true);
+  });
+
+  it('passes at exact limit', async () => {
+    const r = await evaluateAssertion({ type: 'max-steps', max: 3 }, makeResult({ steps: 3 }));
+    expect(r.passed).toBe(true);
+  });
+
+  it('fails when over limit', async () => {
+    const r = await evaluateAssertion({ type: 'max-steps', max: 2 }, makeResult({ steps: 3 }));
+    expect(r.passed).toBe(false);
+  });
+});
+
+describe('max-cost assertion', () => {
+  it('passes when within budget', async () => {
+    const r = await evaluateAssertion({ type: 'max-cost', maxUsd: 0.01 }, makeResult({ cost: 0.005 }));
+    expect(r.passed).toBe(true);
+  });
+
+  it('fails when over budget', async () => {
+    const r = await evaluateAssertion({ type: 'max-cost', maxUsd: 0.001 }, makeResult({ cost: 0.005 }));
+    expect(r.passed).toBe(false);
+  });
+});
+
+describe('llm-rubric assertion', () => {
+  it('fails with no judge model', async () => {
+    const r = await evaluateAssertion(
+      { type: 'llm-rubric', rubric: 'Should be friendly' },
+      makeResult(),
+    );
+    expect(r.passed).toBe(false);
+    expect(r.message).toContain('No judge model');
+  });
+});
+
+describe('custom assertion', () => {
+  it('passes when fn returns true', async () => {
+    const r = await evaluateAssertion(
+      {
+        type: 'custom',
+        name: 'custom check',
+        fn: (result) => result.text.length > 0,
+      },
+      makeResult(),
+    );
+    expect(r.passed).toBe(true);
+  });
+
+  it('fails when fn returns false', async () => {
+    const r = await evaluateAssertion(
+      {
+        type: 'custom',
+        name: 'empty check',
+        fn: (result) => result.text === '',
+      },
+      makeResult(),
+    );
+    expect(r.passed).toBe(false);
+  });
+
+  it('handles async fn', async () => {
+    const r = await evaluateAssertion(
+      {
+        type: 'custom',
+        name: 'async check',
+        fn: async (result) => result.steps === 1,
+      },
+      makeResult(),
+    );
+    expect(r.passed).toBe(true);
+  });
+
+  it('handles fn that throws', async () => {
+    const r = await evaluateAssertion(
+      {
+        type: 'custom',
+        name: 'throwing check',
+        fn: () => { throw new Error('boom'); },
+      },
+      makeResult(),
+    );
+    expect(r.passed).toBe(false);
+    expect(r.message).toContain('boom');
+  });
+});

--- a/tests/eval-runner.test.ts
+++ b/tests/eval-runner.test.ts
@@ -1,0 +1,452 @@
+import { describe, it, expect } from 'vitest';
+import { defineEval, runEvals } from '../src/eval/runner.js';
+import { createMockModel } from '../src/testing/index.js';
+
+describe('defineEval', () => {
+  it('returns the config unchanged', () => {
+    const config = {
+      name: 'test-suite',
+      cases: [
+        { name: 'case1', input: 'hello', assert: [{ type: 'contains' as const, value: 'hello' }] },
+      ],
+    };
+    expect(defineEval(config)).toBe(config);
+  });
+});
+
+describe('runEvals', () => {
+  it('runs a simple contains assertion against mock model', async () => {
+    const model = createMockModel({
+      responses: [{ text: 'The answer is 42' }],
+    });
+
+    const suite = defineEval({
+      name: 'basic-test',
+      model,
+      systemPrompt: 'You are helpful.',
+      cases: [
+        {
+          name: 'knows the answer',
+          input: 'What is the answer?',
+          assert: [{ type: 'contains', value: '42' }],
+        },
+      ],
+    });
+
+    const result = await runEvals(suite, { output: 'silent' });
+
+    expect(result.name).toBe('basic-test');
+    expect(result.providers).toHaveLength(1);
+    expect(result.providers[0]!.passed).toBe(1);
+    expect(result.providers[0]!.failed).toBe(0);
+    expect(result.providers[0]!.cases[0]!.passed).toBe(true);
+  });
+
+  it('detects a failing assertion', async () => {
+    const model = createMockModel({
+      responses: [{ text: 'I have no idea' }],
+    });
+
+    const suite = defineEval({
+      name: 'fail-test',
+      model,
+      cases: [
+        {
+          name: 'should contain answer',
+          input: 'What is 2+2?',
+          assert: [{ type: 'contains', value: '4' }],
+        },
+      ],
+    });
+
+    const result = await runEvals(suite, { output: 'silent' });
+
+    expect(result.providers[0]!.passed).toBe(0);
+    expect(result.providers[0]!.failed).toBe(1);
+    expect(result.providers[0]!.cases[0]!.passed).toBe(false);
+  });
+
+  it('supports multiple assertions on one case', async () => {
+    const model = createMockModel({
+      responses: [{ text: 'Paris is the capital of France' }],
+    });
+
+    const suite = defineEval({
+      name: 'multi-assert',
+      model,
+      cases: [
+        {
+          name: 'capitals',
+          input: 'Capital of France?',
+          assert: [
+            { type: 'contains', value: 'Paris' },
+            { type: 'not-contains', value: 'London' },
+            { type: 'regex', pattern: 'Paris.*France' },
+          ],
+        },
+      ],
+    });
+
+    const result = await runEvals(suite, { output: 'silent' });
+
+    expect(result.providers[0]!.cases[0]!.passed).toBe(true);
+    expect(result.providers[0]!.cases[0]!.assertions).toHaveLength(3);
+  });
+
+  it('case fails if any assertion fails', async () => {
+    const model = createMockModel({
+      responses: [{ text: 'The capital of France is Paris' }],
+    });
+
+    const suite = defineEval({
+      name: 'partial-fail',
+      model,
+      cases: [
+        {
+          name: 'mixed',
+          input: 'test',
+          assert: [
+            { type: 'contains', value: 'Paris' },
+            { type: 'contains', value: 'Berlin' }, // will fail
+          ],
+        },
+      ],
+    });
+
+    const result = await runEvals(suite, { output: 'silent' });
+
+    expect(result.providers[0]!.cases[0]!.passed).toBe(false);
+    expect(result.providers[0]!.cases[0]!.assertions[0]!.passed).toBe(true);
+    expect(result.providers[0]!.cases[0]!.assertions[1]!.passed).toBe(false);
+  });
+
+  it('handles tool-called assertion with mock model', async () => {
+    const model = createMockModel({
+      responses: [
+        {
+          toolCalls: [{ toolName: 'write_file', args: { path: 'test.md', content: 'hello' } }],
+        },
+        { text: 'Done! I saved the file.' },
+      ],
+    });
+
+    const suite = defineEval({
+      name: 'tool-test',
+      model,
+      systemPrompt: 'You are helpful.',
+      cases: [
+        {
+          name: 'writes a file',
+          input: 'Save a note',
+          assert: [
+            { type: 'tool-called', tool: 'write_file' },
+            { type: 'tool-not-called', tool: 'delete_file' },
+          ],
+        },
+      ],
+    });
+
+    const result = await runEvals(suite, { output: 'silent' });
+
+    expect(result.providers[0]!.cases[0]!.passed).toBe(true);
+  });
+
+  it('checks file state after agent run', async () => {
+    const model = createMockModel({
+      responses: [
+        {
+          toolCalls: [{ toolName: 'write_file', args: { path: 'notes.md', content: 'Alice is great' } }],
+        },
+        { text: 'Saved!' },
+      ],
+    });
+
+    const suite = defineEval({
+      name: 'file-state-test',
+      model,
+      systemPrompt: 'You are helpful.',
+      cases: [
+        {
+          name: 'saves note with name',
+          input: 'Remember Alice',
+          assert: [
+            { type: 'file-exists', path: 'notes.md' },
+            { type: 'file-contains', path: 'notes.md', value: 'Alice' },
+          ],
+        },
+      ],
+    });
+
+    const result = await runEvals(suite, { output: 'silent' });
+
+    expect(result.providers[0]!.cases[0]!.passed).toBe(true);
+  });
+
+  it('tracks cost and steps', async () => {
+    const model = createMockModel({
+      responses: [{ text: 'done' }],
+      inputTokensPerCall: 100,
+      outputTokensPerCall: 50,
+    });
+
+    const suite = defineEval({
+      name: 'cost-test',
+      model,
+      cases: [
+        {
+          name: 'within budget',
+          input: 'hello',
+          assert: [
+            { type: 'max-steps', max: 5 },
+            { type: 'max-cost', maxUsd: 1.0 },
+          ],
+        },
+      ],
+    });
+
+    const result = await runEvals(suite, { output: 'silent' });
+
+    expect(result.providers[0]!.cases[0]!.passed).toBe(true);
+    expect(result.providers[0]!.cases[0]!.steps).toBeGreaterThanOrEqual(1);
+  });
+
+  it('runs multiple cases sequentially', async () => {
+    const model = createMockModel({
+      responses: [
+        { text: 'Answer is 4' },
+        { text: 'Answer is 9' },
+      ],
+    });
+
+    const suite = defineEval({
+      name: 'multi-case',
+      model,
+      cases: [
+        {
+          name: 'case 1',
+          input: '2+2?',
+          assert: [{ type: 'contains', value: '4' }],
+        },
+        {
+          name: 'case 2',
+          input: '3*3?',
+          assert: [{ type: 'contains', value: '9' }],
+        },
+      ],
+    });
+
+    const result = await runEvals(suite, { output: 'silent' });
+
+    expect(result.providers[0]!.totalCases).toBe(2);
+    expect(result.providers[0]!.passed).toBe(2);
+  });
+
+  it('throws when no model is provided', async () => {
+    const suite = defineEval({
+      name: 'no-model',
+      cases: [
+        { name: 'test', input: 'hello', assert: [] },
+      ],
+    });
+
+    await expect(runEvals(suite, { output: 'silent' })).rejects.toThrow('No model provided');
+  });
+
+  it('supports model override via options', async () => {
+    const model = createMockModel({
+      responses: [{ text: 'overridden' }],
+      modelId: 'override-model',
+    });
+
+    const suite = defineEval({
+      name: 'override-test',
+      // no model in suite
+      cases: [
+        {
+          name: 'test',
+          input: 'hello',
+          assert: [{ type: 'contains', value: 'overridden' }],
+        },
+      ],
+    });
+
+    const result = await runEvals(suite, { model, output: 'silent' });
+
+    expect(result.providers[0]!.passed).toBe(1);
+    expect(result.providers[0]!.model).toBe('override-model');
+  });
+
+  it('supports multi-provider comparison', async () => {
+    const model1 = createMockModel({
+      responses: [{ text: 'Paris' }],
+      modelId: 'model-a',
+    });
+    const model2 = createMockModel({
+      responses: [{ text: 'London' }], // wrong
+      modelId: 'model-b',
+    });
+
+    const suite = defineEval({
+      name: 'compare-test',
+      cases: [
+        {
+          name: 'capital of France',
+          input: 'Capital of France?',
+          assert: [{ type: 'contains', value: 'Paris' }],
+        },
+      ],
+    });
+
+    const result = await runEvals(suite, {
+      output: 'silent',
+      providers: [
+        { name: 'provider-a', model: model1 },
+        { name: 'provider-b', model: model2 },
+      ],
+    });
+
+    expect(result.providers).toHaveLength(2);
+    expect(result.providers[0]!.passed).toBe(1);
+    expect(result.providers[0]!.provider).toBe('provider-a');
+    expect(result.providers[1]!.passed).toBe(0);
+    expect(result.providers[1]!.provider).toBe('provider-b');
+  });
+
+  it('supports custom assertion', async () => {
+    const model = createMockModel({
+      responses: [{ text: 'Hello World' }],
+    });
+
+    const suite = defineEval({
+      name: 'custom-assert',
+      model,
+      cases: [
+        {
+          name: 'custom check',
+          input: 'hello',
+          assert: [
+            {
+              type: 'custom',
+              name: 'word count',
+              fn: (result) => result.text.split(' ').length === 2,
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = await runEvals(suite, { output: 'silent' });
+    expect(result.providers[0]!.cases[0]!.passed).toBe(true);
+  });
+
+  it('isolates store between cases', async () => {
+    const model = createMockModel({
+      responses: [
+        // Case 1: write a file
+        { toolCalls: [{ toolName: 'write_file', args: { path: 'state.md', content: 'case1' } }] },
+        { text: 'done' },
+        // Case 2: no writes — file should NOT exist
+        { text: 'nothing' },
+      ],
+    });
+
+    const suite = defineEval({
+      name: 'isolation-test',
+      model,
+      cases: [
+        {
+          name: 'writes file',
+          input: 'write something',
+          assert: [{ type: 'file-exists', path: 'state.md' }],
+        },
+        {
+          name: 'file should not exist from previous case',
+          input: 'check state',
+          assert: [
+            {
+              type: 'custom',
+              name: 'no leftover state',
+              fn: async (result) => {
+                const exists = await result.store.exists(result.agentId, 'state.md');
+                return !exists;
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = await runEvals(suite, { output: 'silent' });
+
+    expect(result.providers[0]!.cases[0]!.passed).toBe(true);
+    expect(result.providers[0]!.cases[1]!.passed).toBe(true);
+  });
+
+  it('handles agent errors gracefully', async () => {
+    const model = createMockModel({
+      responses: [], // empty — will cause an error
+    });
+
+    const suite = defineEval({
+      name: 'error-test',
+      model,
+      cases: [
+        {
+          name: 'should handle error',
+          input: 'hello',
+          assert: [{ type: 'contains', value: 'anything' }],
+        },
+      ],
+    });
+
+    const result = await runEvals(suite, { output: 'silent' });
+
+    // Should not throw, should report as failed
+    expect(result.providers[0]!.failed).toBeGreaterThanOrEqual(0);
+  });
+
+  it('result has timestamp', async () => {
+    const model = createMockModel({ responses: [{ text: 'ok' }] });
+    const suite = defineEval({
+      name: 'timestamp-test',
+      model,
+      cases: [{ name: 'test', input: 'hi', assert: [] }],
+    });
+
+    const result = await runEvals(suite, { output: 'silent' });
+    expect(result.timestamp).toBeTruthy();
+    // Should be a valid ISO date
+    expect(new Date(result.timestamp).toISOString()).toBe(result.timestamp);
+  });
+
+  it('tool-args partial match works with nested values', async () => {
+    const model = createMockModel({
+      responses: [
+        {
+          toolCalls: [{
+            toolName: 'write_file',
+            args: { path: 'deep/nested.md', content: 'hello world', encoding: 'utf-8' },
+          }],
+        },
+        { text: 'done' },
+      ],
+    });
+
+    const suite = defineEval({
+      name: 'nested-args',
+      model,
+      cases: [
+        {
+          name: 'partial args match',
+          input: 'save',
+          assert: [
+            { type: 'tool-args', tool: 'write_file', args: { path: 'deep/nested.md' } },
+          ],
+        },
+      ],
+    });
+
+    const result = await runEvals(suite, { output: 'silent' });
+    expect(result.providers[0]!.cases[0]!.passed).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Implements #7 — all 5 phases of the eval framework.

- **Phase 1: Core runner** — `defineEval()` + `runEvals()` with basic assertions (contains, not-contains, regex, json-schema) and 4 output formats (console, json, csv, silent)
- **Phase 2: Agent-specific assertions** — file-exists, file-contains, tool-args, tool-called, tool-not-called, max-steps, max-cost — verify memory store state and tool behavior after agent runs
- **Phase 3: LLM-as-judge** — `llm-rubric` assertion that sends the response to a judge model with a rubric, supports pass-fail and 1-5 scoring
- **Phase 4: Multi-provider comparison** — `options.providers` array runs the same suite across multiple models, prints comparison table
- **Phase 5: Example** — `examples/13-eval-framework.ts` demonstrates all assertion types with a real model

### Key design decisions
- Each eval case gets an **isolated memory store** — no state leaks between cases
- Tool calls are captured via transparent wrapping — works with any ToolSet
- 13 assertion types total, plus `custom` for arbitrary logic
- Supports `runs` per case for non-determinism testing
- Concurrency support via `options.concurrency`
- Uses existing `runAgentLoop` internally — evals exercise the full agent loop

### Files
- `src/eval/types.ts` — all types (assertions, cases, suites, results)
- `src/eval/assertions.ts` — 13 assertion evaluators
- `src/eval/runner.ts` — eval runner, reporters (console/json/csv)
- `src/eval/index.ts` — public exports
- `tests/eval-assertions.test.ts` — 36 assertion tests
- `tests/eval-runner.test.ts` — 17 runner integration tests
- `examples/13-eval-framework.ts` — example usage
- Updated: README, CLAUDE.md, AGENTS.md, llms.txt, package.json

## Test plan

- [x] 53 new tests (36 assertion + 17 runner), 232 total passing
- [x] TypeScript strict mode — clean typecheck
- [x] All existing tests still pass
- [ ] Manual: run `examples/13-eval-framework.ts` with an API key

Closes #7, addresses #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)