### PR TITLE
Fix typecheck regression on main from #57 squash-merge

### DIFF
--- a/tests/skills.test.ts
+++ b/tests/skills.test.ts
@@ -259,7 +259,11 @@ describe('InMemorySkillStore', () => {
     });
     const [r] = await store.search('x');
     expect(r).toEqual({ id: 'x', name: 'X', description: 'd' });
-    expect((r as Record<string, unknown>).url).toBeUndefined();
+    // SkillSearchResult deliberately has no index signature, so the
+    // direct `as Record<string, unknown>` cast is rejected under
+    // `strict` (TS2352). Go through `unknown` to confirm the field is
+    // absent at runtime regardless of declared type.
+    expect((r as unknown as Record<string, unknown>).url).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
Main is currently failing typecheck:

```
tests/skills.test.ts(262,13): error TS2352: Conversion of type 'SkillSearchResult' to type 'Record<string, unknown>' may be a mistake because neither type sufficiently overlaps with the other.
`Index signature for type 'string' is missing in type 'SkillSearchResult'.`
```

## What happened

PR #57 introduced `SkillSearchResult` (no index signature, by design) plus a regression-guard test that cast a result to `Record<string, unknown>` to probe for the absent `url` field. The cast is rejected under TypeScript's `strict` mode.

I pushed a fix to the L-02 branch (`3cccc1c`) shortly after CI on PR #59 caught it — but PR #57 had already been squash-merged from an earlier state, so the fix was orphaned. This PR ports the same fix onto current main.

## Fix

Two-step cast `as unknown as Record<string, unknown>` — the canonical way to assert a runtime field that isn't in the declared type.

## Test plan

- [x] `npm run typecheck` clean.
- [x] 399 tests passing.
- [x] CI on this PR will validate across Node 20/22/24.