### PR TITLE
[trust-boundary] Path resolution + saved-agent validation (closes #20, #22, #30)

### DIFF
--- a/src/cli/agents.ts
+++ b/src/cli/agents.ts
@@ -28,7 +28,12 @@ import type { ParsedArgs } from './args.js';
  */
 export const SavedAgentSchema = z.object({
   name: z.string().regex(/^[a-zA-Z0-9_-]+$/).max(64),
-  provider: z.enum(['anthropic', 'google', 'openai', 'ollama', 'openrouter']),
+  // Providers supported by `src/cli/resolve-model.ts`. openrouter was
+  // in an earlier draft of this enum but the CLI resolver doesn't
+  // handle it (#64 Copilot), so listing it here would have let
+  // `create` accept a config that `run` would reject later. If CLI
+  // OpenRouter support lands, update both surfaces in the same change.
+  provider: z.enum(['anthropic', 'google', 'openai', 'ollama']),
   model: z.string().max(128).optional(),
   systemPrompt: z.string().max(8192),
   memoryDir: z
@@ -229,11 +234,28 @@ export async function listSavedAgents(): Promise<void> {
 export async function loadSavedAgent(name: string): Promise<SavedAgent | null> {
   const filePath = await findAgentFile(name);
   if (!filePath) return null;
+  // Read and parse as two separate steps so the failure modes don't
+  // blur together (Copilot #64). "Malformed JSON" is an actionable
+  // diagnostic; "permission denied" is something the operator needs
+  // to fix at the filesystem level.
+  let content: string;
+  try {
+    content = await fs.promises.readFile(filePath, 'utf-8');
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(
+      `[agent-do] Could not read agent file ${filePath}: ${msg}\n`,
+    );
+    return null;
+  }
   let raw: unknown;
   try {
-    raw = safeJsonParse(await fs.promises.readFile(filePath, 'utf-8'));
-  } catch {
-    process.stderr.write(`[agent-do] Ignoring malformed agent file ${filePath}\n`);
+    raw = safeJsonParse(content);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(
+      `[agent-do] Ignoring malformed agent file ${filePath}: ${msg}\n`,
+    );
     return null;
   }
   const parsed = SavedAgentSchema.safeParse(raw);

--- a/src/cli/agents.ts
+++ b/src/cli/agents.ts
@@ -8,24 +8,46 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { z } from 'zod';
 import type { ParsedArgs } from './args.js';
 
-export interface SavedAgent {
-  name: string;
-  provider: string;
-  model?: string;
-  systemPrompt: string;
-  memoryDir: string;
-  /**
-   * Enable the agent's private memory tools (memory_read, memory_write, etc.).
-   * Workspace tools (read_file, write_file) are always enabled unless noTools.
-   */
-  withMemory?: boolean;
-  readOnly: boolean;
-  maxIterations: number;
-  noTools: boolean;
-  createdAt: string;
-}
+/**
+ * Schema for a saved agent JSON file. See issue #22 — earlier
+ * versions did `JSON.parse(content) as SavedAgent` with no runtime
+ * validation, which let a planted agent file plant a jailbreak
+ * system prompt, point `memoryDir` at filesystem root, or drop
+ * `__proto__` into the parsed object.
+ *
+ * Constraints worth highlighting:
+ * - `provider` is an explicit enum (no surprise providers).
+ * - `memoryDir` is rejected if absolute or if it contains `..` —
+ *   prevents memory store escape via crafted config.
+ * - `systemPrompt` is capped at 8 KB to bound jailbreak-as-data
+ *   payload size.
+ * - `.strict()` rejects unknown keys so future footguns fail closed.
+ */
+export const SavedAgentSchema = z.object({
+  name: z.string().regex(/^[a-zA-Z0-9_-]+$/).max(64),
+  provider: z.enum(['anthropic', 'google', 'openai', 'ollama', 'openrouter']),
+  model: z.string().max(128).optional(),
+  systemPrompt: z.string().max(8192),
+  memoryDir: z
+    .string()
+    .max(256)
+    .refine((v) => !path.isAbsolute(v), {
+      message: 'memoryDir must be a relative path (no absolute paths)',
+    })
+    .refine((v) => !v.split(/[/\\]/).includes('..'), {
+      message: 'memoryDir must not contain `..` segments',
+    }),
+  withMemory: z.boolean().optional(),
+  readOnly: z.boolean(),
+  maxIterations: z.number().int().positive().max(1000),
+  noTools: z.boolean(),
+  createdAt: z.string(),
+}).strict();
+
+export type SavedAgent = z.infer<typeof SavedAgentSchema>;
 
 const AGENTS_DIR = path.join('.agent-do', 'agents');
 
@@ -35,6 +57,20 @@ function validateAgentName(name: string): void {
       `Invalid agent name "${name}". Names may only contain alphanumeric characters, dashes, and underscores.`,
     );
   }
+}
+
+/**
+ * `JSON.parse` reviver that drops prototype-pollution keys at any
+ * depth. Belt-and-braces — even if a future Zod refactor weakens the
+ * schema, these keys can never reach the parsed object.
+ */
+function safeJsonParse(text: string): unknown {
+  return JSON.parse(text, (key, value) => {
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+      return undefined;
+    }
+    return value;
+  });
 }
 
 function agentPath(name: string): string {
@@ -78,7 +114,11 @@ export async function createSavedAgent(args: ParsedArgs): Promise<void> {
     throw new Error('Usage: npx agent-do create <name> [options]');
   }
 
-  const config: SavedAgent = {
+  // Build the candidate config and round-trip through the schema so
+  // `create` enforces the same constraints as `load`. Catches things
+  // like an oversize system prompt or an unknown provider before we
+  // write a file the loader will then reject.
+  const candidate = {
     name: args.agentName,
     provider: args.provider,
     model: args.model,
@@ -90,6 +130,14 @@ export async function createSavedAgent(args: ParsedArgs): Promise<void> {
     noTools: args.noTools,
     createdAt: new Date().toISOString(),
   };
+  const validated = SavedAgentSchema.safeParse(candidate);
+  if (!validated.success) {
+    const issues = validated.error.issues
+      .map((i) => `  ${i.path.join('.') || '(root)'}: ${i.message}`)
+      .join('\n');
+    throw new Error(`Invalid agent config:\n${issues}`);
+  }
+  const config: SavedAgent = validated.data;
 
   await fs.promises.mkdir(AGENTS_DIR, { recursive: true });
   const filePath = agentPath(args.agentName);
@@ -166,16 +214,37 @@ export async function listSavedAgents(): Promise<void> {
 
 /**
  * Try to load a saved agent config by name.
- * Walks up the directory tree from cwd — closest ancestor wins (like `.git`).
- * Returns null if no saved agent with that name exists.
+ *
+ * Walks up the directory tree from cwd — closest ancestor wins (like
+ * `.git`). Returns `null` if the file is missing, malformed JSON, or
+ * fails the {@link SavedAgentSchema} validation. Validation failures
+ * print a diagnostic to stderr so a planted bad file doesn't fail
+ * silently — the operator can see why the agent didn't load.
+ *
+ * See #22 — pre-validation, this function did
+ * `JSON.parse(content) as SavedAgent` and accepted any shape, which
+ * let a planted agent file plant arbitrary system prompts and point
+ * `memoryDir` outside the project root.
  */
 export async function loadSavedAgent(name: string): Promise<SavedAgent | null> {
   const filePath = await findAgentFile(name);
   if (!filePath) return null;
+  let raw: unknown;
   try {
-    const content = await fs.promises.readFile(filePath, 'utf-8');
-    return JSON.parse(content) as SavedAgent;
+    raw = safeJsonParse(await fs.promises.readFile(filePath, 'utf-8'));
   } catch {
+    process.stderr.write(`[agent-do] Ignoring malformed agent file ${filePath}\n`);
     return null;
   }
+  const parsed = SavedAgentSchema.safeParse(raw);
+  if (!parsed.success) {
+    const issues = parsed.error.issues
+      .map((i) => `  ${i.path.join('.') || '(root)'}: ${i.message}`)
+      .join('\n');
+    process.stderr.write(
+      `[agent-do] Ignoring invalid agent file ${filePath}:\n${issues}\n`,
+    );
+    return null;
+  }
+  return parsed.data;
 }

--- a/src/stores/agent-id.ts
+++ b/src/stores/agent-id.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared `agentId` validation. Centralised here so the rule can be
+ * enforced at every boundary that takes an agent ID, not just in the
+ * CLI. See issue #30.
+ *
+ * The rule was originally in `src/cli/agents.ts` (saved-agent name
+ * regex), but `FilesystemMemoryStore.resolve()` happily accepted
+ * arbitrary strings and concatenated them into a path. A library
+ * caller passing `req.user.id` straight in could create
+ * `agentId = '../other-tenant'` and escape the per-agent subdir.
+ */
+
+const AGENT_ID_RE = /^[a-zA-Z0-9_-]+$/;
+const MAX_AGENT_ID_LENGTH = 64;
+
+/**
+ * Throws if `agentId` is not a safe path segment.
+ *
+ * The empty string is permitted because `createWorkspaceTools` uses
+ * agentId `""` to mount file tools at the workspace root rather than a
+ * per-agent subdirectory. The store's path-traversal guard handles
+ * the rest.
+ */
+export function validateAgentId(agentId: string): void {
+  if (typeof agentId !== 'string') {
+    throw new Error('agentId must be a string');
+  }
+  if (agentId.length === 0) return; // workspace-tools mode
+  if (agentId.length > MAX_AGENT_ID_LENGTH) {
+    throw new Error(
+      `agentId too long (${agentId.length} > ${MAX_AGENT_ID_LENGTH}).`,
+    );
+  }
+  if (!AGENT_ID_RE.test(agentId)) {
+    throw new Error(
+      `Invalid agentId "${agentId}". Use only alphanumerics, dashes, and underscores.`,
+    );
+  }
+}

--- a/src/stores/filesystem.ts
+++ b/src/stores/filesystem.ts
@@ -82,14 +82,19 @@ export class FilesystemMemoryStore implements MemoryStore {
    *    is `/` or a Windows drive root the `sep` concatenation turns
    *    into `//` / `C:\\` and rejects legitimate children.
    */
-  private resolve(agentId: string, filePath: string): string {
+  private async resolve(agentId: string, filePath: string): Promise<string> {
     validateAgentId(agentId);
     // Canonicalise base up front so every later comparison is
     // canonical-vs-canonical. If baseDir is itself a symlink the
     // realpath walk resolves to the target; without this the
     // `withinBase(canonical, base)` check would reject every path.
-    const base = realpathSafe(path.resolve(this.baseDir));
-    const agentDir = realpathSafe(path.resolve(base, agentId));
+    //
+    // All three realpath walks are async (Codex #64 follow-up): the
+    // store is on the hot path for every tool call, and sync fs
+    // calls here blocked the event loop under concurrent load —
+    // reintroducing the very behaviour #25 moved away from.
+    const base = await realpathSafe(path.resolve(this.baseDir));
+    const agentDir = await realpathSafe(path.resolve(base, agentId));
     if (!withinBase(agentDir, base)) {
       throw new Error('Path traversal not allowed (agentId)');
     }
@@ -100,7 +105,7 @@ export class FilesystemMemoryStore implements MemoryStore {
     if (!withinBase(resolved, agentDir)) {
       throw new Error('Path traversal not allowed');
     }
-    const canonical = realpathSafe(resolved);
+    const canonical = await realpathSafe(resolved);
     if (!withinBase(canonical, agentDir)) {
       throw new Error('Path traversal via symlink not allowed');
     }
@@ -108,13 +113,13 @@ export class FilesystemMemoryStore implements MemoryStore {
   }
 
   /** Returns the canonicalized relative path for use in callbacks. */
-  private canonicalRelativePath(agentId: string, filePath: string): string {
-    const resolved = this.resolve(agentId, filePath);
+  private async canonicalRelativePath(agentId: string, filePath: string): Promise<string> {
+    const resolved = await this.resolve(agentId, filePath);
     // Use the canonical agentDir (matching `resolve()`'s own
     // canonicalisation) so the relative path has no spurious `..`
     // segments when baseDir or agentDir contain symlinks.
-    const base = realpathSafe(path.resolve(this.baseDir));
-    const agentDir = realpathSafe(path.resolve(base, agentId));
+    const base = await realpathSafe(path.resolve(this.baseDir));
+    const agentDir = await realpathSafe(path.resolve(base, agentId));
     return path.relative(agentDir, resolved);
   }
 
@@ -124,7 +129,7 @@ export class FilesystemMemoryStore implements MemoryStore {
     }
     if (this.options.onBeforeWrite) {
       // Pass the canonicalized path so policies can't be bypassed with ../
-      const canonicalPath = this.canonicalRelativePath(agentId, filePath);
+      const canonicalPath = await this.canonicalRelativePath(agentId, filePath);
       const allowed = await Promise.resolve(this.options.onBeforeWrite(agentId, canonicalPath, op));
       if (!allowed) {
         throw new Error(`Write blocked by onBeforeWrite callback (attempted ${op} on ${canonicalPath})`);
@@ -133,7 +138,7 @@ export class FilesystemMemoryStore implements MemoryStore {
   }
 
   async read(agentId: string, filePath: string): Promise<string> {
-    const full = this.resolve(agentId, filePath);
+    const full = await this.resolve(agentId, filePath);
     try {
       return await fsp.readFile(full, 'utf-8');
     } catch (err) {
@@ -152,21 +157,21 @@ export class FilesystemMemoryStore implements MemoryStore {
 
   async write(agentId: string, filePath: string, content: string): Promise<void> {
     await this.checkWrite(agentId, filePath, 'write');
-    const full = this.resolve(agentId, filePath);
+    const full = await this.resolve(agentId, filePath);
     await fsp.mkdir(path.dirname(full), { recursive: true });
     await fsp.writeFile(full, content, 'utf-8');
   }
 
   async append(agentId: string, filePath: string, content: string): Promise<void> {
     await this.checkWrite(agentId, filePath, 'append');
-    const full = this.resolve(agentId, filePath);
+    const full = await this.resolve(agentId, filePath);
     await fsp.mkdir(path.dirname(full), { recursive: true });
     await fsp.appendFile(full, content, 'utf-8');
   }
 
   async delete(agentId: string, filePath: string): Promise<void> {
     await this.checkWrite(agentId, filePath, 'delete');
-    const full = this.resolve(agentId, filePath);
+    const full = await this.resolve(agentId, filePath);
     try {
       await fsp.unlink(full);
     } catch (err) {
@@ -185,7 +190,7 @@ export class FilesystemMemoryStore implements MemoryStore {
   }
 
   async list(agentId: string, dirPath?: string): Promise<FileEntry[]> {
-    const full = this.resolve(agentId, dirPath || '.');
+    const full = await this.resolve(agentId, dirPath || '.');
     let entries: fs.Dirent[];
     try {
       entries = await fsp.readdir(full, { withFileTypes: true });
@@ -215,12 +220,12 @@ export class FilesystemMemoryStore implements MemoryStore {
 
   async mkdir(agentId: string, dirPath: string): Promise<void> {
     await this.checkWrite(agentId, dirPath, 'mkdir');
-    await fsp.mkdir(this.resolve(agentId, dirPath), { recursive: true });
+    await fsp.mkdir(await this.resolve(agentId, dirPath), { recursive: true });
   }
 
   async exists(agentId: string, filePath: string): Promise<boolean> {
     try {
-      await fsp.stat(this.resolve(agentId, filePath));
+      await fsp.stat(await this.resolve(agentId, filePath));
       return true;
     } catch (err) {
       // Mirror `fs.existsSync`: any path-shape error that means "no
@@ -238,8 +243,9 @@ export class FilesystemMemoryStore implements MemoryStore {
   // (search) ───────────────────────────────────────────────────────
   async search(agentId: string, pattern: string, dirPath?: string): Promise<Array<{ path: string; line: string }>> {
     const results: Array<{ path: string; line: string }> = [];
-    const searchDir = this.resolve(agentId, dirPath || '.');
-    await this.searchRecursive(searchDir, this.resolve(agentId, '.'), pattern, results);
+    const searchDir = await this.resolve(agentId, dirPath || '.');
+    const agentRoot = await this.resolve(agentId, '.');
+    await this.searchRecursive(searchDir, agentRoot, pattern, results);
     return results;
   }
 
@@ -304,42 +310,59 @@ export class FilesystemMemoryStore implements MemoryStore {
 function withinBase(candidate: string, base: string): boolean {
   if (candidate === base) return true;
   const rel = path.relative(base, candidate);
-  // rel starting with `..` means the candidate is *above* or
-  // alongside base. rel being an absolute path means the inputs are
-  // on different roots (Windows drive letters). Either way it's not
-  // inside base.
   if (rel === '' || rel === '.') return true;
-  if (rel.startsWith('..')) return false;
+  // Match only real parent-segment references, not arbitrary names
+  // that happen to start with `..` (Codex #64 follow-up: `..cache` or
+  // `..notes` are valid child directories, and `rel.startsWith('..')`
+  // rejected them as traversal). A traversal `rel` is either exactly
+  // `..` or starts with `../` / `..\` — test for the separator.
+  if (rel === '..' || rel.startsWith('..' + path.sep)) return false;
+  // rel being an absolute path means the inputs are on different
+  // roots (Windows drive letters).
   return !path.isAbsolute(rel);
 }
 
 /**
- * `fs.realpathSync(path)` requires the path to exist. For a fresh
- * write, the leaf doesn't exist yet — realpath would throw. Walk up
- * to the deepest existing ancestor, canonicalise that, and re-append
- * the unresolved suffix so we still detect symlinks anywhere in the
+ * `fsp.realpath(path)` requires the path to exist. For a fresh write
+ * the leaf doesn't exist yet — realpath would throw. Walk up to the
+ * deepest existing ancestor, canonicalise that, and re-append the
+ * unresolved suffix so we still detect symlinks anywhere in the
  * existing portion of the path.
  *
- * Returns the input unchanged if the deepest ancestor doesn't exist
- * (e.g. baseDir itself is missing) — the caller's containment check
- * is still authoritative.
+ * Async (Codex #64 follow-up): the previous sync version used
+ * `existsSync` + `realpathSync` on every `resolve()` call, which is
+ * on the hot path for every tool invocation. Under concurrent agent
+ * load those sync calls block the event loop and reintroduce the
+ * blocking-I/O behaviour the store moved away from in #25. Using
+ * `fsp.realpath` directly (which throws ENOENT if the leaf is
+ * missing) and only walking up on ENOENT keeps the common "leaf
+ * exists" path to a single async call.
+ *
+ * Returns the input unchanged if no ancestor exists (e.g. baseDir
+ * itself is missing) — the caller's containment check is still
+ * authoritative.
  */
-function realpathSafe(p: string): string {
+async function realpathSafe(p: string): Promise<string> {
   let suffix = '';
   let current = p;
-  while (!fs.existsSync(current)) {
-    const parent = path.dirname(current);
-    if (parent === current) return p;
-    suffix = path.join(path.basename(current), suffix);
-    current = parent;
+  while (true) {
+    try {
+      const canonical = await fsp.realpath(current);
+      return suffix ? path.join(canonical, suffix) : canonical;
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== 'ENOENT' && code !== 'ENOTDIR') {
+        // Unknown error — don't swallow it silently; return the input
+        // so the caller's containment check stays authoritative and
+        // the raw error surfaces on the next real I/O call.
+        return p;
+      }
+      const parent = path.dirname(current);
+      if (parent === current) return p; // hit root without resolving
+      suffix = path.join(path.basename(current), suffix);
+      current = parent;
+    }
   }
-  let canonical: string;
-  try {
-    canonical = fs.realpathSync(current);
-  } catch {
-    return p;
-  }
-  return suffix ? path.join(canonical, suffix) : canonical;
 }
 
 /**

--- a/src/stores/filesystem.ts
+++ b/src/stores/filesystem.ts
@@ -48,45 +48,52 @@ export class FilesystemMemoryStore implements MemoryStore {
 
   /**
    * Resolve an agent-relative path to an absolute filesystem path,
-   * with two distinct guards (#20 H-01):
+   * with four distinct guards (#20 H-01 + PR #64 review follow-ups):
    *
-   * 1. **String-prefix bug fix.** The previous check used
-   *    `resolved.startsWith(baseDir)` without a trailing separator,
-   *    so a baseDir of `/data/agent` accidentally accepted siblings
-   *    like `/data/agent-evil/file`. The check now compares against
-   *    `baseDir + path.sep` (or exact equality).
+   * 1. **Agent-id validation** (#30). `validateAgentId` rejects
+   *    traversal-shaped ids like `../other-tenant` before any path
+   *    construction.
    *
-   * 2. **Symlink canonicalisation.** The check used to run on the
-   *    pre-`realpath` path, so `sandbox/escape -> /etc` was allowed:
-   *    the resolved path looked like `<base>/sandbox/escape/passwd`
-   *    (inside base) but the actual read targeted `/etc/passwd`.
-   *    Now we canonicalise the deepest existing ancestor with
-   *    `realpathSync` and re-check that the canonical path is still
-   *    under base.
+   * 2. **Canonical-to-canonical containment.** Both the base dir and
+   *    the resolved target are canonicalised via `realpathSafe`
+   *    *before* the prefix check. Earlier drafts compared a raw
+   *    `path.resolve(baseDir)` against a realpathed target, so a
+   *    baseDir that was itself a symlink (e.g. `/Volumes/tmp` on
+   *    macOS) made every legitimate path fail the check. Both sides
+   *    of the comparison now go through the same canonicalisation.
    *
-   * Plus the per-call `validateAgentId(agentId)` from #30 — the
-   * regex was previously enforced only at the CLI layer. Library
-   * callers passing user input could produce agentIds like
-   * `../other-tenant` and bypass the per-agent subdirectory.
+   * 3. **Per-agent isolation** (PR #64 Copilot). `filePath` is
+   *    resolved against *agentDir*, and the containment check uses
+   *    agentDir — not just baseDir — as the boundary. Without this,
+   *    agentId=`a1` with filePath=`../a2/secret` resolved to a path
+   *    inside baseDir but outside a1's own directory, leaking
+   *    cross-tenant data.
+   *
+   * 4. **Root-path safety.** `withinBase` uses `path.relative` rather
+   *    than a naive `startsWith(base + path.sep)`, because when base
+   *    is `/` or a Windows drive root the `sep` concatenation turns
+   *    into `//` / `C:\\` and rejects legitimate children.
    */
   private resolve(agentId: string, filePath: string): string {
     validateAgentId(agentId);
-    const base = path.resolve(this.baseDir);
-    const agentDir = path.resolve(base, agentId);
+    // Canonicalise base up front so every later comparison is
+    // canonical-vs-canonical. If baseDir is itself a symlink the
+    // realpath walk resolves to the target; without this the
+    // `withinBase(canonical, base)` check would reject every path.
+    const base = realpathSafe(path.resolve(this.baseDir));
+    const agentDir = realpathSafe(path.resolve(base, agentId));
     if (!withinBase(agentDir, base)) {
       throw new Error('Path traversal not allowed (agentId)');
     }
     const resolved = path.resolve(agentDir, filePath);
-    if (!withinBase(resolved, base)) {
+    // Agent-level isolation: the resolved path must stay inside the
+    // agent's own directory. Checking `base` alone would permit
+    // `filePath = "../other-agent/secret"`.
+    if (!withinBase(resolved, agentDir)) {
       throw new Error('Path traversal not allowed');
     }
-    // Canonicalise via realpath so a symlink pointing outside the
-    // base directory is detected and rejected. realpath only works
-    // on existing paths — for fresh writes, walk up to the deepest
-    // existing ancestor and canonicalise that, then re-append the
-    // unresolved suffix.
     const canonical = realpathSafe(resolved);
-    if (!withinBase(canonical, base)) {
+    if (!withinBase(canonical, agentDir)) {
       throw new Error('Path traversal via symlink not allowed');
     }
     return canonical;
@@ -95,7 +102,11 @@ export class FilesystemMemoryStore implements MemoryStore {
   /** Returns the canonicalized relative path for use in callbacks. */
   private canonicalRelativePath(agentId: string, filePath: string): string {
     const resolved = this.resolve(agentId, filePath);
-    const agentDir = path.resolve(this.baseDir, agentId);
+    // Use the canonical agentDir (matching `resolve()`'s own
+    // canonicalisation) so the relative path has no spurious `..`
+    // segments when baseDir or agentDir contain symlinks.
+    const base = realpathSafe(path.resolve(this.baseDir));
+    const agentDir = realpathSafe(path.resolve(base, agentId));
     return path.relative(agentDir, resolved);
   }
 
@@ -196,13 +207,29 @@ export class FilesystemMemoryStore implements MemoryStore {
 
 /**
  * True iff `candidate` is the same as, or strictly inside, `base`.
- * Uses `path.sep` so a sibling whose name happens to share the
- * `base` prefix (e.g. `/data/agent` vs `/data/agent-evil`) doesn't
- * accidentally pass. Both inputs must already be absolute.
+ *
+ * Uses `path.relative` rather than a naive `startsWith(base + sep)`
+ * so:
+ *   - a sibling whose name shares the base prefix (`/data/agent` vs
+ *     `/data/agent-evil`) is still rejected — the relative path
+ *     starts with `..` and we bail;
+ *   - a base that is a filesystem root (`/` on POSIX, `C:\` on
+ *     Windows) is handled correctly — the naive `base + sep`
+ *     concatenation would become `//` / `C:\\` and reject every
+ *     legitimate child.
+ *
+ * Both inputs must already be absolute.
  */
 function withinBase(candidate: string, base: string): boolean {
   if (candidate === base) return true;
-  return candidate.startsWith(base + path.sep);
+  const rel = path.relative(base, candidate);
+  // rel starting with `..` means the candidate is *above* or
+  // alongside base. rel being an absolute path means the inputs are
+  // on different roots (Windows drive letters). Either way it's not
+  // inside base.
+  if (rel === '' || rel === '.') return true;
+  if (rel.startsWith('..')) return false;
+  return !path.isAbsolute(rel);
 }
 
 /**

--- a/src/stores/filesystem.ts
+++ b/src/stores/filesystem.ts
@@ -30,6 +30,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { MemoryStore, FileEntry } from '../stores.js';
 import type { FilesystemMemoryStoreOptions } from '../types.js';
+import { validateAgentId } from './agent-id.js';
 
 export type { FilesystemMemoryStoreOptions } from '../types.js';
 
@@ -45,13 +46,50 @@ export class FilesystemMemoryStore implements MemoryStore {
     }
   }
 
+  /**
+   * Resolve an agent-relative path to an absolute filesystem path,
+   * with two distinct guards (#20 H-01):
+   *
+   * 1. **String-prefix bug fix.** The previous check used
+   *    `resolved.startsWith(baseDir)` without a trailing separator,
+   *    so a baseDir of `/data/agent` accidentally accepted siblings
+   *    like `/data/agent-evil/file`. The check now compares against
+   *    `baseDir + path.sep` (or exact equality).
+   *
+   * 2. **Symlink canonicalisation.** The check used to run on the
+   *    pre-`realpath` path, so `sandbox/escape -> /etc` was allowed:
+   *    the resolved path looked like `<base>/sandbox/escape/passwd`
+   *    (inside base) but the actual read targeted `/etc/passwd`.
+   *    Now we canonicalise the deepest existing ancestor with
+   *    `realpathSync` and re-check that the canonical path is still
+   *    under base.
+   *
+   * Plus the per-call `validateAgentId(agentId)` from #30 — the
+   * regex was previously enforced only at the CLI layer. Library
+   * callers passing user input could produce agentIds like
+   * `../other-tenant` and bypass the per-agent subdirectory.
+   */
   private resolve(agentId: string, filePath: string): string {
-    const agentDir = path.resolve(this.baseDir, agentId);
+    validateAgentId(agentId);
+    const base = path.resolve(this.baseDir);
+    const agentDir = path.resolve(base, agentId);
+    if (!withinBase(agentDir, base)) {
+      throw new Error('Path traversal not allowed (agentId)');
+    }
     const resolved = path.resolve(agentDir, filePath);
-    if (!resolved.startsWith(path.resolve(this.baseDir))) {
+    if (!withinBase(resolved, base)) {
       throw new Error('Path traversal not allowed');
     }
-    return resolved;
+    // Canonicalise via realpath so a symlink pointing outside the
+    // base directory is detected and rejected. realpath only works
+    // on existing paths — for fresh writes, walk up to the deepest
+    // existing ancestor and canonicalise that, then re-append the
+    // unresolved suffix.
+    const canonical = realpathSafe(resolved);
+    if (!withinBase(canonical, base)) {
+      throw new Error('Path traversal via symlink not allowed');
+    }
+    return canonical;
   }
 
   /** Returns the canonicalized relative path for use in callbacks. */
@@ -120,6 +158,7 @@ export class FilesystemMemoryStore implements MemoryStore {
     return fs.existsSync(this.resolve(agentId, filePath));
   }
 
+  // (search) ───────────────────────────────────────────────────────
   async search(agentId: string, pattern: string, dirPath?: string): Promise<Array<{ path: string; line: string }>> {
     const results: Array<{ path: string; line: string }> = [];
     const searchDir = this.resolve(agentId, dirPath || '.');
@@ -153,4 +192,44 @@ export class FilesystemMemoryStore implements MemoryStore {
       }
     }
   }
+}
+
+/**
+ * True iff `candidate` is the same as, or strictly inside, `base`.
+ * Uses `path.sep` so a sibling whose name happens to share the
+ * `base` prefix (e.g. `/data/agent` vs `/data/agent-evil`) doesn't
+ * accidentally pass. Both inputs must already be absolute.
+ */
+function withinBase(candidate: string, base: string): boolean {
+  if (candidate === base) return true;
+  return candidate.startsWith(base + path.sep);
+}
+
+/**
+ * `fs.realpathSync(path)` requires the path to exist. For a fresh
+ * write, the leaf doesn't exist yet — realpath would throw. Walk up
+ * to the deepest existing ancestor, canonicalise that, and re-append
+ * the unresolved suffix so we still detect symlinks anywhere in the
+ * existing portion of the path.
+ *
+ * Returns the input unchanged if the deepest ancestor doesn't exist
+ * (e.g. baseDir itself is missing) — the caller's containment check
+ * is still authoritative.
+ */
+function realpathSafe(p: string): string {
+  let suffix = '';
+  let current = p;
+  while (!fs.existsSync(current)) {
+    const parent = path.dirname(current);
+    if (parent === current) return p;
+    suffix = path.join(path.basename(current), suffix);
+    current = parent;
+  }
+  let canonical: string;
+  try {
+    canonical = fs.realpathSync(current);
+  } catch {
+    return p;
+  }
+  return suffix ? path.join(canonical, suffix) : canonical;
 }

--- a/tests/trust-boundary.test.ts
+++ b/tests/trust-boundary.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
@@ -19,21 +19,26 @@ afterEach(() => {
 
 describe('H-01: path-traversal guards in FilesystemMemoryStore.resolve()', () => {
   it('rejects sibling directory whose name shares the base prefix', () => {
-    // Old check: `resolved.startsWith(baseDir)` without a separator.
-    // Given baseDir `<tmp>/agent`, a sibling `<tmp>/agent-evil` would pass.
+    // Regression for the specific bug PR #64 fixed: the old check was
+    // `resolved.startsWith(baseDir)` without a separator. Given
+    // baseDir `<tmp>/agent`, a `../agent-evil/secret` traversal
+    // resolves to a sibling that shared the base prefix string —
+    // `<tmp>/agent-evil/secret` starts with `<tmp>/agent` — so the
+    // naive startsWith check accepted it. The `withinBase` helper
+    // now uses `path.relative` and rejects the sibling correctly.
     const baseDir = path.join(tmpDir, 'agent');
     fs.mkdirSync(baseDir);
+    const agentDir = path.join(baseDir, 'agent-1');
+    fs.mkdirSync(agentDir);
     fs.mkdirSync(path.join(tmpDir, 'agent-evil'));
     fs.writeFileSync(path.join(tmpDir, 'agent-evil', 'secret'), 'pwn');
 
     const store = new FilesystemMemoryStore(baseDir);
-    // The escape vector requires an agentId starting with `..`. The
-    // M-06 validateAgentId guard rejects that *before* the
-    // string-prefix check would even run, but the assertion is the
-    // same: the escape is blocked.
+    // Valid agentId, traversal-shaped filePath: the filePath path of
+    // the check is what has to catch this.
     expect(() =>
-      store['resolve']('..-evil', 'secret'),
-    ).toThrow(/Invalid agentId|Path traversal/);
+      store['resolve']('agent-1', '../../agent-evil/secret'),
+    ).toThrow(/Path traversal/);
   });
 
   it('rejects symlinks pointing outside the base directory', () => {
@@ -61,8 +66,13 @@ describe('H-01: path-traversal guards in FilesystemMemoryStore.resolve()', () =>
     fs.symlinkSync(tmpDir, path.join(baseDir, 'agent-2'));
 
     const store = new FilesystemMemoryStore(baseDir);
+    // After PR #64's canonicalise-base fix, the agentDir itself gets
+    // realpath'd and escapes baseDir at the agentId check, so the
+    // error is "Path traversal not allowed (agentId)" rather than
+    // the symlink-specific message. Either outcome is correct —
+    // both block the escape.
     expect(() => store['resolve']('agent-2', 'leak.txt')).toThrow(
-      /symlink not allowed/,
+      /Path traversal|symlink not allowed/,
     );
   });
 
@@ -70,8 +80,60 @@ describe('H-01: path-traversal guards in FilesystemMemoryStore.resolve()', () =>
     const baseDir = path.join(tmpDir, 'sandbox');
     const store = new FilesystemMemoryStore(baseDir);
     // Should not throw; resolve() returns an absolute path inside baseDir.
+    // Use `realpathSafe` on baseDir (via fs.realpathSync when it exists)
+    // because macOS /var -> /private/var symlinks cause `path.resolve`
+    // to disagree with the resolve() output once we canonicalise
+    // everything (PR #64 fix). The relative-path check is robust to
+    // the indirection.
     const out = store['resolve']('agent-1', 'notes.md');
-    expect(out.startsWith(path.resolve(baseDir) + path.sep)).toBe(true);
+    const rel = path.relative(fs.realpathSync(baseDir), out);
+    expect(rel).not.toMatch(/^\.\./);
+    expect(path.isAbsolute(rel)).toBe(false);
+  });
+
+  it('rejects cross-agent traversal (PR #64 Copilot)', () => {
+    // `filePath = "../a2/secret"` resolves to a path inside baseDir
+    // but outside the requesting agent's own directory. The fixed
+    // resolve() checks containment against agentDir, not baseDir.
+    const baseDir = path.join(tmpDir, 'sandbox');
+    fs.mkdirSync(baseDir);
+    const a2 = path.join(baseDir, 'a2');
+    fs.mkdirSync(a2);
+    fs.writeFileSync(path.join(a2, 'secret'), 'tenant-2');
+
+    const store = new FilesystemMemoryStore(baseDir);
+    expect(() =>
+      store['resolve']('a1', '../a2/secret'),
+    ).toThrow(/Path traversal/);
+  });
+
+  it('handles a symlinked baseDir (Codex #64 P2)', () => {
+    // baseDir itself is a symlink. The earlier fix canonicalised the
+    // target but not the base, so every in-base path failed `withinBase`
+    // because the realpath landed on a different string than the raw
+    // `path.resolve(baseDir)` the comparison used.
+    const realBase = path.join(tmpDir, 'real-store');
+    fs.mkdirSync(realBase);
+    const linkedBase = path.join(tmpDir, 'linked-store');
+    fs.symlinkSync(realBase, linkedBase);
+
+    const store = new FilesystemMemoryStore(linkedBase);
+    // Normal read/write through a linked base must not throw.
+    expect(() => store['resolve']('a1', 'notes.md')).not.toThrow();
+  });
+
+  it('handles a filesystem-root baseDir (PR #64 Copilot)', () => {
+    // When base is `/` (or a Windows drive root), `base + sep` becomes
+    // `//` — the old naive startsWith would reject every legitimate
+    // path. The `path.relative`-based `withinBase` handles this.
+    // We can't actually test with `/` in a sandboxed test, but we can
+    // test the helper via a base that IS its own filesystem root
+    // segment: `tmpDir` already has a root ancestor, so use that.
+    // Easier: construct a store at tmpDir and just verify a resolve
+    // under it works — the root case is proven by withinBase's
+    // path.relative implementation (no startsWith(base + sep) anywhere).
+    const store = new FilesystemMemoryStore(tmpDir);
+    expect(() => store['resolve']('a1', 'notes.md')).not.toThrow();
   });
 
   it('canonicalises non-existent paths via deepest existing ancestor', () => {
@@ -267,8 +329,3 @@ describe('H-03: loadSavedAgent rejects invalid files at runtime', () => {
     expect(result!.provider).toBe('anthropic');
   });
 });
-
-// vi-spyOn import has to come after the describe blocks otherwise top-level
-// hoisting puts it before fs/path. Importing here to keep the file shape
-// consistent with the rest of the suite.
-import { vi } from 'vitest';

--- a/tests/trust-boundary.test.ts
+++ b/tests/trust-boundary.test.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { FilesystemMemoryStore } from '../src/stores/filesystem.js';
+import { validateAgentId } from '../src/stores/agent-id.js';
+import { SavedAgentSchema, loadSavedAgent } from '../src/cli/agents.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-do-trust-'));
+});
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ─── #20 H-01: path traversal in FilesystemMemoryStore.resolve() ──────────────
+
+describe('H-01: path-traversal guards in FilesystemMemoryStore.resolve()', () => {
+  it('rejects sibling directory whose name shares the base prefix', () => {
+    // Old check: `resolved.startsWith(baseDir)` without a separator.
+    // Given baseDir `<tmp>/agent`, a sibling `<tmp>/agent-evil` would pass.
+    const baseDir = path.join(tmpDir, 'agent');
+    fs.mkdirSync(baseDir);
+    fs.mkdirSync(path.join(tmpDir, 'agent-evil'));
+    fs.writeFileSync(path.join(tmpDir, 'agent-evil', 'secret'), 'pwn');
+
+    const store = new FilesystemMemoryStore(baseDir);
+    // The escape vector requires an agentId starting with `..`. The
+    // M-06 validateAgentId guard rejects that *before* the
+    // string-prefix check would even run, but the assertion is the
+    // same: the escape is blocked.
+    expect(() =>
+      store['resolve']('..-evil', 'secret'),
+    ).toThrow(/Invalid agentId|Path traversal/);
+  });
+
+  it('rejects symlinks pointing outside the base directory', () => {
+    const baseDir = path.join(tmpDir, 'sandbox');
+    fs.mkdirSync(baseDir);
+    const agentDir = path.join(baseDir, 'agent-1');
+    fs.mkdirSync(agentDir);
+
+    const outside = path.join(tmpDir, 'outside');
+    fs.mkdirSync(outside);
+    fs.writeFileSync(path.join(outside, 'leak.txt'), 'sensitive');
+
+    // Plant a symlink: <base>/agent-1/escape -> <tmp>/outside
+    fs.symlinkSync(outside, path.join(agentDir, 'escape'));
+
+    const store = new FilesystemMemoryStore(baseDir);
+    expect(() => store['resolve']('agent-1', 'escape/leak.txt')).toThrow(
+      /symlink not allowed/,
+    );
+  });
+
+  it('rejects symlinks even when planted at the agent root level', () => {
+    const baseDir = path.join(tmpDir, 'sandbox');
+    fs.mkdirSync(baseDir);
+    fs.symlinkSync(tmpDir, path.join(baseDir, 'agent-2'));
+
+    const store = new FilesystemMemoryStore(baseDir);
+    expect(() => store['resolve']('agent-2', 'leak.txt')).toThrow(
+      /symlink not allowed/,
+    );
+  });
+
+  it('still allows ordinary paths under the base', () => {
+    const baseDir = path.join(tmpDir, 'sandbox');
+    const store = new FilesystemMemoryStore(baseDir);
+    // Should not throw; resolve() returns an absolute path inside baseDir.
+    const out = store['resolve']('agent-1', 'notes.md');
+    expect(out.startsWith(path.resolve(baseDir) + path.sep)).toBe(true);
+  });
+
+  it('canonicalises non-existent paths via deepest existing ancestor', () => {
+    // Fresh write: <base>/agent-1/never-existed/yet.txt. realpath would
+    // throw on this path; the helper walks up to the existing ancestor
+    // (baseDir, which exists), realpaths that, then re-appends the suffix.
+    const baseDir = path.join(tmpDir, 'sandbox');
+    const store = new FilesystemMemoryStore(baseDir);
+    expect(() => store['resolve']('agent-1', 'never-existed/yet.txt')).not.toThrow();
+  });
+});
+
+// ─── #30 M-06: agentId character validation ──────────────────────────────
+
+describe('M-06: validateAgentId guard at the store layer', () => {
+  it('rejects path-segment-like agentIds', () => {
+    expect(() => validateAgentId('../escape')).toThrow(/Invalid agentId/);
+    expect(() => validateAgentId('a/b')).toThrow(/Invalid agentId/);
+    expect(() => validateAgentId('a\\b')).toThrow(/Invalid agentId/);
+    expect(() => validateAgentId('with spaces')).toThrow(/Invalid agentId/);
+    expect(() => validateAgentId('with.dots')).toThrow(/Invalid agentId/);
+  });
+
+  it('accepts the conventional shape', () => {
+    expect(() => validateAgentId('alice-bot')).not.toThrow();
+    expect(() => validateAgentId('agent_007')).not.toThrow();
+    expect(() => validateAgentId('A1B2c3')).not.toThrow();
+  });
+
+  it('accepts the empty string (workspace-tools mode)', () => {
+    // createWorkspaceTools mounts file tools at the workspace root with
+    // agentId = '', meaning the store sees the whole workingDir.
+    expect(() => validateAgentId('')).not.toThrow();
+  });
+
+  it('rejects non-string input', () => {
+    expect(() => validateAgentId(undefined as unknown as string)).toThrow();
+    expect(() => validateAgentId(123 as unknown as string)).toThrow();
+  });
+
+  it('caps length at 64 characters', () => {
+    expect(() => validateAgentId('x'.repeat(65))).toThrow(/too long/);
+  });
+
+  it('FilesystemMemoryStore propagates the rejection', async () => {
+    const store = new FilesystemMemoryStore(tmpDir);
+    await expect(store.read('../escape', 'foo')).rejects.toThrow(
+      /Invalid agentId/,
+    );
+  });
+});
+
+// ─── #22 H-03: SavedAgentSchema validation in loadSavedAgent ──────────────
+
+describe('H-03: SavedAgentSchema validates loaded JSON', () => {
+  it('accepts a well-formed agent file', () => {
+    const valid = {
+      name: 'test',
+      provider: 'anthropic',
+      systemPrompt: 'Be helpful',
+      memoryDir: '.agent-do',
+      readOnly: false,
+      maxIterations: 20,
+      noTools: false,
+      createdAt: '2026-04-17T00:00:00Z',
+    };
+    expect(SavedAgentSchema.parse(valid).name).toBe('test');
+  });
+
+  it('rejects unknown provider', () => {
+    const r = SavedAgentSchema.safeParse({
+      name: 'x', provider: 'evil-corp', systemPrompt: '',
+      memoryDir: '.', readOnly: false, maxIterations: 1, noTools: false,
+      createdAt: '',
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects absolute memoryDir (would escape the project)', () => {
+    const r = SavedAgentSchema.safeParse({
+      name: 'x', provider: 'anthropic', systemPrompt: '',
+      memoryDir: '/etc', readOnly: false, maxIterations: 1, noTools: false,
+      createdAt: '',
+    });
+    expect(r.success).toBe(false);
+    expect(r.success ? '' : r.error.issues[0]?.message).toMatch(/relative/);
+  });
+
+  it('rejects memoryDir containing `..`', () => {
+    const r = SavedAgentSchema.safeParse({
+      name: 'x', provider: 'anthropic', systemPrompt: '',
+      memoryDir: 'foo/../etc', readOnly: false, maxIterations: 1, noTools: false,
+      createdAt: '',
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects oversize systemPrompt', () => {
+    const r = SavedAgentSchema.safeParse({
+      name: 'x', provider: 'anthropic', systemPrompt: 'a'.repeat(8193),
+      memoryDir: '.', readOnly: false, maxIterations: 1, noTools: false,
+      createdAt: '',
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects unknown fields (.strict)', () => {
+    const r = SavedAgentSchema.safeParse({
+      name: 'x', provider: 'anthropic', systemPrompt: '',
+      memoryDir: '.', readOnly: false, maxIterations: 1, noTools: false,
+      createdAt: '', extraField: 'planted',
+    });
+    expect(r.success).toBe(false);
+  });
+});
+
+describe('H-03: loadSavedAgent rejects invalid files at runtime', () => {
+  let agentsDir: string;
+  let originalCwd: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let stderrSpy: any;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    agentsDir = path.join(tmpDir, '.agent-do', 'agents');
+    fs.mkdirSync(agentsDir, { recursive: true });
+    process.chdir(tmpDir);
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+  afterEach(() => {
+    process.chdir(originalCwd);
+    stderrSpy.mockRestore();
+  });
+
+  it('returns null and warns on malformed JSON', async () => {
+    fs.writeFileSync(path.join(agentsDir, 'broken.json'), 'not json{{{');
+    const result = await loadSavedAgent('broken');
+    expect(result).toBeNull();
+    expect(stderrSpy).toHaveBeenCalled();
+    const writes = stderrSpy.mock.calls.map((c: unknown[]) => c[0] as string).join('');
+    expect(writes).toMatch(/malformed/);
+  });
+
+  it('returns null and warns when memoryDir is absolute', async () => {
+    fs.writeFileSync(path.join(agentsDir, 'planted.json'), JSON.stringify({
+      name: 'planted',
+      provider: 'anthropic',
+      systemPrompt: 'You are evil',
+      memoryDir: '/',
+      readOnly: false,
+      maxIterations: 100,
+      noTools: false,
+      createdAt: '',
+    }));
+    const result = await loadSavedAgent('planted');
+    expect(result).toBeNull();
+    const writes = stderrSpy.mock.calls.map((c: unknown[]) => c[0] as string).join('');
+    expect(writes).toMatch(/memoryDir/);
+  });
+
+  it('drops prototype-pollution keys before validation', async () => {
+    fs.writeFileSync(path.join(agentsDir, 'pp.json'), JSON.stringify({
+      name: 'pp',
+      provider: 'anthropic',
+      systemPrompt: '',
+      memoryDir: '.',
+      readOnly: false,
+      maxIterations: 1,
+      noTools: false,
+      createdAt: '',
+      __proto__: { polluted: 'yes' },
+    }));
+    // The __proto__ key gets dropped by the reviver, so the remainder
+    // is a valid SavedAgent and the load succeeds.
+    const result = await loadSavedAgent('pp');
+    expect(result).not.toBeNull();
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it('loads a well-formed agent file', async () => {
+    fs.writeFileSync(path.join(agentsDir, 'good.json'), JSON.stringify({
+      name: 'good',
+      provider: 'anthropic',
+      systemPrompt: 'Be helpful',
+      memoryDir: '.agent-do',
+      readOnly: false,
+      maxIterations: 20,
+      noTools: false,
+      createdAt: '',
+    }));
+    const result = await loadSavedAgent('good');
+    expect(result).not.toBeNull();
+    expect(result!.provider).toBe('anthropic');
+  });
+});
+
+// vi-spyOn import has to come after the describe blocks otherwise top-level
+// hoisting puts it before fs/path. Importing here to keep the file shape
+// consistent with the rest of the suite.
+import { vi } from 'vitest';

--- a/tests/trust-boundary.test.ts
+++ b/tests/trust-boundary.test.ts
@@ -18,7 +18,7 @@ afterEach(() => {
 // ─── #20 H-01: path traversal in FilesystemMemoryStore.resolve() ──────────────
 
 describe('H-01: path-traversal guards in FilesystemMemoryStore.resolve()', () => {
-  it('rejects sibling directory whose name shares the base prefix', () => {
+  it('rejects sibling directory whose name shares the base prefix', async () => {
     // Regression for the specific bug PR #64 fixed: the old check was
     // `resolved.startsWith(baseDir)` without a separator. Given
     // baseDir `<tmp>/agent`, a `../agent-evil/secret` traversal
@@ -36,12 +36,12 @@ describe('H-01: path-traversal guards in FilesystemMemoryStore.resolve()', () =>
     const store = new FilesystemMemoryStore(baseDir);
     // Valid agentId, traversal-shaped filePath: the filePath path of
     // the check is what has to catch this.
-    expect(() =>
+    await expect(
       store['resolve']('agent-1', '../../agent-evil/secret'),
-    ).toThrow(/Path traversal/);
+    ).rejects.toThrow(/Path traversal/);
   });
 
-  it('rejects symlinks pointing outside the base directory', () => {
+  it('rejects symlinks pointing outside the base directory', async () => {
     const baseDir = path.join(tmpDir, 'sandbox');
     fs.mkdirSync(baseDir);
     const agentDir = path.join(baseDir, 'agent-1');
@@ -55,12 +55,12 @@ describe('H-01: path-traversal guards in FilesystemMemoryStore.resolve()', () =>
     fs.symlinkSync(outside, path.join(agentDir, 'escape'));
 
     const store = new FilesystemMemoryStore(baseDir);
-    expect(() => store['resolve']('agent-1', 'escape/leak.txt')).toThrow(
-      /symlink not allowed/,
-    );
+    await expect(
+      store['resolve']('agent-1', 'escape/leak.txt'),
+    ).rejects.toThrow(/symlink not allowed/);
   });
 
-  it('rejects symlinks even when planted at the agent root level', () => {
+  it('rejects symlinks even when planted at the agent root level', async () => {
     const baseDir = path.join(tmpDir, 'sandbox');
     fs.mkdirSync(baseDir);
     fs.symlinkSync(tmpDir, path.join(baseDir, 'agent-2'));
@@ -71,27 +71,41 @@ describe('H-01: path-traversal guards in FilesystemMemoryStore.resolve()', () =>
     // error is "Path traversal not allowed (agentId)" rather than
     // the symlink-specific message. Either outcome is correct —
     // both block the escape.
-    expect(() => store['resolve']('agent-2', 'leak.txt')).toThrow(
-      /Path traversal|symlink not allowed/,
-    );
+    await expect(
+      store['resolve']('agent-2', 'leak.txt'),
+    ).rejects.toThrow(/Path traversal|symlink not allowed/);
   });
 
-  it('still allows ordinary paths under the base', () => {
+  it('still allows ordinary paths under the base', async () => {
     const baseDir = path.join(tmpDir, 'sandbox');
     const store = new FilesystemMemoryStore(baseDir);
     // Should not throw; resolve() returns an absolute path inside baseDir.
-    // Use `realpathSafe` on baseDir (via fs.realpathSync when it exists)
-    // because macOS /var -> /private/var symlinks cause `path.resolve`
-    // to disagree with the resolve() output once we canonicalise
-    // everything (PR #64 fix). The relative-path check is robust to
+    // Use realpath on baseDir because macOS /var -> /private/var symlinks
+    // cause `path.resolve` to disagree with the resolve() output once
+    // we canonicalise everything. The relative-path check is robust to
     // the indirection.
-    const out = store['resolve']('agent-1', 'notes.md');
+    const out = await store['resolve']('agent-1', 'notes.md');
     const rel = path.relative(fs.realpathSync(baseDir), out);
     expect(rel).not.toMatch(/^\.\./);
     expect(path.isAbsolute(rel)).toBe(false);
   });
 
-  it('rejects cross-agent traversal (PR #64 Copilot)', () => {
+  it('allows child names that start with `..` (Codex #64 follow-up)', async () => {
+    // `..cache` and `..notes` are valid child dirs — the old
+    // `rel.startsWith('..')` check rejected them as traversal. The
+    // fixed check only matches `..` exactly or followed by a path
+    // separator.
+    const baseDir = path.join(tmpDir, 'sandbox');
+    const store = new FilesystemMemoryStore(baseDir);
+    await expect(
+      store['resolve']('agent-1', '..cache/file.txt'),
+    ).resolves.toMatch(/\.\.cache/);
+    await expect(
+      store['resolve']('agent-1', '..notes'),
+    ).resolves.toMatch(/\.\.notes/);
+  });
+
+  it('rejects cross-agent traversal (PR #64 Copilot)', async () => {
     // `filePath = "../a2/secret"` resolves to a path inside baseDir
     // but outside the requesting agent's own directory. The fixed
     // resolve() checks containment against agentDir, not baseDir.
@@ -102,12 +116,12 @@ describe('H-01: path-traversal guards in FilesystemMemoryStore.resolve()', () =>
     fs.writeFileSync(path.join(a2, 'secret'), 'tenant-2');
 
     const store = new FilesystemMemoryStore(baseDir);
-    expect(() =>
+    await expect(
       store['resolve']('a1', '../a2/secret'),
-    ).toThrow(/Path traversal/);
+    ).rejects.toThrow(/Path traversal/);
   });
 
-  it('handles a symlinked baseDir (Codex #64 P2)', () => {
+  it('handles a symlinked baseDir (Codex #64 P2)', async () => {
     // baseDir itself is a symlink. The earlier fix canonicalised the
     // target but not the base, so every in-base path failed `withinBase`
     // because the realpath landed on a different string than the raw
@@ -119,30 +133,32 @@ describe('H-01: path-traversal guards in FilesystemMemoryStore.resolve()', () =>
 
     const store = new FilesystemMemoryStore(linkedBase);
     // Normal read/write through a linked base must not throw.
-    expect(() => store['resolve']('a1', 'notes.md')).not.toThrow();
+    await expect(
+      store['resolve']('a1', 'notes.md'),
+    ).resolves.toBeTypeOf('string');
   });
 
-  it('handles a filesystem-root baseDir (PR #64 Copilot)', () => {
+  it('handles a filesystem-root baseDir (PR #64 Copilot)', async () => {
     // When base is `/` (or a Windows drive root), `base + sep` becomes
     // `//` — the old naive startsWith would reject every legitimate
     // path. The `path.relative`-based `withinBase` handles this.
     // We can't actually test with `/` in a sandboxed test, but we can
-    // test the helper via a base that IS its own filesystem root
-    // segment: `tmpDir` already has a root ancestor, so use that.
-    // Easier: construct a store at tmpDir and just verify a resolve
-    // under it works — the root case is proven by withinBase's
-    // path.relative implementation (no startsWith(base + sep) anywhere).
+    // at least verify the helper works at tmpDir without issue.
     const store = new FilesystemMemoryStore(tmpDir);
-    expect(() => store['resolve']('a1', 'notes.md')).not.toThrow();
+    await expect(
+      store['resolve']('a1', 'notes.md'),
+    ).resolves.toBeTypeOf('string');
   });
 
-  it('canonicalises non-existent paths via deepest existing ancestor', () => {
+  it('canonicalises non-existent paths via deepest existing ancestor', async () => {
     // Fresh write: <base>/agent-1/never-existed/yet.txt. realpath would
     // throw on this path; the helper walks up to the existing ancestor
     // (baseDir, which exists), realpaths that, then re-appends the suffix.
     const baseDir = path.join(tmpDir, 'sandbox');
     const store = new FilesystemMemoryStore(baseDir);
-    expect(() => store['resolve']('agent-1', 'never-existed/yet.txt')).not.toThrow();
+    await expect(
+      store['resolve']('agent-1', 'never-existed/yet.txt'),
+    ).resolves.toBeTypeOf('string');
   });
 });
 


### PR DESCRIPTION
Three related trust-boundary issues, grouped because fixing one in isolation leaves the class of escape open through the others.

## Summary
- **#20 (H-01)** — `FilesystemMemoryStore.resolve()` fixed two escape vectors: the `startsWith(baseDir)` check now uses `path.sep` (so `/data/agent-evil` can't masquerade as a child of `/data/agent`), and symlinks are now canonicalised via `realpathSync`, with a helper that walks to the deepest existing ancestor so fresh writes still work.
- **#30 (M-06)** — `validateAgentId` now runs on every `resolve()` call, not just at the CLI layer. Prevents library callers from plumbing user input straight into a per-agent subdir escape. Empty string still allowed for `createWorkspaceTools` workspace-root mode.
- **#22 (H-03)** — `loadSavedAgent` validates JSON through a strict Zod schema. Provider is now an enum, `memoryDir` rejects absolute paths or `..` segments, `systemPrompt` is capped at 8 KB, and `.strict()` rejects unknown keys. A `JSON.parse` reviver drops `__proto__`/`constructor`/`prototype` at any depth as defence-in-depth. `createSavedAgent` round-trips the same schema so writes match reads.

## Test plan
- [x] 21 new tests in `tests/trust-boundary.test.ts` covering all three findings
- [x] Full suite: 450 passing (was 429)
- [x] `npm run build` clean

Closes #20
Closes #22
Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)