### PR TITLE
Add npx agent-do CLI with prompt, run, and eval modes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,13 @@ src/
     types.ts        — eval types (assertions, cases, results)
     assertions.ts   — assertion evaluators (13 types)
     runner.ts       — eval runner (defineEval, runEvals)
+  cli.ts            — CLI entry point (npx agent-do)
+  cli/
+    args.ts         — argument parser + stdin reader
+    prompt.ts       — prompt mode (one-shot + interactive)
+    script.ts       — script mode (npx agent-do run)
+    eval-cmd.ts     — eval mode (npx agent-do eval)
+    resolve-model.ts — dynamic provider/model resolution
   index.ts          — all exports
 
 tests/              — vitest unit tests (one file per module)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,13 @@ src/
     types.ts        — eval types (assertions, cases, results)
     assertions.ts   — assertion evaluators (13 types)
     runner.ts       — eval runner (defineEval, runEvals)
+  cli.ts            — CLI entry point (npx agent-do)
+  cli/
+    args.ts         — argument parser + stdin reader
+    prompt.ts       — prompt mode (one-shot + interactive)
+    script.ts       — script mode (npx agent-do run)
+    eval-cmd.ts     — eval mode (npx agent-do eval)
+    resolve-model.ts — dynamic provider/model resolution
   index.ts          — all exports
 
 tests/              — vitest unit tests (one file per module)

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ npx agent-do
 # Choose provider and model
 npx agent-do --provider google --model gemini-2.5-flash "Hello"
 
-# Run a custom agent script
-npx agent-do run my-agent.ts "Do something"
+# Run a custom agent script (.js files, or .ts with tsx loader)
+npx agent-do run my-agent.js "Do something"
 
 # Run eval cases
 npx agent-do eval evals/basic.ts

--- a/README.md
+++ b/README.md
@@ -23,6 +23,69 @@ npm install agent-do
 
 Peer dependency: `ai` (Vercel AI SDK v6+).
 
+## CLI
+
+Run agents from the command line with zero config:
+
+```bash
+# One-shot task
+npx agent-do "What is TypeScript?"
+
+# Pipe content as context
+cat README.md | npx agent-do "Summarize this"
+
+# Pipe + prompt merged
+echo "function add(a, b) { return a + b }" | npx agent-do "Review this code"
+
+# Interactive chat
+npx agent-do
+
+# Choose provider and model
+npx agent-do --provider google --model gemini-2.5-flash "Hello"
+
+# Run a custom agent script
+npx agent-do run my-agent.ts "Do something"
+
+# Run eval cases
+npx agent-do eval evals/basic.ts
+
+# Compare providers
+npx agent-do eval evals/ --compare anthropic,google,openai --output json
+```
+
+### CLI options
+
+```
+npx agent-do [options] [prompt]          One-shot or interactive
+npx agent-do run <file> [task]           Run agent script
+npx agent-do eval <file|dir> [options]   Run evals
+
+Options:
+  --provider <name>      anthropic | google | openai | ollama (default: anthropic)
+  --model <id>           Model ID (default: provider-specific)
+  --system <prompt>      System prompt
+  --memory <dir>         Memory directory (default: .agent-do/)
+  --read-only            No filesystem writes
+  --max-iterations <n>   Max loop iterations (default: 20)
+  --no-tools             Disable file tools
+  --verbose              Show tool calls
+  --json                 JSON output
+  --output <fmt>         console | json | csv (eval only)
+  --compare <providers>  Compare providers (eval only, comma-separated)
+  --concurrency <n>      Parallel eval cases (default: 1)
+```
+
+### Piping
+
+Piped stdin is merged with the command-line prompt:
+
+| stdin | prompt | result |
+|-------|--------|--------|
+| no | `"Hello"` | Task: `"Hello"` |
+| `"context"` | no | Task: `"context"` |
+| `"context"` | `"Summarize"` | Task: `"Summarize\n\n---\n\ncontext"` |
+| no | no | Interactive mode |
+
 ## Quick Start
 
 ```ts

--- a/llms.txt
+++ b/llms.txt
@@ -108,3 +108,21 @@
 - Custom assertions via `{ type: 'custom', name, fn: (result) => boolean }`
 - Each case gets isolated memory store — no state leaks between cases
 - `options.concurrency: number` — parallel case execution (default: 1)
+
+## CLI (npx agent-do)
+
+- `npx agent-do "prompt"` — one-shot task with default agent
+- `npx agent-do` — interactive chat REPL
+- `echo "context" | npx agent-do "prompt"` — pipe stdin as context, merged with prompt
+- `npx agent-do run <file>` — run a script exporting an Agent, AgentConfig, or simple config
+- `npx agent-do eval <file|dir>` — run eval cases from file or directory
+- `--provider <name>` — anthropic | google | openai | ollama (default: anthropic)
+- `--model <id>` — model ID (default: provider-specific)
+- `--system <prompt>` — system prompt
+- `--memory <dir>` — memory directory (default: .agent-do/)
+- `--read-only` — no filesystem writes
+- `--verbose` — show tool calls
+- `--json` — JSON output
+- `--compare <providers>` — eval: compare across providers (comma-separated)
+- `--output <format>` — eval: console | json | csv
+- `--concurrency <n>` — eval: parallel case execution

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "bin": {
+    "agent-do": "./dist/cli.js"
+  },
   "exports": {
     ".": "./src/index.ts",
     "./testing": "./src/testing/index.ts",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {
-    "agent-do": "./dist/cli.js"
+    "agent-do": "./dist/src/cli.js"
   },
   "exports": {
     ".": "./src/index.ts",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -70,7 +70,7 @@ Options:
   --read-only            No filesystem writes
   --max-iterations <n>   Max loop iterations (default: 20)
   --no-tools             Disable file tools
-  --verbose              Show tool calls and step details
+  --verbose              Show thinking, tool calls, and per-step text (quiet by default)
   --json                 Output as JSON
   -h, --help             Show this help
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+
+/**
+ * agent-do CLI
+ *
+ * Usage:
+ *   npx agent-do "prompt"                     One-shot task
+ *   npx agent-do                              Interactive chat
+ *   echo "prompt" | npx agent-do              Piped input
+ *   echo "context" | npx agent-do "prompt"    Piped context merged with prompt
+ *   npx agent-do run script.ts                Run a script that exports an agent
+ *   npx agent-do eval evals/basic.ts          Run eval cases
+ */
+
+import { parseArgs, type ParsedArgs } from './cli/args.js';
+import { runPromptMode } from './cli/prompt.js';
+import { runScriptMode } from './cli/script.js';
+import { runEvalMode } from './cli/eval-cmd.js';
+
+async function main(): Promise<void> {
+  let args: ParsedArgs;
+  try {
+    args = parseArgs(process.argv.slice(2));
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+
+  try {
+    switch (args.command) {
+      case 'prompt':
+        await runPromptMode(args);
+        break;
+      case 'run':
+        await runScriptMode(args);
+        break;
+      case 'eval':
+        await runEvalMode(args);
+        break;
+    }
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+}
+
+function printHelp(): void {
+  console.log(`
+agent-do — run AI agents from the command line
+
+Usage:
+  npx agent-do [options] [prompt]          One-shot task or interactive chat
+  npx agent-do run <file>                  Run a script that exports an agent
+  npx agent-do eval <file|dir> [options]   Run eval cases
+
+Piping:
+  echo "context" | npx agent-do "prompt"   Merge piped input with prompt
+  cat file.txt | npx agent-do "Summarize"  Pipe file contents as context
+
+Options:
+  --provider <name>      anthropic | google | openai | ollama (default: anthropic)
+  --model <id>           Model ID (default: provider-specific)
+  --system <prompt>      System prompt (default: "You are a helpful assistant.")
+  --memory <dir>         Memory directory (default: .agent-do/)
+  --read-only            No filesystem writes
+  --max-iterations <n>   Max loop iterations (default: 20)
+  --no-tools             Disable file tools
+  --verbose              Show tool calls and step details
+  --json                 Output as JSON
+  -h, --help             Show this help
+
+Eval options:
+  --output <format>      console | json | csv (default: console)
+  --compare <providers>  Compare across providers (comma-separated)
+  --concurrency <n>      Parallel case execution (default: 1)
+
+Environment:
+  ANTHROPIC_API_KEY      Required for Anthropic models
+  GOOGLE_GENERATIVE_AI_API_KEY   Required for Google models
+  OPENAI_API_KEY         Required for OpenAI models
+
+Examples:
+  npx agent-do "What is TypeScript?"
+  npx agent-do --provider google --model gemini-2.5-flash "Hello"
+  cat README.md | npx agent-do "Summarize this"
+  npx agent-do run my-agent.ts
+  npx agent-do eval evals/basic.ts
+  npx agent-do eval evals/ --compare anthropic,google --output json
+`);
+}
+
+main();

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -1,0 +1,159 @@
+/**
+ * CLI argument parser.
+ *
+ * Zero-dependency argument parsing. Supports flags, options with values,
+ * and positional arguments.
+ */
+
+export interface ParsedArgs {
+  command: 'prompt' | 'run' | 'eval';
+  prompt?: string;
+  file?: string;
+  provider: string;
+  model?: string;
+  systemPrompt: string;
+  memoryDir: string;
+  readOnly: boolean;
+  maxIterations: number;
+  noTools: boolean;
+  verbose: boolean;
+  json: boolean;
+  help: boolean;
+  // Eval-specific
+  output: 'console' | 'json' | 'csv';
+  compare?: string[];
+  concurrency: number;
+}
+
+/**
+ * Parse CLI arguments into a structured object.
+ *
+ * Handles subcommands (run, eval), flags, and options.
+ * Remaining positional args become the prompt.
+ */
+export function parseArgs(argv: string[]): ParsedArgs {
+  const args: ParsedArgs = {
+    command: 'prompt',
+    provider: 'anthropic',
+    systemPrompt: 'You are a helpful assistant.',
+    memoryDir: '.agent-do',
+    readOnly: false,
+    maxIterations: 20,
+    noTools: false,
+    verbose: false,
+    json: false,
+    help: false,
+    output: 'console',
+    concurrency: 1,
+  };
+
+  const positional: string[] = [];
+  let i = 0;
+
+  // Check for subcommand
+  if (argv.length > 0) {
+    const first = argv[0];
+    if (first === 'run') {
+      args.command = 'run';
+      i = 1;
+    } else if (first === 'eval') {
+      args.command = 'eval';
+      i = 1;
+    }
+  }
+
+  while (i < argv.length) {
+    const arg = argv[i]!;
+
+    if (arg === '-h' || arg === '--help') {
+      args.help = true;
+    } else if (arg === '--provider') {
+      args.provider = requireValue(argv, ++i, '--provider');
+    } else if (arg === '--model') {
+      args.model = requireValue(argv, ++i, '--model');
+    } else if (arg === '--system') {
+      args.systemPrompt = requireValue(argv, ++i, '--system');
+    } else if (arg === '--memory') {
+      args.memoryDir = requireValue(argv, ++i, '--memory');
+    } else if (arg === '--read-only') {
+      args.readOnly = true;
+    } else if (arg === '--max-iterations') {
+      const val = requireValue(argv, ++i, '--max-iterations');
+      args.maxIterations = parseInt(val, 10);
+      if (isNaN(args.maxIterations) || args.maxIterations < 1) {
+        throw new Error('--max-iterations must be a positive integer');
+      }
+    } else if (arg === '--no-tools') {
+      args.noTools = true;
+    } else if (arg === '--verbose') {
+      args.verbose = true;
+    } else if (arg === '--json') {
+      args.json = true;
+    } else if (arg === '--output') {
+      const val = requireValue(argv, ++i, '--output');
+      if (val !== 'console' && val !== 'json' && val !== 'csv') {
+        throw new Error('--output must be console, json, or csv');
+      }
+      args.output = val;
+    } else if (arg === '--compare') {
+      const val = requireValue(argv, ++i, '--compare');
+      args.compare = val.split(',').map(s => s.trim()).filter(Boolean);
+    } else if (arg === '--concurrency') {
+      const val = requireValue(argv, ++i, '--concurrency');
+      args.concurrency = parseInt(val, 10);
+      if (isNaN(args.concurrency) || args.concurrency < 1) {
+        throw new Error('--concurrency must be a positive integer');
+      }
+    } else if (arg.startsWith('-')) {
+      throw new Error(`Unknown option: ${arg}. Use --help for usage.`);
+    } else {
+      positional.push(arg);
+    }
+
+    i++;
+  }
+
+  // Assign positional args based on command
+  if (args.command === 'run') {
+    if (positional.length === 0) {
+      throw new Error('Usage: npx agent-do run <file>');
+    }
+    args.file = positional[0];
+    args.prompt = positional.slice(1).join(' ') || undefined;
+  } else if (args.command === 'eval') {
+    if (positional.length === 0 && !args.help) {
+      throw new Error('Usage: npx agent-do eval <file|dir>');
+    }
+    args.file = positional[0];
+  } else {
+    // prompt mode — all positional args become the prompt
+    if (positional.length > 0) {
+      args.prompt = positional.join(' ');
+    }
+  }
+
+  return args;
+}
+
+function requireValue(argv: string[], index: number, flag: string): string {
+  if (index >= argv.length || argv[index]!.startsWith('-')) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return argv[index]!;
+}
+
+/**
+ * Read stdin if it's being piped (non-TTY).
+ * Returns the piped content or undefined if stdin is a TTY.
+ */
+export async function readStdin(): Promise<string | undefined> {
+  if (process.stdin.isTTY) return undefined;
+
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk as Buffer);
+  }
+
+  const content = Buffer.concat(chunks).toString('utf-8').trim();
+  return content || undefined;
+}

--- a/src/cli/eval-cmd.ts
+++ b/src/cli/eval-cmd.ts
@@ -10,6 +10,7 @@
 
 import * as path from 'node:path';
 import * as fs from 'node:fs';
+import { pathToFileURL } from 'node:url';
 import type { ParsedArgs } from './args.js';
 import { resolveModel, resolveCompareProviders } from './resolve-model.js';
 import { runEvals } from '../eval/runner.js';
@@ -27,26 +28,30 @@ export async function runEvalMode(args: ParsedArgs): Promise<void> {
     throw new Error(`No eval suites found in "${args.file}"`);
   }
 
-  // Build run options
-  const options: RunEvalsOptions = {
-    output: args.output,
-    concurrency: args.concurrency,
-  };
-
-  // Multi-provider comparison
-  if (args.compare && args.compare.length > 0) {
-    options.providers = await resolveCompareProviders(args.compare, args.model);
-  } else {
-    // Single model — override if CLI specifies provider/model, or use suite's model
-    const needsModel = suites.some(s => !s.model);
-    if (args.model || needsModel) {
-      options.model = await resolveModel(args.provider, args.model);
-    }
-  }
+  // Determine if CLI explicitly specifies a provider/model override
+  const hasCliModelOverride = !!args.model || args.provider !== 'anthropic';
 
   let hasFailures = false;
 
   for (const suite of suites) {
+    // Build per-suite options to preserve each suite's own model
+    const options: RunEvalsOptions = {
+      output: args.output,
+      concurrency: args.concurrency,
+    };
+
+    // Multi-provider comparison
+    if (args.compare && args.compare.length > 0) {
+      options.providers = await resolveCompareProviders(args.compare, args.model);
+    } else if (hasCliModelOverride) {
+      // CLI explicitly overrides provider/model — applies to all suites
+      options.model = await resolveModel(args.provider, args.model);
+    } else if (!suite.model) {
+      // Suite has no model — resolve default
+      options.model = await resolveModel(args.provider, args.model);
+    }
+    // else: suite has its own model and CLI didn't override — use suite's model
+
     const result = await runEvals(suite, options);
     if (result.providers.some(p => p.failed > 0)) {
       hasFailures = true;
@@ -90,7 +95,8 @@ async function loadSuites(target: string): Promise<EvalSuiteConfig[]> {
 async function loadSuiteFile(filePath: string): Promise<EvalSuiteConfig> {
   let mod: Record<string, unknown>;
   try {
-    mod = await import(filePath);
+    // Use file URL for cross-platform compatibility (Windows paths)
+    mod = await import(pathToFileURL(filePath).href);
   } catch (err) {
     throw new Error(
       `Failed to import eval file "${filePath}": ${err instanceof Error ? err.message : String(err)}`,

--- a/src/cli/eval-cmd.ts
+++ b/src/cli/eval-cmd.ts
@@ -1,0 +1,110 @@
+/**
+ * Eval command — run eval cases from a file or directory.
+ *
+ * Usage:
+ *   npx agent-do eval evals/basic.ts
+ *   npx agent-do eval evals/
+ *   npx agent-do eval evals/basic.ts --compare anthropic,google
+ *   npx agent-do eval evals/basic.ts --output json
+ */
+
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import type { ParsedArgs } from './args.js';
+import { resolveModel, resolveCompareProviders } from './resolve-model.js';
+import { runEvals } from '../eval/runner.js';
+import type { EvalSuiteConfig, RunEvalsOptions } from '../eval/types.js';
+
+export async function runEvalMode(args: ParsedArgs): Promise<void> {
+  if (!args.file) {
+    throw new Error('Usage: npx agent-do eval <file|dir>');
+  }
+
+  const target = path.resolve(args.file);
+  const suites = await loadSuites(target);
+
+  if (suites.length === 0) {
+    throw new Error(`No eval suites found in "${args.file}"`);
+  }
+
+  // Build run options
+  const options: RunEvalsOptions = {
+    output: args.output,
+    concurrency: args.concurrency,
+  };
+
+  // Multi-provider comparison
+  if (args.compare && args.compare.length > 0) {
+    options.providers = await resolveCompareProviders(args.compare, args.model);
+  } else {
+    // Single model — override if CLI specifies provider/model, or use suite's model
+    const needsModel = suites.some(s => !s.model);
+    if (args.model || needsModel) {
+      options.model = await resolveModel(args.provider, args.model);
+    }
+  }
+
+  let hasFailures = false;
+
+  for (const suite of suites) {
+    const result = await runEvals(suite, options);
+    if (result.providers.some(p => p.failed > 0)) {
+      hasFailures = true;
+    }
+  }
+
+  if (hasFailures) {
+    process.exit(1);
+  }
+}
+
+async function loadSuites(target: string): Promise<EvalSuiteConfig[]> {
+  const stat = await fs.promises.stat(target).catch(() => null);
+
+  if (!stat) {
+    throw new Error(`File or directory not found: ${target}`);
+  }
+
+  if (stat.isFile()) {
+    return [await loadSuiteFile(target)];
+  }
+
+  if (stat.isDirectory()) {
+    const files = await fs.promises.readdir(target);
+    const evalFiles = files.filter(f => /\.(ts|js|mjs|mts)$/.test(f));
+
+    if (evalFiles.length === 0) {
+      throw new Error(`No .ts or .js files found in "${target}"`);
+    }
+
+    const suites: EvalSuiteConfig[] = [];
+    for (const file of evalFiles.sort()) {
+      suites.push(await loadSuiteFile(path.join(target, file)));
+    }
+    return suites;
+  }
+
+  throw new Error(`"${target}" is not a file or directory`);
+}
+
+async function loadSuiteFile(filePath: string): Promise<EvalSuiteConfig> {
+  let mod: Record<string, unknown>;
+  try {
+    mod = await import(filePath);
+  } catch (err) {
+    throw new Error(
+      `Failed to import eval file "${filePath}": ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  const suite = (mod.default ?? mod) as EvalSuiteConfig;
+
+  if (!suite.name || !Array.isArray(suite.cases)) {
+    throw new Error(
+      `Eval file "${filePath}" must export a config with 'name' and 'cases'. ` +
+      `Use defineEval() from 'agent-do/eval'.`,
+    );
+  }
+
+  return suite;
+}

--- a/src/cli/prompt.ts
+++ b/src/cli/prompt.ts
@@ -77,19 +77,28 @@ async function runOneShot(
   args: ParsedArgs,
 ): Promise<void> {
   if (args.json) {
-    // JSON mode — collect everything
+    // JSON mode — collect everything, detect errors
     const events: ProgressEvent[] = [];
     let finalText = '';
+    let hasError = false;
+    let errorMessage = '';
 
     for await (const event of agent.stream(task)) {
       events.push(event);
       if (event.type === 'done') finalText = event.content;
+      if (event.type === 'error') {
+        hasError = true;
+        errorMessage = event.content;
+      }
     }
 
     console.log(JSON.stringify({
       text: finalText,
+      error: hasError ? errorMessage : undefined,
       events: args.verbose ? events : undefined,
     }, null, 2));
+
+    if (hasError) process.exit(1);
     return;
   }
 
@@ -97,7 +106,9 @@ async function runOneShot(
   for await (const event of agent.stream(task)) {
     switch (event.type) {
       case 'thinking':
-        process.stdout.write(event.content);
+        if (args.verbose) {
+          process.stdout.write(event.content);
+        }
         break;
       case 'tool-call':
         if (args.verbose) {
@@ -110,7 +121,8 @@ async function runOneShot(
         }
         break;
       case 'text':
-        // Final text — already streamed via thinking
+        // Final text output for a step
+        process.stdout.write(event.content);
         break;
       case 'done':
         process.stdout.write('\n');
@@ -149,13 +161,15 @@ async function runInteractive(
     if (!trimmed) continue;
     if (trimmed === 'exit' || trimmed === 'quit') break;
 
-    history.push({ role: 'user', content: trimmed });
-
+    // Pass only prior turns as history — streamAgentLoop appends the current
+    // user message from the task parameter, so adding it here would duplicate it
     let response = '';
     for await (const event of agent.stream(trimmed, undefined, history)) {
       switch (event.type) {
         case 'thinking':
-          process.stdout.write(event.content);
+          if (args.verbose) {
+            process.stdout.write(event.content);
+          }
           break;
         case 'tool-call':
           if (args.verbose) {
@@ -167,6 +181,9 @@ async function runInteractive(
             console.log(`[result] ${truncate(String(event.toolResult), 200)}`);
           }
           break;
+        case 'text':
+          process.stdout.write(event.content);
+          break;
         case 'done':
           response = event.content;
           process.stdout.write('\n\n');
@@ -177,6 +194,8 @@ async function runInteractive(
       }
     }
 
+    // Add both turns to history AFTER the run completes
+    history.push({ role: 'user', content: trimmed });
     if (response) {
       history.push({ role: 'assistant', content: response });
     }

--- a/src/cli/prompt.ts
+++ b/src/cli/prompt.ts
@@ -1,0 +1,195 @@
+/**
+ * Prompt mode — one-shot task or interactive chat.
+ *
+ * Supports:
+ * - npx agent-do "prompt"           — one-shot
+ * - echo "ctx" | npx agent-do "p"   — piped context + prompt
+ * - cat file | npx agent-do         — piped as prompt
+ * - npx agent-do                    — interactive REPL
+ */
+
+import * as readline from 'node:readline';
+import type { ParsedArgs } from './args.js';
+import { readStdin } from './args.js';
+import { resolveModel } from './resolve-model.js';
+import { createAgent } from '../agent.js';
+import { createFileTools } from '../tools/file-tools.js';
+import { FilesystemMemoryStore } from '../stores/filesystem.js';
+import { InMemoryMemoryStore } from '../stores/in-memory.js';
+import type { ProgressEvent, ConversationMessage } from '../types.js';
+
+export async function runPromptMode(args: ParsedArgs): Promise<void> {
+  const model = await resolveModel(args.provider, args.model);
+
+  // Set up memory store
+  const store = args.noTools
+    ? new InMemoryMemoryStore()
+    : new FilesystemMemoryStore(args.memoryDir, { readOnly: args.readOnly });
+
+  const tools = args.noTools ? undefined : createFileTools(store, 'cli-agent');
+
+  const agent = createAgent({
+    id: 'cli-agent',
+    name: 'agent-do',
+    model,
+    systemPrompt: args.systemPrompt,
+    tools,
+    maxIterations: args.maxIterations,
+    permissions: { mode: 'accept-all' },
+    usage: { enabled: true },
+  });
+
+  // Read stdin if piped
+  const stdinContent = await readStdin();
+
+  // Build the task from prompt + stdin
+  const task = buildTask(args.prompt, stdinContent);
+
+  if (task) {
+    // One-shot mode
+    await runOneShot(agent, task, args);
+  } else {
+    // Interactive mode
+    await runInteractive(agent, args);
+  }
+}
+
+/**
+ * Merge piped stdin with command-line prompt.
+ *
+ * - Only prompt: use prompt as task
+ * - Only stdin: use stdin as task
+ * - Both: prompt becomes the instruction, stdin becomes context
+ * - Neither: null (interactive mode)
+ */
+function buildTask(prompt?: string, stdin?: string): string | null {
+  if (prompt && stdin) {
+    return `${prompt}\n\n---\n\n${stdin}`;
+  }
+  if (prompt) return prompt;
+  if (stdin) return stdin;
+  return null;
+}
+
+async function runOneShot(
+  agent: ReturnType<typeof createAgent>,
+  task: string,
+  args: ParsedArgs,
+): Promise<void> {
+  if (args.json) {
+    // JSON mode — collect everything
+    const events: ProgressEvent[] = [];
+    let finalText = '';
+
+    for await (const event of agent.stream(task)) {
+      events.push(event);
+      if (event.type === 'done') finalText = event.content;
+    }
+
+    console.log(JSON.stringify({
+      text: finalText,
+      events: args.verbose ? events : undefined,
+    }, null, 2));
+    return;
+  }
+
+  // Streaming mode
+  for await (const event of agent.stream(task)) {
+    switch (event.type) {
+      case 'thinking':
+        process.stdout.write(event.content);
+        break;
+      case 'tool-call':
+        if (args.verbose) {
+          console.log(`\n[tool] ${event.toolName}(${truncateArgs(event.toolArgs)})`);
+        }
+        break;
+      case 'tool-result':
+        if (args.verbose) {
+          console.log(`[result] ${truncate(String(event.toolResult), 200)}`);
+        }
+        break;
+      case 'text':
+        // Final text — already streamed via thinking
+        break;
+      case 'done':
+        process.stdout.write('\n');
+        break;
+      case 'error':
+        console.error(`\nError: ${event.content}`);
+        process.exit(1);
+        break;
+    }
+  }
+}
+
+async function runInteractive(
+  agent: ReturnType<typeof createAgent>,
+  args: ParsedArgs,
+): Promise<void> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  const history: ConversationMessage[] = [];
+
+  console.log('agent-do interactive mode. Type "exit" or Ctrl+C to quit.\n');
+
+  const askQuestion = (): Promise<string> => {
+    return new Promise((resolve) => {
+      rl.question('> ', (answer) => resolve(answer));
+    });
+  };
+
+  while (true) {
+    const input = await askQuestion();
+    const trimmed = input.trim();
+
+    if (!trimmed) continue;
+    if (trimmed === 'exit' || trimmed === 'quit') break;
+
+    history.push({ role: 'user', content: trimmed });
+
+    let response = '';
+    for await (const event of agent.stream(trimmed, undefined, history)) {
+      switch (event.type) {
+        case 'thinking':
+          process.stdout.write(event.content);
+          break;
+        case 'tool-call':
+          if (args.verbose) {
+            console.log(`\n[tool] ${event.toolName}(${truncateArgs(event.toolArgs)})`);
+          }
+          break;
+        case 'tool-result':
+          if (args.verbose) {
+            console.log(`[result] ${truncate(String(event.toolResult), 200)}`);
+          }
+          break;
+        case 'done':
+          response = event.content;
+          process.stdout.write('\n\n');
+          break;
+        case 'error':
+          console.error(`\nError: ${event.content}\n`);
+          break;
+      }
+    }
+
+    if (response) {
+      history.push({ role: 'assistant', content: response });
+    }
+  }
+
+  rl.close();
+}
+
+function truncate(s: string, max: number): string {
+  return s.length > max ? s.slice(0, max) + '...' : s;
+}
+
+function truncateArgs(args: unknown): string {
+  const s = JSON.stringify(args);
+  return truncate(s, 100);
+}

--- a/src/cli/prompt.ts
+++ b/src/cli/prompt.ts
@@ -102,7 +102,7 @@ async function runOneShot(
     return;
   }
 
-  // Streaming mode
+  // Streaming mode — quiet by default, only final answer printed
   for await (const event of agent.stream(task)) {
     switch (event.type) {
       case 'thinking':
@@ -121,14 +121,20 @@ async function runOneShot(
         }
         break;
       case 'text':
-        // Final text output for a step
-        process.stdout.write(event.content);
+        // Per-step text — only show in verbose mode to avoid intermediate outputs
+        if (args.verbose) {
+          console.log(event.content);
+        }
         break;
       case 'done':
+        // Final answer — always print
+        if (!args.verbose) {
+          process.stdout.write(event.content);
+        }
         process.stdout.write('\n');
         break;
       case 'error':
-        console.error(`\nError: ${event.content}`);
+        console.error(`Error: ${event.content}`);
         process.exit(1);
         break;
     }
@@ -182,14 +188,19 @@ async function runInteractive(
           }
           break;
         case 'text':
-          process.stdout.write(event.content);
+          if (args.verbose) {
+            console.log(event.content);
+          }
           break;
         case 'done':
           response = event.content;
+          if (!args.verbose) {
+            process.stdout.write(response);
+          }
           process.stdout.write('\n\n');
           break;
         case 'error':
-          console.error(`\nError: ${event.content}\n`);
+          console.error(`Error: ${event.content}\n`);
           break;
       }
     }

--- a/src/cli/resolve-model.ts
+++ b/src/cli/resolve-model.ts
@@ -1,0 +1,82 @@
+/**
+ * Resolve a LanguageModel from provider name and model ID.
+ *
+ * Dynamically imports the provider SDK. Users must have the
+ * provider package installed and the API key set in env.
+ */
+
+import type { LanguageModel } from 'ai';
+
+const DEFAULT_MODELS: Record<string, string> = {
+  anthropic: 'claude-sonnet-4-6',
+  google: 'gemini-2.5-flash',
+  openai: 'gpt-4.1-mini',
+  ollama: 'llama3.2',
+};
+
+/**
+ * Resolve a model from a provider name and optional model ID.
+ * Dynamically imports the provider SDK — it must be installed.
+ */
+export async function resolveModel(
+  provider: string,
+  modelId?: string,
+): Promise<LanguageModel> {
+  const id = modelId ?? DEFAULT_MODELS[provider];
+  if (!id) {
+    throw new Error(
+      `Unknown provider "${provider}" and no --model specified. ` +
+      `Known providers: ${Object.keys(DEFAULT_MODELS).join(', ')}`,
+    );
+  }
+
+  switch (provider) {
+    case 'anthropic': {
+      const { createAnthropic } = await tryImport('@ai-sdk/anthropic', provider);
+      return createAnthropic()( id) as LanguageModel;
+    }
+    case 'google': {
+      const { createGoogleGenerativeAI } = await tryImport('@ai-sdk/google', provider);
+      return createGoogleGenerativeAI()(id) as LanguageModel;
+    }
+    case 'openai': {
+      const { createOpenAI } = await tryImport('@ai-sdk/openai', provider);
+      return createOpenAI()(id) as LanguageModel;
+    }
+    case 'ollama': {
+      const { createOllama } = await tryImport('ollama-ai-provider', provider);
+      return createOllama()(id) as LanguageModel;
+    }
+    default:
+      throw new Error(
+        `Unknown provider "${provider}". ` +
+        `Available: ${Object.keys(DEFAULT_MODELS).join(', ')}`,
+      );
+  }
+}
+
+async function tryImport(pkg: string, provider: string): Promise<any> {
+  try {
+    return await import(pkg);
+  } catch {
+    throw new Error(
+      `Provider "${provider}" requires "${pkg}" to be installed.\n` +
+      `Run: npm install ${pkg}`,
+    );
+  }
+}
+
+/**
+ * Resolve models for comparison across multiple providers.
+ */
+export async function resolveCompareProviders(
+  providerNames: string[],
+  modelId?: string,
+): Promise<Array<{ name: string; model: LanguageModel }>> {
+  const results = [];
+  for (const name of providerNames) {
+    const model = await resolveModel(name, modelId);
+    results.push({ name, model });
+  }
+  return results;
+}

--- a/src/cli/resolve-model.ts
+++ b/src/cli/resolve-model.ts
@@ -33,7 +33,7 @@ export async function resolveModel(
   switch (provider) {
     case 'anthropic': {
       const { createAnthropic } = await tryImport('@ai-sdk/anthropic', provider);
-      return createAnthropic()( id) as LanguageModel;
+      return createAnthropic()(id) as LanguageModel;
     }
     case 'google': {
       const { createGoogleGenerativeAI } = await tryImport('@ai-sdk/google', provider);
@@ -44,8 +44,12 @@ export async function resolveModel(
       return createOpenAI()(id) as LanguageModel;
     }
     case 'ollama': {
-      const { createOllama } = await tryImport('ollama-ai-provider', provider);
-      return createOllama()(id) as LanguageModel;
+      // Use OpenAI-compatible endpoint for Ollama (consistent with examples)
+      const { createOpenAI } = await tryImport('@ai-sdk/openai', 'ollama (via @ai-sdk/openai)');
+      return createOpenAI({
+        baseURL: process.env.OLLAMA_BASE_URL ?? 'http://127.0.0.1:11434/v1',
+        apiKey: 'ollama',
+      })(id) as LanguageModel;
     }
     default:
       throw new Error(

--- a/src/cli/script.ts
+++ b/src/cli/script.ts
@@ -7,9 +7,14 @@
  * - An Agent instance (has .run() and .stream())
  * - An AgentConfig object (has .model and .id)
  * - A simple config object (has .systemPrompt, auto-resolves model)
+ *
+ * Note: .ts files require a TypeScript loader (tsx, ts-node).
+ * Run with: npx tsx node_modules/.bin/agent-do run script.ts
+ * Or use compiled .js files directly.
  */
 
 import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import type { ParsedArgs } from './args.js';
 import { readStdin } from './args.js';
 import { resolveModel } from './resolve-model.js';
@@ -26,7 +31,8 @@ export async function runScriptMode(args: ParsedArgs): Promise<void> {
   const filePath = path.resolve(args.file);
   let mod: Record<string, unknown>;
   try {
-    mod = await import(filePath);
+    // Use file URL for cross-platform compatibility (Windows paths)
+    mod = await import(pathToFileURL(filePath).href);
   } catch (err) {
     throw new Error(
       `Failed to import "${args.file}": ${err instanceof Error ? err.message : String(err)}`,
@@ -50,16 +56,22 @@ export async function runScriptMode(args: ParsedArgs): Promise<void> {
       (exported.provider as string) ?? args.provider,
       (exported.model as string) ?? args.model,
     );
-    const memDir = (exported.memory as string) ?? args.memoryDir;
-    const store = new FilesystemMemoryStore(memDir, { readOnly: args.readOnly });
     const agentId = (exported.id as string) ?? 'script-agent';
+
+    // Respect --no-tools flag
+    let tools = undefined;
+    if (!args.noTools) {
+      const memDir = (exported.memory as string) ?? args.memoryDir;
+      const store = new FilesystemMemoryStore(memDir, { readOnly: args.readOnly });
+      tools = createFileTools(store, agentId);
+    }
 
     agent = createAgent({
       id: agentId,
       name: (exported.name as string) ?? 'Script Agent',
       model,
       systemPrompt: (exported.systemPrompt as string) ?? args.systemPrompt,
-      tools: createFileTools(store, agentId),
+      tools,
       maxIterations: (exported.maxIterations as number) ?? args.maxIterations,
       permissions: { mode: 'accept-all' },
       usage: { enabled: true },
@@ -85,7 +97,9 @@ export async function runScriptMode(args: ParsedArgs): Promise<void> {
   for await (const event of agent.stream(task)) {
     switch (event.type) {
       case 'thinking':
-        process.stdout.write(event.content);
+        if (args.verbose) {
+          process.stdout.write(event.content);
+        }
         break;
       case 'tool-call':
         if (args.verbose) {
@@ -96,6 +110,9 @@ export async function runScriptMode(args: ParsedArgs): Promise<void> {
         if (args.verbose) {
           console.log(`[result] ${String(event.toolResult).slice(0, 200)}`);
         }
+        break;
+      case 'text':
+        process.stdout.write(event.content);
         break;
       case 'done':
         process.stdout.write('\n');

--- a/src/cli/script.ts
+++ b/src/cli/script.ts
@@ -93,7 +93,7 @@ export async function runScriptMode(args: ParsedArgs): Promise<void> {
     );
   }
 
-  // Run the agent
+  // Run the agent — quiet by default, only final answer printed
   for await (const event of agent.stream(task)) {
     switch (event.type) {
       case 'thinking':
@@ -112,13 +112,18 @@ export async function runScriptMode(args: ParsedArgs): Promise<void> {
         }
         break;
       case 'text':
-        process.stdout.write(event.content);
+        if (args.verbose) {
+          console.log(event.content);
+        }
         break;
       case 'done':
+        if (!args.verbose) {
+          process.stdout.write(event.content);
+        }
         process.stdout.write('\n');
         break;
       case 'error':
-        console.error(`\nError: ${event.content}`);
+        console.error(`Error: ${event.content}`);
         process.exit(1);
         break;
     }

--- a/src/cli/script.ts
+++ b/src/cli/script.ts
@@ -1,0 +1,116 @@
+/**
+ * Script mode — run a JS/TS file that exports an agent.
+ *
+ * Usage: npx agent-do run my-agent.ts [task]
+ *
+ * The file can export:
+ * - An Agent instance (has .run() and .stream())
+ * - An AgentConfig object (has .model and .id)
+ * - A simple config object (has .systemPrompt, auto-resolves model)
+ */
+
+import * as path from 'node:path';
+import type { ParsedArgs } from './args.js';
+import { readStdin } from './args.js';
+import { resolveModel } from './resolve-model.js';
+import { createAgent } from '../agent.js';
+import { createFileTools } from '../tools/file-tools.js';
+import { FilesystemMemoryStore } from '../stores/filesystem.js';
+import type { Agent } from '../types.js';
+
+export async function runScriptMode(args: ParsedArgs): Promise<void> {
+  if (!args.file) {
+    throw new Error('Usage: npx agent-do run <file>');
+  }
+
+  const filePath = path.resolve(args.file);
+  let mod: Record<string, unknown>;
+  try {
+    mod = await import(filePath);
+  } catch (err) {
+    throw new Error(
+      `Failed to import "${args.file}": ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  const exported = (mod.default ?? mod) as Record<string, unknown>;
+
+  // Determine if it's an Agent instance, AgentConfig, or simple config
+  let agent: Agent;
+
+  if (typeof exported.run === 'function' && typeof exported.stream === 'function') {
+    // It's an Agent instance
+    agent = exported as unknown as Agent;
+  } else if (exported.model && exported.id) {
+    // It's an AgentConfig — create agent from it
+    agent = createAgent(exported as any);
+  } else if (exported.systemPrompt || exported.name) {
+    // Simple config — resolve model from provider/args
+    const model = await resolveModel(
+      (exported.provider as string) ?? args.provider,
+      (exported.model as string) ?? args.model,
+    );
+    const memDir = (exported.memory as string) ?? args.memoryDir;
+    const store = new FilesystemMemoryStore(memDir, { readOnly: args.readOnly });
+    const agentId = (exported.id as string) ?? 'script-agent';
+
+    agent = createAgent({
+      id: agentId,
+      name: (exported.name as string) ?? 'Script Agent',
+      model,
+      systemPrompt: (exported.systemPrompt as string) ?? args.systemPrompt,
+      tools: createFileTools(store, agentId),
+      maxIterations: (exported.maxIterations as number) ?? args.maxIterations,
+      permissions: { mode: 'accept-all' },
+      usage: { enabled: true },
+    });
+  } else {
+    throw new Error(
+      'Script must export an Agent instance, an AgentConfig (with model + id), ' +
+      'or a simple config (with systemPrompt or name).',
+    );
+  }
+
+  // Get the task
+  const stdinContent = await readStdin();
+  const task = buildTask(args.prompt, stdinContent);
+
+  if (!task) {
+    throw new Error(
+      'No task provided. Pass a prompt after the file: npx agent-do run script.ts "your task"',
+    );
+  }
+
+  // Run the agent
+  for await (const event of agent.stream(task)) {
+    switch (event.type) {
+      case 'thinking':
+        process.stdout.write(event.content);
+        break;
+      case 'tool-call':
+        if (args.verbose) {
+          console.log(`\n[tool] ${event.toolName}(${JSON.stringify(event.toolArgs).slice(0, 100)})`);
+        }
+        break;
+      case 'tool-result':
+        if (args.verbose) {
+          console.log(`[result] ${String(event.toolResult).slice(0, 200)}`);
+        }
+        break;
+      case 'done':
+        process.stdout.write('\n');
+        break;
+      case 'error':
+        console.error(`\nError: ${event.content}`);
+        process.exit(1);
+        break;
+    }
+  }
+}
+
+function buildTask(prompt?: string, stdin?: string): string | null {
+  if (prompt && stdin) return `${prompt}\n\n---\n\n${stdin}`;
+  if (prompt) return prompt;
+  if (stdin) return stdin;
+  return null;
+}

--- a/tests/cli-args.test.ts
+++ b/tests/cli-args.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from 'vitest';
+import { parseArgs } from '../src/cli/args.js';
+
+describe('parseArgs', () => {
+  it('defaults to prompt command with no args', () => {
+    const args = parseArgs([]);
+    expect(args.command).toBe('prompt');
+    expect(args.prompt).toBeUndefined();
+    expect(args.provider).toBe('anthropic');
+    expect(args.maxIterations).toBe(20);
+  });
+
+  it('parses a simple prompt', () => {
+    const args = parseArgs(['Hello', 'world']);
+    expect(args.command).toBe('prompt');
+    expect(args.prompt).toBe('Hello world');
+  });
+
+  it('parses quoted prompt', () => {
+    const args = parseArgs(['What is TypeScript?']);
+    expect(args.prompt).toBe('What is TypeScript?');
+  });
+
+  it('recognizes run subcommand', () => {
+    const args = parseArgs(['run', 'my-agent.ts']);
+    expect(args.command).toBe('run');
+    expect(args.file).toBe('my-agent.ts');
+  });
+
+  it('recognizes run subcommand with task', () => {
+    const args = parseArgs(['run', 'script.ts', 'do', 'something']);
+    expect(args.command).toBe('run');
+    expect(args.file).toBe('script.ts');
+    expect(args.prompt).toBe('do something');
+  });
+
+  it('recognizes eval subcommand', () => {
+    const args = parseArgs(['eval', 'evals/basic.ts']);
+    expect(args.command).toBe('eval');
+    expect(args.file).toBe('evals/basic.ts');
+  });
+
+  it('parses --provider', () => {
+    const args = parseArgs(['--provider', 'google', 'hello']);
+    expect(args.provider).toBe('google');
+    expect(args.prompt).toBe('hello');
+  });
+
+  it('parses --model', () => {
+    const args = parseArgs(['--model', 'gpt-4o', 'hello']);
+    expect(args.model).toBe('gpt-4o');
+  });
+
+  it('parses --system', () => {
+    const args = parseArgs(['--system', 'Be brief.', 'hello']);
+    expect(args.systemPrompt).toBe('Be brief.');
+  });
+
+  it('parses --memory', () => {
+    const args = parseArgs(['--memory', '/tmp/data', 'hello']);
+    expect(args.memoryDir).toBe('/tmp/data');
+  });
+
+  it('parses --read-only', () => {
+    const args = parseArgs(['--read-only', 'hello']);
+    expect(args.readOnly).toBe(true);
+  });
+
+  it('parses --max-iterations', () => {
+    const args = parseArgs(['--max-iterations', '5', 'hello']);
+    expect(args.maxIterations).toBe(5);
+  });
+
+  it('parses --no-tools', () => {
+    const args = parseArgs(['--no-tools', 'hello']);
+    expect(args.noTools).toBe(true);
+  });
+
+  it('parses --verbose', () => {
+    const args = parseArgs(['--verbose', 'hello']);
+    expect(args.verbose).toBe(true);
+  });
+
+  it('parses --json', () => {
+    const args = parseArgs(['--json', 'hello']);
+    expect(args.json).toBe(true);
+  });
+
+  it('parses --help', () => {
+    const args = parseArgs(['--help']);
+    expect(args.help).toBe(true);
+  });
+
+  it('parses -h as help', () => {
+    const args = parseArgs(['-h']);
+    expect(args.help).toBe(true);
+  });
+
+  // Eval-specific
+  it('parses --output for eval', () => {
+    const args = parseArgs(['eval', 'file.ts', '--output', 'json']);
+    expect(args.output).toBe('json');
+  });
+
+  it('parses --output csv', () => {
+    const args = parseArgs(['eval', 'file.ts', '--output', 'csv']);
+    expect(args.output).toBe('csv');
+  });
+
+  it('parses --compare', () => {
+    const args = parseArgs(['eval', 'file.ts', '--compare', 'anthropic,google,openai']);
+    expect(args.compare).toEqual(['anthropic', 'google', 'openai']);
+  });
+
+  it('parses --concurrency', () => {
+    const args = parseArgs(['eval', 'file.ts', '--concurrency', '4']);
+    expect(args.concurrency).toBe(4);
+  });
+
+  // Error cases
+  it('throws on unknown option', () => {
+    expect(() => parseArgs(['--unknown'])).toThrow('Unknown option');
+  });
+
+  it('throws when --provider has no value', () => {
+    expect(() => parseArgs(['--provider'])).toThrow('requires a value');
+  });
+
+  it('throws when --max-iterations is not a number', () => {
+    expect(() => parseArgs(['--max-iterations', 'abc'])).toThrow('positive integer');
+  });
+
+  it('throws when --max-iterations is zero', () => {
+    expect(() => parseArgs(['--max-iterations', '0'])).toThrow('positive integer');
+  });
+
+  it('throws when --output is invalid', () => {
+    expect(() => parseArgs(['eval', 'f.ts', '--output', 'xml'])).toThrow('must be console, json, or csv');
+  });
+
+  it('throws when run has no file', () => {
+    expect(() => parseArgs(['run'])).toThrow('Usage');
+  });
+
+  it('throws when eval has no file (and no --help)', () => {
+    expect(() => parseArgs(['eval'])).toThrow('Usage');
+  });
+
+  it('eval with --help does not throw', () => {
+    const args = parseArgs(['eval', '--help']);
+    expect(args.help).toBe(true);
+  });
+
+  // Combined options
+  it('handles multiple flags together', () => {
+    const args = parseArgs([
+      '--provider', 'openai',
+      '--model', 'gpt-4o',
+      '--verbose',
+      '--read-only',
+      '--max-iterations', '10',
+      'Summarize this',
+    ]);
+    expect(args.provider).toBe('openai');
+    expect(args.model).toBe('gpt-4o');
+    expect(args.verbose).toBe(true);
+    expect(args.readOnly).toBe(true);
+    expect(args.maxIterations).toBe(10);
+    expect(args.prompt).toBe('Summarize this');
+  });
+
+  it('flags before and after prompt', () => {
+    const args = parseArgs(['--verbose', 'hello', 'world']);
+    expect(args.verbose).toBe(true);
+    expect(args.prompt).toBe('hello world');
+  });
+});


### PR DESCRIPTION
## Summary

Implements #9 and #10 — the `npx agent-do` CLI, built on top of the eval framework (#12).

- **Prompt mode** — `npx agent-do "task"` for one-shot, `npx agent-do` for interactive REPL with conversation history
- **Run mode** — `npx agent-do run script.ts` loads a file that exports an Agent instance, AgentConfig, or simple config object
- **Eval mode** — `npx agent-do eval evals/basic.ts` runs eval suites with `--compare` for multi-provider and `--output json|csv`
- **Stdin piping** — `cat file.txt | npx agent-do "Summarize"` merges piped content with the CLI prompt as context

### Key features
- Dynamic provider resolution: `--provider anthropic|google|openai|ollama` with `--model` override
- Provider SDKs imported on demand — no hard dependency on any provider
- `--verbose` shows tool calls, `--json` outputs structured JSON, `--read-only` blocks writes
- Interactive mode maintains conversation history across turns
- Eval mode supports `--compare anthropic,google` and `--concurrency 4`
- `bin.agent-do` in package.json for `npx` support

### Files
- `src/cli.ts` — entry point with help text
- `src/cli/args.ts` — zero-dependency argument parser + stdin reader
- `src/cli/prompt.ts` — one-shot and interactive REPL
- `src/cli/script.ts` — script runner (Agent/AgentConfig/simple config detection)
- `src/cli/eval-cmd.ts` — eval file/directory loader + runner
- `src/cli/resolve-model.ts` — dynamic provider import + model resolution
- `tests/cli-args.test.ts` — 31 tests for argument parsing

## Test plan

- [x] 31 new CLI arg parser tests, 263 total passing
- [x] TypeScript strict mode — clean typecheck
- [x] All existing tests still pass
- [ ] Manual: `npx agent-do "Hello"` with ANTHROPIC_API_KEY
- [ ] Manual: `echo "context" | npx agent-do "Summarize"`
- [ ] Manual: `npx agent-do eval examples/13-eval-framework.ts`

Closes #9, closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)