### PR TITLE
[L-02] Drop url from SkillStore.search return type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ export { createOrchestrator } from './orchestrator.js';
 export type {
   ProgressEvent,
   Skill,
+  SkillSearchResult,
   SkillStore,
   UsageRecord,
   RunUsage,

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -2,7 +2,7 @@ import { tool } from 'ai';
 import type { ToolSet } from 'ai';
 import { z } from 'zod';
 import YAML from 'yaml';
-import type { Skill, SkillStore } from './types.js';
+import type { Skill, SkillStore, SkillSearchResult } from './types.js';
 
 /**
  * Per-field schemas for the frontmatter block of a SKILL.md file.
@@ -245,18 +245,9 @@ export class InMemorySkillStore implements SkillStore {
     this.skills.delete(skillId);
   }
 
-  async search(
-    query: string,
-  ): Promise<
-    Array<{ id: string; name: string; description: string; url?: string }>
-  > {
+  async search(query: string): Promise<SkillSearchResult[]> {
     const lower = query.toLowerCase();
-    const results: Array<{
-      id: string;
-      name: string;
-      description: string;
-      url?: string;
-    }> = [];
+    const results: SkillSearchResult[] = [];
     for (const skill of this.skills.values()) {
       if (
         skill.name.toLowerCase().includes(lower) ||

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,17 +47,37 @@ export interface Skill {
   version?: string;
 }
 
-// Skill store interface
+/**
+ * A search result returned by `SkillStore.search()`.
+ *
+ * Deliberately does **not** include a `url` field. Earlier drafts of the
+ * interface carried `url?: string` and signalled "external skill registries
+ * are fine to wire up." That's an SSRF / supply-chain footgun (see #34): a
+ * hostile registry could return a URL the agent then auto-fetches with the
+ * user's credentials. If you need URL-backed skill registries, build them
+ * outside this interface, gate behind an explicit host allowlist, require
+ * HTTPS, and never auto-install — `install()` must always receive the
+ * verified content directly.
+ */
+export interface SkillSearchResult {
+  id: string;
+  name: string;
+  description: string;
+}
+
+/**
+ * Storage interface for skill definitions.
+ *
+ * Implementations are expected to be local (in-memory, OPFS, IndexedDB,
+ * SQLite, …). External / network-backed implementations must not auto-fetch
+ * skill content from `search()` results — see {@link SkillSearchResult}.
+ */
 export interface SkillStore {
   list(): Promise<Skill[]>;
   get(skillId: string): Promise<Skill | undefined>;
   install(skill: Skill): Promise<void>;
   remove(skillId: string): Promise<void>;
-  search(
-    query: string,
-  ): Promise<
-    Array<{ id: string; name: string; description: string; url?: string }>
-  >;
+  search(query: string): Promise<SkillSearchResult[]>;
 }
 
 // Usage record

--- a/tests/skills.test.ts
+++ b/tests/skills.test.ts
@@ -249,7 +249,7 @@ describe('InMemorySkillStore', () => {
     // an SSRF footgun — a hostile registry could return a URL that the
     // agent then auto-fetches with the user's credentials. The field is
     // gone from the public type; this test guards against accidental
-    // re-introduction by an InMemorySkillStore subclass.
+    // re-introduction in InMemorySkillStore itself.
     const store = new InMemorySkillStore();
     await store.install({
       id: 'x',

--- a/tests/skills.test.ts
+++ b/tests/skills.test.ts
@@ -242,6 +242,25 @@ describe('InMemorySkillStore', () => {
     const all = await store.search('');
     expect(all).toHaveLength(2);
   });
+
+  it('search results never carry a `url` field (#34: SSRF / supply-chain guard)', async () => {
+    // Earlier drafts of SkillSearchResult included `url?: string`, which
+    // signalled "external skill registries are fine to wire up." That's
+    // an SSRF footgun — a hostile registry could return a URL that the
+    // agent then auto-fetches with the user's credentials. The field is
+    // gone from the public type; this test guards against accidental
+    // re-introduction by an InMemorySkillStore subclass.
+    const store = new InMemorySkillStore();
+    await store.install({
+      id: 'x',
+      name: 'X',
+      description: 'd',
+      content: 'c',
+    });
+    const [r] = await store.search('x');
+    expect(r).toEqual({ id: 'x', name: 'X', description: 'd' });
+    expect((r as Record<string, unknown>).url).toBeUndefined();
+  });
 });
 
 describe('createSkillTools', () => {


### PR DESCRIPTION
Fixes #34.

## Summary

`SkillStore.search()` previously returned objects with an optional `url?: string`. Nothing read it, but the shape suggested external skill registries were a fine extension — and the natural "auto-fetch then install" wiring is an SSRF / supply-chain footgun.

## What changed

- New `SkillSearchResult` interface (`{ id, name, description }`), exported from `agent-do`.
- Doc block on the interface explains the rule for network-backed implementations: never auto-fetch, allowlist hosts, require HTTPS, get user confirmation, and only pass verified content to `install()`.
- `InMemorySkillStore.search()` simplified to return the new type.

## Soft API impact

Downstream `SkillStore` implementations that were returning a `url` will fail TypeScript narrowing on the public type. The field was unused at runtime, so nothing breaks at runtime.

## Test plan

- [x] New regression case asserts `url` is absent from search results.
- [x] Full suite: 393 passing.