### PR TITLE
[L-05] Replace hand-rolled YAML parser with yaml package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "agent-do",
-  "version": "0.1.1",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-do",
-      "version": "0.1.1",
+      "version": "0.1.4",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.0",
         "@ai-sdk/google": "^3.0.0",
         "@ai-sdk/openai": "^3.0.0",
         "ai": "^6.0.0",
+        "yaml": "^2.8.3",
         "zod": "^3.23.0"
       },
       "bin": {
@@ -2037,7 +2038,6 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@ai-sdk/google": "^3.0.0",
     "@ai-sdk/openai": "^3.0.0",
     "ai": "^6.0.0",
+    "yaml": "^2.8.3",
     "zod": "^3.23.0"
   },
   "peerDependencies": {
@@ -56,9 +57,15 @@
     "@ai-sdk/openai": "^3.0.0"
   },
   "peerDependenciesMeta": {
-    "@ai-sdk/anthropic": { "optional": true },
-    "@ai-sdk/google": { "optional": true },
-    "@ai-sdk/openai": { "optional": true }
+    "@ai-sdk/anthropic": {
+      "optional": true
+    },
+    "@ai-sdk/google": {
+      "optional": true
+    },
+    "@ai-sdk/openai": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@types/node": "^25.6.0",

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -5,19 +5,56 @@ import YAML from 'yaml';
 import type { Skill, SkillStore } from './types.js';
 
 /**
- * Schema for the frontmatter block of a SKILL.md file.
+ * Per-field schemas for the frontmatter block of a SKILL.md file.
  *
- * Unknown keys are allowed (forward-compatible with community skills), but
- * required fields are typed and length-limited. See issue #37 for the
- * rationale — the previous hand-rolled parser silently truncated values at
- * colons and dropped multiline fields.
+ * Validating field-by-field (rather than the whole object at once) means a
+ * single bad value — e.g. `version: 2` landing as a YAML number — only
+ * drops that one field, leaving the rest of the metadata intact. Each
+ * schema uses `z.coerce.string()` so numeric/boolean YAML values are
+ * stringified rather than rejected. Length caps are upper bounds; oversize
+ * values are dropped. Unknown keys are preserved by callers that want them
+ * but ignored for the typed `Skill` fields.
+ *
+ * See issue #37 — the previous hand-rolled parser silently truncated
+ * values at colons and dropped multiline fields.
  */
-const SkillFrontmatterSchema = z.object({
-  name: z.string().max(128).optional(),
-  description: z.string().max(512).optional(),
-  author: z.string().max(128).optional(),
-  version: z.string().max(32).optional(),
-}).passthrough();
+const SKILL_FIELD_SCHEMAS = {
+  name: z.coerce.string().min(1).max(128),
+  description: z.coerce.string().max(512),
+  author: z.coerce.string().max(128),
+  version: z.coerce.string().max(32),
+} as const;
+
+type SkillMeta = Partial<Record<keyof typeof SKILL_FIELD_SCHEMAS, string>>;
+
+/**
+ * Pull the known frontmatter fields out of a parsed YAML object.
+ *
+ * - Lowercases keys so `Name:` / `DESCRIPTION:` still parse (matching the
+ *   pre-v0.1.4 behaviour).
+ * - Validates each field independently, so one bad field doesn't lose the
+ *   others.
+ * - Skips prototype-pollution keys defensively.
+ */
+function extractSkillMeta(raw: unknown): SkillMeta {
+  if (typeof raw !== 'object' || raw === null) return {};
+
+  const lowered: Record<string, unknown> = Object.create(null);
+  for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
+    if (k === '__proto__' || k === 'constructor' || k === 'prototype') continue;
+    lowered[k.toLowerCase()] = v;
+  }
+
+  const out: SkillMeta = {};
+  for (const field of Object.keys(SKILL_FIELD_SCHEMAS) as Array<keyof typeof SKILL_FIELD_SCHEMAS>) {
+    const value = lowered[field];
+    if (value === undefined || value === null) continue;
+    const parsed = SKILL_FIELD_SCHEMAS[field].safeParse(value);
+    if (parsed.success) out[field] = parsed.data;
+    // else: skip this field only, keep the others
+  }
+  return out;
+}
 
 /**
  * Build a system prompt section from a list of skills.
@@ -71,17 +108,16 @@ export function parseSkillMd(content: string, id?: string): Skill {
   const frontmatter = match[1];
   const body = match[2];
 
-  // Proper YAML parsing. On parse error (malformed frontmatter) or schema
-  // failure, fall back to an empty metadata object so the body is still
-  // returned rather than the whole skill being dropped.
+  // Proper YAML parsing. On parse error (malformed frontmatter) fall back
+  // to an empty object so the body is still returned rather than the whole
+  // skill being dropped. Per-field validation happens in extractSkillMeta.
   let rawMeta: unknown = {};
   try {
     rawMeta = YAML.parse(frontmatter) ?? {};
   } catch {
     rawMeta = {};
   }
-  const parsed = SkillFrontmatterSchema.safeParse(rawMeta);
-  const meta = parsed.success ? parsed.data : {};
+  const meta = extractSkillMeta(rawMeta);
 
   const skillId =
     id ||

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -1,7 +1,23 @@
 import { tool } from 'ai';
 import type { ToolSet } from 'ai';
 import { z } from 'zod';
+import YAML from 'yaml';
 import type { Skill, SkillStore } from './types.js';
+
+/**
+ * Schema for the frontmatter block of a SKILL.md file.
+ *
+ * Unknown keys are allowed (forward-compatible with community skills), but
+ * required fields are typed and length-limited. See issue #37 for the
+ * rationale — the previous hand-rolled parser silently truncated values at
+ * colons and dropped multiline fields.
+ */
+const SkillFrontmatterSchema = z.object({
+  name: z.string().max(128).optional(),
+  description: z.string().max(512).optional(),
+  author: z.string().max(128).optional(),
+  version: z.string().max(32).optional(),
+}).passthrough();
 
 /**
  * Build a system prompt section from a list of skills.
@@ -55,14 +71,17 @@ export function parseSkillMd(content: string, id?: string): Skill {
   const frontmatter = match[1];
   const body = match[2];
 
-  const meta: Record<string, string> = {};
-  for (const line of frontmatter.split('\n')) {
-    const kv = line.match(/^(\w[\w-]*):\s*(.+)$/);
-    if (!kv) continue;
-    const key = kv[1].toLowerCase();
-    const value = kv[2].replace(/^["']|["']$/g, '').trim();
-    meta[key] = value;
+  // Proper YAML parsing. On parse error (malformed frontmatter) or schema
+  // failure, fall back to an empty metadata object so the body is still
+  // returned rather than the whole skill being dropped.
+  let rawMeta: unknown = {};
+  try {
+    rawMeta = YAML.parse(frontmatter) ?? {};
+  } catch {
+    rawMeta = {};
   }
+  const parsed = SkillFrontmatterSchema.safeParse(rawMeta);
+  const meta = parsed.success ? parsed.data : {};
 
   const skillId =
     id ||

--- a/tests/skills.test.ts
+++ b/tests/skills.test.ts
@@ -85,6 +85,71 @@ body goes here`;
     expect(skill.id).toBe('broken');
     expect(skill.content).toBe('body goes here');
   });
+
+  it('keeps valid fields when a single field has the wrong type', () => {
+    // YAML parses bare `2` as a number; the old implementation dropped the
+    // entire metadata object when that happened. Per-field validation keeps
+    // the other fields.
+    const content = `---
+name: Numbery
+description: Has a bad version
+version: 2
+---
+
+body`;
+    const skill = parseSkillMd(content, 'numbery');
+    expect(skill.name).toBe('Numbery');
+    expect(skill.description).toBe('Has a bad version');
+    // 2 coerces to "2" via z.coerce.string — acceptable. The important
+    // thing is we didn't lose name / description.
+    expect(skill.version).toBe('2');
+  });
+
+  it('drops only the oversize field, not sibling fields', () => {
+    const big = 'x'.repeat(1000);
+    const content = `---
+name: Valid
+description: ${big}
+---
+
+body`;
+    const skill = parseSkillMd(content, 'valid');
+    expect(skill.name).toBe('Valid');
+    // description exceeds 512 cap → dropped, not allowed to nuke `name`.
+    expect(skill.description).toBe('');
+  });
+
+  it('is case-insensitive for frontmatter keys (Name:, DESCRIPTION:)', () => {
+    // The pre-v0.1.4 parser lowercased keys. Restore that so SKILL.md
+    // files written with capitalised keys still parse.
+    const content = `---
+Name: Capitalised
+DESCRIPTION: Yelling header
+Author: Them
+---
+
+body`;
+    const skill = parseSkillMd(content, 'cap');
+    expect(skill.name).toBe('Capitalised');
+    expect(skill.description).toBe('Yelling header');
+    expect(skill.author).toBe('Them');
+  });
+
+  it('ignores prototype-pollution keys in frontmatter', () => {
+    // Not possible to embed `__proto__` via standard YAML keys without
+    // quoting, but belt-and-braces: if it does get through, skip it.
+    const content = `---
+name: Safe
+"__proto__":
+  polluted: true
+---
+
+body`;
+    const skill = parseSkillMd(content, 'safe');
+    expect(skill.name).toBe('Safe');
+    // No prototype side effects:
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
 });
 
 describe('buildSkillsPrompt', () => {

--- a/tests/skills.test.ts
+++ b/tests/skills.test.ts
@@ -48,6 +48,43 @@ Content here.`;
     expect(skill.id).toBe('my-cool-skill');
     expect(skill.name).toBe('My Cool Skill');
   });
+
+  it('preserves quoted values that contain colons', () => {
+    const content = `---
+name: "Helpful: gets things done"
+description: "Role: assistant; style: terse"
+---
+
+body`;
+    const skill = parseSkillMd(content, 'helpful');
+    expect(skill.name).toBe('Helpful: gets things done');
+    expect(skill.description).toBe('Role: assistant; style: terse');
+  });
+
+  it('preserves multiline description via YAML folded/literal blocks', () => {
+    const content = `---
+name: Multi
+description: |
+  line one
+  line two
+---
+
+body`;
+    const skill = parseSkillMd(content, 'multi');
+    expect(skill.description).toContain('line one');
+    expect(skill.description).toContain('line two');
+  });
+
+  it('falls back to empty meta on malformed YAML without dropping the body', () => {
+    const content = `---
+name: "unterminated
+---
+
+body goes here`;
+    const skill = parseSkillMd(content, 'broken');
+    expect(skill.id).toBe('broken');
+    expect(skill.content).toBe('body goes here');
+  });
 });
 
 describe('buildSkillsPrompt', () => {


### PR DESCRIPTION
Fixes #37. Also improves the defence-in-depth story for #24 (install_skill).

## Summary

- Adds `yaml` as a dependency (maintained, ~40 KB gzipped).
- `parseSkillMd` now parses frontmatter with `YAML.parse`, then validates via Zod.
- Malformed frontmatter falls back to empty metadata — skill body is still preserved.
- New `SkillFrontmatterSchema` caps field lengths and allows forward-compatible extra keys.

## Test plan

- [x] New cases in `tests/skills.test.ts`: quoted colon values, multiline `description: |`, malformed YAML fallback.
- [x] Full suite: 295 tests passing.
- [ ] Sanity-check a few real-world skill files if you have any committed.