### PR TITLE
[L-06] Warn once for unknown models in estimateCost

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,12 @@ export type { ToolResult } from './tools/types.js';
 export { normaliseToolResult, isToolResult } from './tools/types.js';
 
 // Usage
-export { UsageTracker, estimateCost, DEFAULT_PRICING } from './usage.js';
+export {
+  UsageTracker,
+  estimateCost,
+  DEFAULT_PRICING,
+  resetPricingWarnings,
+} from './usage.js';
 
 // Orchestrator
 export { createOrchestrator } from './orchestrator.js';

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -133,10 +133,13 @@ export function estimateCost(
     Object.entries(table).find(([key]) => normalized.startsWith(key))?.[1];
 
   if (!prices) {
-    // Distinguish the default table from a caller-supplied one when
-    // de-duplicating warnings. Avoids spamming and avoids cross-table
-    // suppression.
-    const tableId = pricing ? 'custom' : 'default';
+    // Distinguish the built-in default table from a truly caller-supplied
+    // custom one when de-duplicating warnings. Passing DEFAULT_PRICING
+    // explicitly (UsageTracker does this internally) should still count as
+    // the default — otherwise the same model would warn twice and appear
+    // in the warning text as "custom".
+    const tableId =
+      pricing === undefined || pricing === DEFAULT_PRICING ? 'default' : 'custom';
     const key = `${tableId}:${normalized}`;
     if (!WARNED_MODELS.has(key)) {
       WARNED_MODELS.add(key);

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -93,7 +93,31 @@ function normalizeModelId(model: string): string {
 }
 
 /**
+ * Models we've already warned about — keyed by `${tableId}:${modelId}` so a
+ * caller passing a custom `pricing` table doesn't suppress warnings about
+ * the default table (and vice versa). Bounded by the number of distinct
+ * model IDs an agent uses, so it can't grow without bound in practice.
+ *
+ * The store is module-scoped on purpose: warning once per process matches
+ * the lifetime of `agent-do` runs in CLIs and short-lived servers.
+ * Long-lived servers can call {@link resetPricingWarnings} between runs
+ * if they want a fresh warning cycle.
+ */
+const WARNED_MODELS = new Set<string>();
+
+/** Reset the warned-model set. Mainly for tests / long-lived servers. */
+export function resetPricingWarnings(): void {
+  WARNED_MODELS.clear();
+}
+
+/**
  * Estimate cost in USD for a given model and token counts.
+ *
+ * When the model isn't in the active pricing table, returns `0` (preserving
+ * the historical contract — cost tracking is best-effort) but emits a
+ * one-time stderr warning per process so cost-limit enforcement based on
+ * an unknown model isn't silently disabled. Pass your own
+ * {@link PricingTable} via `AgentConfig.usage.pricing` to override.
  */
 export function estimateCost(
   model: string,
@@ -108,7 +132,28 @@ export function estimateCost(
     table[normalized] ||
     Object.entries(table).find(([key]) => normalized.startsWith(key))?.[1];
 
-  if (!prices) return 0;
+  if (!prices) {
+    // Distinguish the default table from a caller-supplied one when
+    // de-duplicating warnings. Avoids spamming and avoids cross-table
+    // suppression.
+    const tableId = pricing ? 'custom' : 'default';
+    const key = `${tableId}:${normalized}`;
+    if (!WARNED_MODELS.has(key)) {
+      WARNED_MODELS.add(key);
+      const writeStderr = (msg: string): void => {
+        // Browsers don't have process.stderr; fall back to console.warn.
+        const proc = (globalThis as { process?: { stderr?: { write?: (s: string) => void } } }).process;
+        if (proc?.stderr?.write) proc.stderr.write(msg);
+        else console.warn(msg.trimEnd());
+      };
+      writeStderr(
+        `[agent-do] No pricing entry for model "${normalized}" in the ${tableId} table; ` +
+        `cost tracking and spending limits are disabled for this model. ` +
+        `Set AgentConfig.usage.pricing to provide your own rates.\n`,
+      );
+    }
+    return 0;
+  }
 
   return (
     (inputTokens / 1_000_000) * prices.input +

--- a/tests/usage.test.ts
+++ b/tests/usage.test.ts
@@ -79,6 +79,23 @@ describe('estimateCost', () => {
       expect(stderrSpy).toHaveBeenCalledTimes(2);
     });
 
+    it('treats explicit DEFAULT_PRICING as the default table (not custom)', () => {
+      // Regression guard: passing DEFAULT_PRICING explicitly used to be
+      // misclassified as "custom" because the check was `pricing ?
+      // 'custom' : 'default'`. UsageTracker always passes a pricing
+      // table — for the default case it passes DEFAULT_PRICING — so the
+      // bug would warn twice for the same model and label one of them
+      // wrong.
+      estimateCost('shared-model', 1, 1);                     // implicit default
+      estimateCost('shared-model', 1, 1, DEFAULT_PRICING);    // explicit default
+      expect(stderrSpy).toHaveBeenCalledTimes(1);
+      const writes = stderrSpy.mock.calls
+        .map((c: unknown[]) => c[0] as string)
+        .join('');
+      expect(writes).toContain('default table');
+      expect(writes).not.toContain('custom table');
+    });
+
     it('does not warn for known models', () => {
       estimateCost('claude-sonnet-4-6', 1000, 500);
       expect(stderrSpy).not.toHaveBeenCalled();

--- a/tests/usage.test.ts
+++ b/tests/usage.test.ts
@@ -1,7 +1,16 @@
-import { describe, it, expect, vi } from 'vitest';
-import { UsageTracker, estimateCost, DEFAULT_PRICING } from '../src/usage.js';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  UsageTracker,
+  estimateCost,
+  DEFAULT_PRICING,
+  resetPricingWarnings,
+} from '../src/usage.js';
 
 describe('estimateCost', () => {
+  beforeEach(() => {
+    resetPricingWarnings();
+  });
+
   it('calculates cost for known model', () => {
     // claude-sonnet-4-6: input 3.0/1M, output 15.0/1M
     const cost = estimateCost('claude-sonnet-4-6', 1000, 500);
@@ -10,7 +19,14 @@ describe('estimateCost', () => {
   });
 
   it('returns 0 for unknown model', () => {
-    expect(estimateCost('unknown-model', 1000, 500)).toBe(0);
+    // Suppress the new warning so this assertion stays focused on the
+    // 0-cost contract; the warning behaviour is tested separately below.
+    const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      expect(estimateCost('unknown-model', 1000, 500)).toBe(0);
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   it('uses custom pricing table', () => {
@@ -28,6 +44,62 @@ describe('estimateCost', () => {
     // "claude-sonnet-4-6-20260301" should match "claude-sonnet-4-6"
     const cost = estimateCost('claude-sonnet-4-6-20260301', 1000, 500);
     expect(cost).toBeCloseTo(0.0105, 6);
+  });
+
+  describe('unknown-model warning (#38)', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let stderrSpy: any;
+
+    beforeEach(() => {
+      stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    });
+    afterEach(() => {
+      stderrSpy.mockRestore();
+    });
+
+    it('warns once per process when a model isn\'t in the table', () => {
+      estimateCost('totally-new-model', 1000, 500);
+      const writes = stderrSpy.mock.calls.map((c: unknown[]) => c[0] as string).join('');
+      expect(writes).toContain('No pricing entry');
+      expect(writes).toContain('totally-new-model');
+      expect(writes).toContain('AgentConfig.usage.pricing');
+    });
+
+    it('does not warn twice for the same model', () => {
+      estimateCost('repeat-model', 1, 1);
+      estimateCost('repeat-model', 100, 100);
+      estimateCost('repeat-model', 1000, 1000);
+      expect(stderrSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps separate warning state for default vs custom tables', () => {
+      // Same model name, different tables — both warnings should fire.
+      estimateCost('only-in-custom', 1, 1); // unknown in default
+      estimateCost('only-in-custom', 1, 1, { 'something-else': { input: 1, output: 1 } });
+      expect(stderrSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not warn for known models', () => {
+      estimateCost('claude-sonnet-4-6', 1000, 500);
+      expect(stderrSpy).not.toHaveBeenCalled();
+    });
+
+    it('falls back to console.warn in environments without process.stderr', () => {
+      // Simulate a browser-style runtime by stripping process.stderr
+      // for the duration of the call.
+      const realProc = (globalThis as { process?: unknown }).process;
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (globalThis as any).process = undefined;
+        estimateCost('browser-only-model', 1, 1);
+        expect(consoleSpy).toHaveBeenCalledOnce();
+      } finally {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (globalThis as any).process = realProc;
+        consoleSpy.mockRestore();
+      }
+    });
   });
 });
 


### PR DESCRIPTION
Fixes #38.

## Summary

`estimateCost` previously returned 0 silently for unknown models, which silently disabled `perRunLimit` / `perDayLimit` enforcement. Now it emits a one-time stderr warning per process per model so the gap is visible.

## What changed

- One-time warning per `(table, modelId)` — custom tables don't suppress warnings about the default and vice versa.
- New `resetPricingWarnings()` export for long-lived servers / tests.
- Portable: stderr when available, `console.warn` fallback.
- Behaviour preserved: still returns 0. The fix is observability, not enforcement.
- Doc comment on `estimateCost` now states the best-effort contract explicitly and points users at `AgentConfig.usage.pricing`.

## Test plan

- [x] 5 new cases (warning fires, dedup, custom-vs-default state, no warning for known models, console.warn fallback).
- [x] Existing `returns 0 for unknown model` test stubbed stderr to stay focused.
- [x] Full suite: 397 passing.