### PR TITLE
Run typecheck/build/test on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# Cancel an in-progress run when a new commit lands on the same PR / branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Node ${{ matrix.node }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Active LTS + Current. agent-do targets Node 18+ in practice via the
+        # ai SDK; pin to LTS lines so we catch regressions on the versions
+        # users are most likely to be on.
+        node: ['20', '22', '24']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: Type-check (tsc --noEmit)
+        run: npm run typecheck
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test


### PR DESCRIPTION
Adds a GitHub Actions workflow so every PR (and every push to main) runs the full pipeline before merge.

## Coverage

- Node 20, 22, 24 (active LTS + current)
- `npm run typecheck` (catches type errors that vitest skips)
- `npm run build` (`tsc` to dist/)
- `npm test` (vitest)

## Other touches

- Concurrency cancellation so superseded commits on the same PR don't pile up runners.
- Read-only `contents` permission — minimum needed for checkout + test.
- `fail-fast: false` so a regression on one Node version doesn't hide one on another.

## Test plan

- [x] YAML lints (no syntax errors locally).
- [ ] First run on this PR will validate it works end-to-end across all three Node versions.