### PR TITLE
Bump to 0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-do",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-do",
-      "version": "0.1.4",
+      "version": "0.2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.0",
         "@ai-sdk/google": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-do",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "type": "module",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",


### PR DESCRIPTION
Soft breaking change: `event.toolResult` on `tool-result` ProgressEvents now requires `AgentConfig.emitFullResult: true` (or CLI `--show-content`).

## Highlights since 0.1.4

- Structured `ToolResult` layer (modelContent / userSummary / data) — closes #48, #18, #29, #36
- Sensitive-file deny list (`.env`, `.ssh/**`, `.git/hooks/**`, etc.) with `.agent-doignore` + `--exclude` + `--include-sensitive` — closes #23
- CLI verbose rendering moved to stderr; `--show-content` opt-in for full output
- Portable UTF-8 byte helpers (`TextEncoder`/`TextDecoder`) — runs in browsers / Workers / Deno
- Allowlisted errno → model-string mapping (no absolute-path leaks)
- SECURITY.md with private vulnerability reporting (#54)

## Test plan
- [x] 392 tests passing
- [x] Build clean
- [ ] Publish from a clean checkout once merged