### PR TITLE
[L-03] Fail fast when API key is missing

### DIFF
--- a/src/cli/resolve-model.ts
+++ b/src/cli/resolve-model.ts
@@ -7,36 +7,42 @@
 
 import type { LanguageModel } from 'ai';
 
-const DEFAULT_MODELS: Record<string, string> = {
-  anthropic: 'claude-sonnet-4-6',
-  google: 'gemini-2.5-flash',
-  openai: 'gpt-4.1-mini',
-  ollama: 'llama3.2',
-};
+// Use `Map`s for provider tables so lookups don't touch the prototype chain.
+// Indexing a plain object with a user-supplied provider name returns inherited
+// values for keys like `constructor`, `toString`, or `__proto__`, which leaks
+// into assertApiKey / resolveModel and produces misleading errors.
+
+const DEFAULT_MODELS = new Map<string, string>([
+  ['anthropic', 'claude-sonnet-4-6'],
+  ['google', 'gemini-2.5-flash'],
+  ['openai', 'gpt-4.1-mini'],
+  ['ollama', 'llama3.2'],
+]);
 
 /**
  * Env var each provider expects. `null` means the provider does not require a key.
+ * Absent keys mean the provider is unknown — resolveModel will throw later.
  */
-const REQUIRED_ENV: Record<string, string | null> = {
-  anthropic: 'ANTHROPIC_API_KEY',
-  google: 'GOOGLE_GENERATIVE_AI_API_KEY',
-  openai: 'OPENAI_API_KEY',
-  ollama: null,
-};
+const REQUIRED_ENV = new Map<string, string | null>([
+  ['anthropic', 'ANTHROPIC_API_KEY'],
+  ['google', 'GOOGLE_GENERATIVE_AI_API_KEY'],
+  ['openai', 'OPENAI_API_KEY'],
+  ['ollama', null],
+]);
 
-const PROVIDER_HINTS: Record<string, string> = {
-  anthropic: 'https://console.anthropic.com/',
-  google: 'https://aistudio.google.com/',
-  openai: 'https://platform.openai.com/api-keys',
-};
+const PROVIDER_HINTS = new Map<string, string>([
+  ['anthropic', 'https://console.anthropic.com/'],
+  ['google', 'https://aistudio.google.com/'],
+  ['openai', 'https://platform.openai.com/api-keys'],
+]);
 
 function assertApiKey(provider: string): void {
-  const envVar = REQUIRED_ENV[provider];
-  if (envVar === null) return; // e.g. ollama
+  const envVar = REQUIRED_ENV.get(provider);
   if (envVar === undefined) return; // unknown provider — resolveModel throws later
+  if (envVar === null) return; // e.g. ollama, no key required
   const value = process.env[envVar];
   if (!value || value.length < 4) {
-    const hint = PROVIDER_HINTS[provider];
+    const hint = PROVIDER_HINTS.get(provider);
     throw new Error(
       `Missing API key for provider "${provider}". Set ${envVar} in your environment.` +
       (hint ? `\nGet a key at ${hint}.` : ''),
@@ -52,11 +58,11 @@ export async function resolveModel(
   provider: string,
   modelId?: string,
 ): Promise<LanguageModel> {
-  const id = modelId ?? DEFAULT_MODELS[provider];
+  const id = modelId ?? DEFAULT_MODELS.get(provider);
   if (!id) {
     throw new Error(
       `Unknown provider "${provider}" and no --model specified. ` +
-      `Known providers: ${Object.keys(DEFAULT_MODELS).join(', ')}`,
+      `Known providers: ${[...DEFAULT_MODELS.keys()].join(', ')}`,
     );
   }
 
@@ -86,7 +92,7 @@ export async function resolveModel(
     default:
       throw new Error(
         `Unknown provider "${provider}".\n` +
-        `The CLI supports: ${Object.keys(DEFAULT_MODELS).join(', ')}.\n` +
+        `The CLI supports: ${[...DEFAULT_MODELS.keys()].join(', ')}.\n` +
         `\n` +
         `For other providers (Mistral, Groq, Cohere, OpenRouter, Bedrock, etc.),\n` +
         `use agent-do as a library and pass any Vercel AI SDK LanguageModel:\n` +

--- a/src/cli/resolve-model.ts
+++ b/src/cli/resolve-model.ts
@@ -15,6 +15,36 @@ const DEFAULT_MODELS: Record<string, string> = {
 };
 
 /**
+ * Env var each provider expects. `null` means the provider does not require a key.
+ */
+const REQUIRED_ENV: Record<string, string | null> = {
+  anthropic: 'ANTHROPIC_API_KEY',
+  google: 'GOOGLE_GENERATIVE_AI_API_KEY',
+  openai: 'OPENAI_API_KEY',
+  ollama: null,
+};
+
+const PROVIDER_HINTS: Record<string, string> = {
+  anthropic: 'https://console.anthropic.com/',
+  google: 'https://aistudio.google.com/',
+  openai: 'https://platform.openai.com/api-keys',
+};
+
+function assertApiKey(provider: string): void {
+  const envVar = REQUIRED_ENV[provider];
+  if (envVar === null) return; // e.g. ollama
+  if (envVar === undefined) return; // unknown provider — resolveModel throws later
+  const value = process.env[envVar];
+  if (!value || value.length < 4) {
+    const hint = PROVIDER_HINTS[provider];
+    throw new Error(
+      `Missing API key for provider "${provider}". Set ${envVar} in your environment.` +
+      (hint ? `\nGet a key at ${hint}.` : ''),
+    );
+  }
+}
+
+/**
  * Resolve a model from a provider name and optional model ID.
  * Dynamically imports the provider SDK — it must be installed.
  */
@@ -29,6 +59,8 @@ export async function resolveModel(
       `Known providers: ${Object.keys(DEFAULT_MODELS).join(', ')}`,
     );
   }
+
+  assertApiKey(provider);
 
   switch (provider) {
     case 'anthropic': {

--- a/tests/resolve-model.test.ts
+++ b/tests/resolve-model.test.ts
@@ -52,4 +52,17 @@ describe('resolveModel — API key preflight', () => {
     const model = await resolveModel('anthropic');
     expect(model).toBeDefined();
   });
+
+  it('returns the "Unknown provider" error (not a bogus API-key error) for prototype keys', async () => {
+    // Regression guard: plain-object lookups leaked Object.prototype members
+    // like `constructor`, `toString`, `__proto__` — producing a misleading
+    // "Missing API key" error for `--provider constructor`.
+    for (const bogus of ['constructor', 'toString', '__proto__', 'hasOwnProperty']) {
+      await expect(resolveModel(bogus)).rejects.toThrow(/Unknown provider/);
+    }
+  });
+
+  it('treats an unknown provider as unknown without touching env', async () => {
+    await expect(resolveModel('unknown-xyz')).rejects.toThrow(/Unknown provider "unknown-xyz"/);
+  });
 });

--- a/tests/resolve-model.test.ts
+++ b/tests/resolve-model.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { resolveModel } from '../src/cli/resolve-model.js';
+
+const ENV_VARS = [
+  'ANTHROPIC_API_KEY',
+  'GOOGLE_GENERATIVE_AI_API_KEY',
+  'OPENAI_API_KEY',
+] as const;
+
+describe('resolveModel — API key preflight', () => {
+  const saved: Partial<Record<(typeof ENV_VARS)[number], string | undefined>> = {};
+
+  beforeEach(() => {
+    for (const v of ENV_VARS) {
+      saved[v] = process.env[v];
+      delete process.env[v];
+    }
+  });
+
+  afterEach(() => {
+    for (const v of ENV_VARS) {
+      if (saved[v] === undefined) delete process.env[v];
+      else process.env[v] = saved[v];
+    }
+  });
+
+  it('throws a helpful error naming the env var when ANTHROPIC_API_KEY is missing', async () => {
+    await expect(resolveModel('anthropic')).rejects.toThrow(/ANTHROPIC_API_KEY/);
+    await expect(resolveModel('anthropic')).rejects.toThrow(/Missing API key/);
+  });
+
+  it('throws when GOOGLE_GENERATIVE_AI_API_KEY is missing', async () => {
+    await expect(resolveModel('google')).rejects.toThrow(/GOOGLE_GENERATIVE_AI_API_KEY/);
+  });
+
+  it('throws when OPENAI_API_KEY is missing', async () => {
+    await expect(resolveModel('openai')).rejects.toThrow(/OPENAI_API_KEY/);
+  });
+
+  it('does not require an API key for ollama', async () => {
+    const model = await resolveModel('ollama');
+    expect(model).toBeDefined();
+  });
+
+  it('rejects obviously empty keys (< 4 chars) the same as missing', async () => {
+    process.env.ANTHROPIC_API_KEY = 'x';
+    await expect(resolveModel('anthropic')).rejects.toThrow(/ANTHROPIC_API_KEY/);
+  });
+
+  it('proceeds when a plausible key is present', async () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-stub-key';
+    const model = await resolveModel('anthropic');
+    expect(model).toBeDefined();
+  });
+});


### PR DESCRIPTION
Fixes #35.

## Summary

- Adds a `REQUIRED_ENV` table mapping each provider to its expected env var.
- `resolveModel` calls `assertApiKey(provider)` before constructing the client.
- Clean error message names the env var and links to where to get a key.

## Test plan

- [x] `tests/resolve-model.test.ts` — 6 cases covering missing keys per provider, the too-short key case, ollama bypass, and the happy path.
- [x] Full suite: 298 tests passing.
- [ ] Manual: `unset ANTHROPIC_API_KEY && npx agent-do "hi"` surfaces the new error immediately.