### PR TITLE
[C-03] Gate script-file import behind --script flag (closes #19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,10 @@ npx agent-do run code-reviewer "Review this function"
 # List saved agents
 npx agent-do list
 
-# Run a custom agent script (.js files, or .ts with tsx loader)
-npx agent-do run my-agent.js "Do something"
+# Run a custom agent script (.js/.mjs/.cjs/.ts files).
+# --script is required to import local JavaScript/TypeScript; see
+# "Script mode" below for the security reasoning.
+npx agent-do run ./my-agent.ts --script "Do something"
 
 # Run eval cases
 npx agent-do eval evals/basic.ts
@@ -131,7 +133,7 @@ npx agent-do eval evals/ --compare anthropic,google,openai --output json
 
 ```
 npx agent-do [options] [prompt]          One-shot or interactive
-npx agent-do run <file> [task]           Run agent script
+npx agent-do run <name|file> [task]      Run a saved agent OR a script file
 npx agent-do eval <file|dir> [options]   Run evals
 
 Options:
@@ -148,11 +150,44 @@ Options:
   --no-tools             Disable all file tools
   --verbose              Show per-step thinking + tool summaries (stderr)
   --show-content         With --verbose: also include each tool's full result
+  --script               Required for `run <path>` to import local JS/TS files
+  -y, --yes              Skip the interactive confirmation for --script
   --json                 JSON output
   --output <fmt>         console | json | csv (eval only)
   --compare <providers>  Compare providers (eval only, comma-separated)
   --concurrency <n>      Parallel eval cases (default: 1)
 ```
+
+### Script mode: `run <path> --script`
+
+`agent-do run <arg>` resolves saved-agent names by default. To run a
+local JavaScript or TypeScript file as an agent, pass `--script`
+explicitly:
+
+```bash
+npx agent-do run ./my-agent.ts --script "Do something"
+```
+
+Importing an arbitrary JS/TS file runs its top-level code with your
+user privileges — the same trust model as running any local script.
+The `--script` flag is a deliberate speed bump so that:
+
+- A missed saved-agent lookup (typo, stale name) fails with a clear
+  error instead of silently `import()`-ing a stray file that happens
+  to match the name.
+- Social-engineering vectors like "download this helper script, then
+  run `agent-do run helper.js`" require an explicit opt-in.
+
+When `--script` is passed:
+
+- The path must point inside `--cwd` (symlinks and `..` escapes are
+  rejected after canonicalisation).
+- Only `.js`/`.mjs`/`.cjs`/`.ts`/`.mts`/`.cts` extensions are allowed.
+- The file must be a regular file (no directories, no special files).
+- A banner prints the path, size, and SHA-256 prefix, then asks
+  `Continue? [y/N]`. Pass `-y`/`--yes` to skip the prompt (required
+  in non-TTY contexts — CI, piped input — since there's nowhere to
+  type the answer).
 
 ### Tools: workspace vs memory
 

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -42,6 +42,18 @@ export interface ParsedArgs {
   output: 'console' | 'json' | 'csv';
   compare?: string[];
   concurrency: number;
+  /**
+   * Opt-in for script-file import (#19, C-03). Without this flag, `run
+   * <path>` refuses to `await import()` a local file. Only saved-agent
+   * names are accepted unless the user explicitly says "yes I know what
+   * I'm doing, run arbitrary code from this path."
+   */
+  script: boolean;
+  /**
+   * Skip interactive confirmation when `--script` is passed. Required for
+   * non-TTY contexts (CI, shell piping) that can't prompt.
+   */
+  yes: boolean;
 }
 
 /**
@@ -69,6 +81,8 @@ export function parseArgs(argv: string[]): ParsedArgs {
     includeSensitive: false,
     output: 'console',
     concurrency: 1,
+    script: false,
+    yes: false,
   };
 
   const positional: string[] = [];
@@ -148,6 +162,10 @@ export function parseArgs(argv: string[]): ParsedArgs {
       if (isNaN(args.concurrency) || args.concurrency < 1) {
         throw new Error('--concurrency must be a positive integer');
       }
+    } else if (arg === '--script') {
+      args.script = true;
+    } else if (arg === '-y' || arg === '--yes') {
+      args.yes = true;
     } else if (arg.startsWith('-')) {
       throw new Error(`Unknown option: ${arg}. Use --help for usage.`);
     } else {

--- a/src/cli/script.ts
+++ b/src/cli/script.ts
@@ -80,6 +80,25 @@ function looksLikeScriptPath(arg: string): boolean {
  * checks for `--yes` in that case, so reaching here without a TTY means
  * the user passed `--script` but not `--yes` over a pipe.
  */
+/**
+ * Hard cap on a script file before we'll hash it for the confirmation
+ * banner. Per-PR-#66 Copilot: reading the whole file into memory just
+ * to compute a SHA-256 is wasteful for large files; cap at a safe
+ * upper bound and stream the hash instead of buffering.
+ */
+const SCRIPT_MAX_SIZE = 2 * 1024 * 1024; // 2 MB
+
+async function hashFileStreaming(filePath: string): Promise<string> {
+  const hasher = createHash('sha256');
+  const stream = fs.createReadStream(filePath);
+  await new Promise<void>((resolve, reject) => {
+    stream.on('data', (chunk) => hasher.update(chunk as Buffer));
+    stream.on('end', () => resolve());
+    stream.on('error', reject);
+  });
+  return hasher.digest('hex').slice(0, 16);
+}
+
 async function confirmScriptImport(filePath: string): Promise<boolean> {
   if (!process.stdin.isTTY || !process.stdout.isTTY) {
     process.stderr.write(
@@ -88,8 +107,17 @@ async function confirmScriptImport(filePath: string): Promise<boolean> {
     return false;
   }
   const stat = await fs.promises.stat(filePath);
-  const content = await fs.promises.readFile(filePath);
-  const sha = createHash('sha256').update(content).digest('hex').slice(0, 16);
+  if (stat.size > SCRIPT_MAX_SIZE) {
+    process.stderr.write(
+      `[agent-do] Refusing script import: file is ${stat.size} bytes, limit is ${SCRIPT_MAX_SIZE}. ` +
+      `A script this large is almost certainly not an agent definition.\n`,
+    );
+    return false;
+  }
+  // Stream the SHA-256 rather than buffering the whole file. Lets the
+  // banner appear quickly on a 1 MB script instead of waiting for a
+  // full readFile round trip.
+  const sha = await hashFileStreaming(filePath);
   process.stderr.write(
     `[agent-do] About to import and execute a local script:\n` +
     `           path:   ${filePath}\n` +
@@ -112,29 +140,83 @@ async function confirmScriptImport(filePath: string): Promise<boolean> {
 }
 
 /**
+ * True iff `candidate` is the same as, or strictly inside, `base`.
+ * Uses `path.relative` so the check handles filesystem roots correctly
+ * (Codex #66 P2: `cwd === "/"` made the old `startsWith(cwd + sep)`
+ * check compose `"//"` and reject every legit path). A sibling whose
+ * name shares the base prefix also returns a relative path starting
+ * with `..` and is rejected.
+ */
+function withinCwd(candidate: string, base: string): boolean {
+  if (candidate === base) return true;
+  const rel = path.relative(base, candidate);
+  if (rel === '' || rel === '.') return true;
+  if (rel.startsWith('..')) return false;
+  return !path.isAbsolute(rel);
+}
+
+/**
  * Resolve, validate, and import a script path. Throws with a specific
  * error on each failure mode so tests can distinguish them.
  *
- * The containment check compares `resolvedPath` against
- * `cwd + path.sep` (not bare `startsWith`) so a sibling whose name shares
- * the cwd prefix (`/work/project` vs `/work/project-evil`) can't slip
- * through. Same logic as `FilesystemMemoryStore.withinBase` (#20).
+ * - Canonicalises the target via `fs.realpath` before the cwd-containment
+ *   check, so a `./trusted.mjs` that's actually a symlink to
+ *   `../outside.mjs` is detected and refused (Codex #66 P2).
+ * - `withinCwd` uses `path.relative` rather than a naive `startsWith`
+ *   so filesystem-root cwds (`/` on POSIX, `C:\` on Windows) don't
+ *   reject every legit child.
+ * - Requires the target to be a regular file (`stat().isFile()`).
+ *   `access(R_OK)` would also accept a readable directory or special
+ *   file, deferring the error to a confusing point inside `import()`.
  */
 export async function importScriptFile(
   rawPath: string,
   opts: { yes: boolean },
 ): Promise<Record<string, unknown>> {
-  const filePath = path.resolve(rawPath);
-  const cwd = path.resolve(process.cwd());
-  if (filePath !== cwd && !filePath.startsWith(cwd + path.sep)) {
+  const requested = path.resolve(rawPath);
+  // Canonicalise cwd too (macOS /var -> /private/var, etc.) so both
+  // sides of any comparison are realpathed — same canonical-vs-canonical
+  // invariant as the FilesystemMemoryStore trust-boundary fix (#64).
+  const cwd = await fs.promises.realpath(process.cwd());
+
+  // Fast-fail containment check on the non-canonical path. Catches the
+  // common `../escape.js` case (where the target doesn't exist) with a
+  // clear error before we try to realpath a non-existent file.
+  if (!withinCwd(requested, cwd)) {
+    throw new Error(
+      `Refusing to import "${requested}": path is outside the working directory (${cwd}).`,
+    );
+  }
+
+  // Now canonicalise the target to detect the symlink-escape case:
+  // `./trusted.mjs` points inside cwd string-wise but the symlink
+  // target is outside. If the path doesn't exist, realpath throws
+  // ENOENT — translate to the friendlier "not found" message.
+  let filePath: string;
+  try {
+    filePath = await fs.promises.realpath(requested);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new Error(`Script not found: ${requested}`);
+    }
+    throw err;
+  }
+  if (!withinCwd(filePath, cwd)) {
     throw new Error(
       `Refusing to import "${filePath}": path is outside the working directory (${cwd}).`,
     );
   }
+
+  let stat: fs.Stats;
   try {
-    await fs.promises.access(filePath, fs.constants.R_OK);
+    stat = await fs.promises.stat(filePath);
   } catch {
     throw new Error(`Script not found or unreadable: ${filePath}`);
+  }
+  if (!stat.isFile()) {
+    throw new Error(
+      `Refusing to import "${filePath}": not a regular file (is it a directory or special file?).`,
+    );
   }
   if (!SCRIPT_EXTENSIONS.test(filePath)) {
     throw new Error(

--- a/src/cli/script.ts
+++ b/src/cli/script.ts
@@ -169,29 +169,61 @@ function withinCwd(candidate: string, base: string): boolean {
  *   `access(R_OK)` would also accept a readable directory or special
  *   file, deferring the error to a confusing point inside `import()`.
  */
+/**
+ * Canonicalise the deepest existing ancestor of `p` and re-append the
+ * unresolved suffix. Used for the fast-fail containment check so we
+ * compare canonical-to-canonical even when the leaf doesn't exist.
+ *
+ * Codex follow-up on PR #66: without this, the shell cwd is realpathed
+ * (`/private/var/tmp/...` on macOS) while `requested` stays at
+ * `/var/tmp/...`, producing spurious "outside working directory"
+ * rejections for safe scripts. This mirrors the `realpathSafe` helper
+ * in `FilesystemMemoryStore` (#64).
+ */
+async function realpathSafe(p: string): Promise<string> {
+  let suffix = '';
+  let current = p;
+  // Walk up until realpath succeeds. `access` is cheaper than realpath
+  // for a negative check, and its ENOENT behaviour matches ours.
+  while (true) {
+    try {
+      const canonical = await fs.promises.realpath(current);
+      return suffix ? path.join(canonical, suffix) : canonical;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+      const parent = path.dirname(current);
+      if (parent === current) return p; // hit root without resolving
+      suffix = path.join(path.basename(current), suffix);
+      current = parent;
+    }
+  }
+}
+
 export async function importScriptFile(
   rawPath: string,
   opts: { yes: boolean },
 ): Promise<Record<string, unknown>> {
   const requested = path.resolve(rawPath);
   // Canonicalise cwd too (macOS /var -> /private/var, etc.) so both
-  // sides of any comparison are realpathed — same canonical-vs-canonical
+  // sides of the comparison are realpathed — same canonical-vs-canonical
   // invariant as the FilesystemMemoryStore trust-boundary fix (#64).
   const cwd = await fs.promises.realpath(process.cwd());
 
-  // Fast-fail containment check on the non-canonical path. Catches the
-  // common `../escape.js` case (where the target doesn't exist) with a
-  // clear error before we try to realpath a non-existent file.
-  if (!withinCwd(requested, cwd)) {
+  // Canonicalise the *ancestors* of `requested` so the fast-fail
+  // containment check also compares canonical-to-canonical. Without
+  // this the check rejects valid in-tree scripts when the shell cwd
+  // is a symlink path (Codex #66 follow-up).
+  const canonicalRequested = await realpathSafe(requested);
+  if (!withinCwd(canonicalRequested, cwd)) {
     throw new Error(
       `Refusing to import "${requested}": path is outside the working directory (${cwd}).`,
     );
   }
 
-  // Now canonicalise the target to detect the symlink-escape case:
-  // `./trusted.mjs` points inside cwd string-wise but the symlink
-  // target is outside. If the path doesn't exist, realpath throws
-  // ENOENT — translate to the friendlier "not found" message.
+  // Now canonicalise the target fully to detect the symlink-escape
+  // case: `./trusted.mjs` points inside cwd string-wise but the
+  // symlink target is outside. If the path doesn't exist, realpath
+  // throws ENOENT — translate to the friendlier "not found" message.
   let filePath: string;
   try {
     filePath = await fs.promises.realpath(requested);

--- a/src/cli/script.ts
+++ b/src/cli/script.ts
@@ -11,9 +11,29 @@
  * Note: .ts files require a TypeScript loader (tsx, ts-node).
  * Run with: npx tsx node_modules/.bin/agent-do run script.ts
  * Or use compiled .js files directly.
+ *
+ * ## Security (#19, C-03)
+ *
+ * Importing an arbitrary JS/TS file runs its top-level code with the
+ * Node.js process's full privileges. Previously the dispatcher silently
+ * fell back from saved-agent lookup to `await import()` on any positional
+ * — a social-engineering vector ("run this helper script") and a
+ * saved-agent name collision risk. The current behaviour:
+ *
+ * 1. Positionals that look like a saved-agent name (identifier-shaped,
+ *    no slashes, no JS extension) resolve ONLY via saved agents. If the
+ *    lookup misses, fail closed with a clear error — never attempt to
+ *    import.
+ * 2. Positionals that look like a path (start with `./`, `../`, `/`, or
+ *    end in `.js`/`.mjs`/`.cjs`/`.ts`/`.mts`/`.cts`) require the explicit
+ *    `--script` flag, must be inside cwd, and prompt the user for
+ *    confirmation (skip with `-y`/`--yes`, refuse in non-TTY without `-y`).
  */
 
+import * as fs from 'node:fs';
 import * as path from 'node:path';
+import * as readline from 'node:readline';
+import { createHash } from 'node:crypto';
 import { pathToFileURL } from 'node:url';
 import type { ParsedArgs } from './args.js';
 import { readStdin } from './args.js';
@@ -28,28 +48,133 @@ import { FilesystemMemoryStore } from '../stores/filesystem.js';
 import type { Agent } from '../types.js';
 import type { ToolSet } from 'ai';
 
+/**
+ * Extensions that identify a positional as a script path rather than a
+ * saved-agent name. Kept narrow on purpose — anything not in this list
+ * falls through to the saved-agent branch, which errors cleanly if the
+ * name is unknown.
+ */
+const SCRIPT_EXTENSIONS = /\.(?:m?js|cjs|mts|cts|ts)$/i;
+
+/**
+ * `true` when the positional unambiguously refers to a filesystem path.
+ *
+ * The rule is conservative: explicit path prefixes (`./`, `../`, `/`,
+ * Windows drive letters) OR a JS/TS extension. This lets saved-agent
+ * names stay as short identifiers like `security-reviewer` and avoids
+ * the old footgun where a positional with an unknown name silently fell
+ * through to `await import()`.
+ */
+function looksLikeScriptPath(arg: string): boolean {
+  if (arg.startsWith('./') || arg.startsWith('../') || arg.startsWith('/')) {
+    return true;
+  }
+  // Windows absolute path: `C:\...` or `C:/...`.
+  if (/^[a-zA-Z]:[\\/]/.test(arg)) return true;
+  return SCRIPT_EXTENSIONS.test(arg);
+}
+
+/**
+ * Prompt the user to confirm a script import. Returns `true` on `y`/`yes`
+ * (case-insensitive). Refuses to run in non-TTY mode — the caller already
+ * checks for `--yes` in that case, so reaching here without a TTY means
+ * the user passed `--script` but not `--yes` over a pipe.
+ */
+async function confirmScriptImport(filePath: string): Promise<boolean> {
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    process.stderr.write(
+      `[agent-do] --script needs interactive confirmation. Pass -y/--yes to run non-interactively.\n`,
+    );
+    return false;
+  }
+  const stat = await fs.promises.stat(filePath);
+  const content = await fs.promises.readFile(filePath);
+  const sha = createHash('sha256').update(content).digest('hex').slice(0, 16);
+  process.stderr.write(
+    `[agent-do] About to import and execute a local script:\n` +
+    `           path:   ${filePath}\n` +
+    `           size:   ${stat.size} bytes\n` +
+    `           sha256: ${sha}…\n` +
+    `           This will run arbitrary JavaScript with your user privileges.\n`,
+  );
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stderr,
+  });
+  try {
+    const answer: string = await new Promise((resolve) => {
+      rl.question('[agent-do] Continue? [y/N] ', resolve);
+    });
+    return /^y(es)?$/i.test(answer.trim());
+  } finally {
+    rl.close();
+  }
+}
+
+/**
+ * Resolve, validate, and import a script path. Throws with a specific
+ * error on each failure mode so tests can distinguish them.
+ *
+ * The containment check compares `resolvedPath` against
+ * `cwd + path.sep` (not bare `startsWith`) so a sibling whose name shares
+ * the cwd prefix (`/work/project` vs `/work/project-evil`) can't slip
+ * through. Same logic as `FilesystemMemoryStore.withinBase` (#20).
+ */
+export async function importScriptFile(
+  rawPath: string,
+  opts: { yes: boolean },
+): Promise<Record<string, unknown>> {
+  const filePath = path.resolve(rawPath);
+  const cwd = path.resolve(process.cwd());
+  if (filePath !== cwd && !filePath.startsWith(cwd + path.sep)) {
+    throw new Error(
+      `Refusing to import "${filePath}": path is outside the working directory (${cwd}).`,
+    );
+  }
+  try {
+    await fs.promises.access(filePath, fs.constants.R_OK);
+  } catch {
+    throw new Error(`Script not found or unreadable: ${filePath}`);
+  }
+  if (!SCRIPT_EXTENSIONS.test(filePath)) {
+    throw new Error(
+      `Refusing to import "${filePath}": only .js/.mjs/.cjs/.ts/.mts/.cts files are allowed.`,
+    );
+  }
+  if (!opts.yes) {
+    const ok = await confirmScriptImport(filePath);
+    if (!ok) throw new Error('Aborted by user.');
+  }
+  return (await import(pathToFileURL(filePath).href)) as Record<string, unknown>;
+}
+
 export async function runScriptMode(args: ParsedArgs): Promise<void> {
   if (!args.file) {
     throw new Error('Usage: npx agent-do run <file-or-agent-name> [task]');
   }
 
-  // First try loading as a saved agent name
-  const saved = await loadSavedAgent(args.file);
-  if (saved) {
-    return runSavedAgent(saved, args);
-  }
-
-  // Otherwise try loading as a file
-  const filePath = path.resolve(args.file);
-  let mod: Record<string, unknown>;
-  try {
-    // Use file URL for cross-platform compatibility (Windows paths)
-    mod = await import(pathToFileURL(filePath).href);
-  } catch (err) {
+  // Disambiguate path-vs-name *first*. Previously we tried saved-agent
+  // lookup, and on miss silently fell back to `import()` — letting a
+  // stray `.js` file in cwd masquerade as a saved agent and run before
+  // any permission check. Split explicit, fail closed.
+  if (!looksLikeScriptPath(args.file)) {
+    const saved = await loadSavedAgent(args.file);
+    if (saved) return runSavedAgent(saved, args);
     throw new Error(
-      `No saved agent "${args.file}" found, and failed to import as file: ${err instanceof Error ? err.message : String(err)}`,
+      `No saved agent "${args.file}" found. If you meant to run a script file, ` +
+      `use a path (e.g. ./agent.ts) and pass --script.`,
     );
   }
+
+  if (!args.script) {
+    throw new Error(
+      `Refusing to import "${args.file}": running a local JS/TS file with agent-do ` +
+      `requires --script (it executes arbitrary code with your privileges). ` +
+      `Re-run with --script (adds an interactive confirmation) or --script -y to skip it.`,
+    );
+  }
+
+  const mod = await importScriptFile(args.file, { yes: args.yes });
 
   const exported = (mod.default ?? mod) as Record<string, unknown>;
 

--- a/tests/cli-render.test.ts
+++ b/tests/cli-render.test.ts
@@ -22,6 +22,8 @@ function makeArgs(overrides: Partial<ParsedArgs> = {}): ParsedArgs {
     includeSensitive: false,
     output: 'console',
     concurrency: 1,
+    script: false,
+    yes: false,
     ...overrides,
   };
 }

--- a/tests/script-import.test.ts
+++ b/tests/script-import.test.ts
@@ -148,7 +148,33 @@ describe('importScriptFile', () => {
   it('rejects a non-existent file', async () => {
     await expect(
       importScriptFile('./missing.js', { yes: true }),
-    ).rejects.toThrow(/not found or unreadable/);
+    ).rejects.toThrow(/not found/);
+  });
+
+  it('rejects a symlink pointing outside cwd (Codex #66 P2)', async () => {
+    // Plant a file outside cwd, symlink it into cwd with a trusted-
+    // looking name. `path.resolve(rawPath)` stays inside cwd (the
+    // symlink path is inside) but realpath reveals the escape.
+    const outside = path.join(os.tmpdir(), `agent-do-escape-${process.pid}.mjs`);
+    fs.writeFileSync(outside, "export default { pwned: true };\n");
+    try {
+      fs.symlinkSync(outside, path.join(tmpDir, 'trusted.mjs'));
+      await expect(
+        importScriptFile('./trusted.mjs', { yes: true }),
+      ).rejects.toThrow(/outside the working directory/);
+    } finally {
+      fs.rmSync(outside, { force: true });
+    }
+  });
+
+  it('rejects a directory that has a script-like extension (isFile check)', async () => {
+    // With isFile() we reject directories explicitly. The old R_OK
+    // check would have passed a readable directory and then produced
+    // a less clear error at import time.
+    fs.mkdirSync(path.join(tmpDir, 'fake.mjs'));
+    await expect(
+      importScriptFile('./fake.mjs', { yes: true }),
+    ).rejects.toThrow(/not a regular file/);
   });
 
   it('rejects a disallowed extension', async () => {

--- a/tests/script-import.test.ts
+++ b/tests/script-import.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { parseArgs } from '../src/cli/args.js';
+import { runScriptMode, importScriptFile } from '../src/cli/script.js';
+import type { ParsedArgs } from '../src/cli/args.js';
+
+// ─── #19 C-03: CLI flag surface ──────────────────────────────────────────
+
+describe('parseArgs: --script and --yes', () => {
+  it('defaults both to false', () => {
+    const args = parseArgs([]);
+    expect(args.script).toBe(false);
+    expect(args.yes).toBe(false);
+  });
+
+  it('parses --script', () => {
+    const args = parseArgs(['run', './a.ts', '--script']);
+    expect(args.script).toBe(true);
+  });
+
+  it('parses --yes and -y', () => {
+    expect(parseArgs(['run', './a.ts', '--yes']).yes).toBe(true);
+    expect(parseArgs(['run', './a.ts', '-y']).yes).toBe(true);
+  });
+});
+
+// ─── #19 C-03: path-vs-name disambiguation ──────────────────────────────
+
+function baseArgs(overrides: Partial<ParsedArgs> = {}): ParsedArgs {
+  return {
+    command: 'run',
+    provider: 'anthropic',
+    systemPrompt: '',
+    workingDir: process.cwd(),
+    memoryDir: '.agent-do',
+    withMemory: false,
+    readOnly: false,
+    maxIterations: 20,
+    noTools: true, // keep the sandbox tight in tests
+    verbose: false,
+    showContent: false,
+    json: false,
+    help: false,
+    exclude: [],
+    includeSensitive: false,
+    output: 'console',
+    concurrency: 1,
+    script: false,
+    yes: false,
+    ...overrides,
+  };
+}
+
+describe('runScriptMode dispatcher', () => {
+  let tmpDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-do-script-'));
+    process.chdir(tmpDir);
+  });
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('treats saved-agent-shaped names as saved agents, not scripts', async () => {
+    // No saved agent exists and no file either — must fail with the
+    // saved-agent error, *not* fall through to an import attempt.
+    await expect(
+      runScriptMode(baseArgs({ file: 'nonexistent-agent' })),
+    ).rejects.toThrow(/No saved agent "nonexistent-agent"/);
+  });
+
+  it('refuses to import a script path without --script', async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'evil.js'),
+      "throw new Error('should never import');",
+    );
+    await expect(
+      runScriptMode(baseArgs({ file: './evil.js' })),
+    ).rejects.toThrow(/requires --script/);
+  });
+
+  it('refuses a script outside cwd even with --script', async () => {
+    // Relative path that escapes cwd.
+    await expect(
+      runScriptMode(
+        baseArgs({ file: '../escape.js', script: true, yes: true }),
+      ),
+    ).rejects.toThrow(/outside the working directory/);
+  });
+
+  it('refuses an extension that isn\'t in the allowlist', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'evil.sh'), 'echo pwn');
+    // `.sh` is not a script extension — the dispatcher falls through to
+    // the saved-agent branch because it doesn't look like a path *nor*
+    // a script extension... except it *does* start with `./`. Which
+    // means it hits the --script gate first.
+    await expect(
+      runScriptMode(
+        baseArgs({ file: './evil.sh', script: true, yes: true }),
+      ),
+    ).rejects.toThrow(/only .* files are allowed/);
+  });
+
+  it('does not attempt to import when saved-agent lookup fails (no silent fallback)', async () => {
+    // Plant a file named `security-reviewer.js` in cwd — the old code
+    // path would import it after the saved-agent lookup missed. The
+    // fix leaves the saved-agent branch alone because `security-reviewer`
+    // doesn't look like a path.
+    const planted = path.join(tmpDir, 'security-reviewer.js');
+    fs.writeFileSync(
+      planted,
+      "throw new Error('silent fallback import happened!');",
+    );
+    await expect(
+      runScriptMode(baseArgs({ file: 'security-reviewer' })),
+    ).rejects.toThrow(/No saved agent/);
+  });
+});
+
+// ─── #19 C-03: importScriptFile unit coverage ───────────────────────────
+
+describe('importScriptFile', () => {
+  let tmpDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-do-import-'));
+    process.chdir(tmpDir);
+  });
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('rejects a path escaping cwd via ../', async () => {
+    await expect(
+      importScriptFile('../outside.js', { yes: true }),
+    ).rejects.toThrow(/outside the working directory/);
+  });
+
+  it('rejects a non-existent file', async () => {
+    await expect(
+      importScriptFile('./missing.js', { yes: true }),
+    ).rejects.toThrow(/not found or unreadable/);
+  });
+
+  it('rejects a disallowed extension', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'nope.txt'), 'data');
+    await expect(
+      importScriptFile('./nope.txt', { yes: true }),
+    ).rejects.toThrow(/only .* files are allowed/);
+  });
+
+  it('imports a valid .mjs file with --yes', async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'good.mjs'),
+      'export default { name: "from-script", ok: true };\n',
+    );
+    const mod = await importScriptFile('./good.mjs', { yes: true });
+    expect((mod.default as Record<string, unknown>).ok).toBe(true);
+    expect((mod.default as Record<string, unknown>).name).toBe('from-script');
+  });
+
+  it('refuses in non-TTY context without --yes', async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'a.mjs'),
+      'export default { name: "x" };\n',
+    );
+    // vitest runs non-interactively; stdin is not a TTY. Without --yes,
+    // confirmScriptImport returns false and importScriptFile throws.
+    // Mock stdin.isTTY to guarantee non-TTY semantics regardless of env.
+    const originalIsTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: false,
+      configurable: true,
+    });
+    const stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .mockImplementation(() => true) as any;
+    try {
+      await expect(
+        importScriptFile('./a.mjs', { yes: false }),
+      ).rejects.toThrow(/Aborted by user/);
+    } finally {
+      Object.defineProperty(process.stdin, 'isTTY', {
+        value: originalIsTTY,
+        configurable: true,
+      });
+      stderrSpy.mockRestore();
+    }
+  });
+});

--- a/tests/script-import.test.ts
+++ b/tests/script-import.test.ts
@@ -151,6 +151,42 @@ describe('importScriptFile', () => {
     ).rejects.toThrow(/not found/);
   });
 
+  it('accepts a legit script when cwd is reached via a symlink (Codex #66 follow-up)', async () => {
+    // Codex re-review on #66: if the shell cwd is a symlink path
+    // (e.g. `/var/...` on macOS, which realpath resolves to
+    // `/private/var/...`), the fast-fail containment check used to
+    // compare non-canonical `requested` against canonical `cwd` and
+    // reject every legit script. The realpathSafe-based fix
+    // canonicalises ancestors of `requested` too.
+    const linkedRoot = path.join(os.tmpdir(), `agent-do-linked-${process.pid}`);
+    // Skip gracefully if we can't create a symlink (e.g. in a CI
+    // sandbox that forbids it); no point in a flaky test.
+    try {
+      fs.symlinkSync(tmpDir, linkedRoot);
+    } catch {
+      return;
+    }
+    try {
+      const originalCwdLocal = process.cwd();
+      fs.writeFileSync(
+        path.join(tmpDir, 'legit.mjs'),
+        'export default { ok: true };\n',
+      );
+      try {
+        process.chdir(linkedRoot);
+        const mod = await importScriptFile('./legit.mjs', { yes: true });
+        expect((mod.default as Record<string, unknown>).ok).toBe(true);
+      } finally {
+        process.chdir(originalCwdLocal);
+      }
+    } finally {
+      // Symlinks need `unlink`, not `rmSync` (which refuses to delete
+      // a directory-symlink without `recursive: true` and would then
+      // recurse into the real directory we don't want to touch).
+      try { fs.unlinkSync(linkedRoot); } catch { /* already gone */ }
+    }
+  });
+
   it('rejects a symlink pointing outside cwd (Codex #66 P2)', async () => {
     // Plant a file outside cwd, symlink it into cwd with a trusted-
     // looking name. `path.resolve(rawPath)` stays inside cwd (the


### PR DESCRIPTION
## Summary
- `agent-do run <arg>` no longer silently imports local JS/TS files. Positionals that look like a path (start with `./`, `../`, `/`, Windows drive letter, or JS extension) take the script branch; everything else is a saved-agent name.
- Script branch requires explicit `--script`, prompts for confirmation (size/SHA-256 prefix shown), and refuses in non-TTY without `-y`/`--yes`.
- Paths must live inside cwd (same containment check as the #20 trust-boundary fix), extension must be on the allowlist (`.js`/`.mjs`/`.cjs`/`.ts`/`.mts`/`.cts`), file must be readable.
- Saved-agent misses now error with a clear message instead of falling through to an import — so a stray `security-reviewer.js` in cwd can't masquerade as a saved agent.

## Test plan
- [x] 13 new tests in `tests/script-import.test.ts` covering flag parsing, dispatch, cwd containment, extension allowlist, non-TTY refuse-without-yes, saved-agent no-silent-fallback
- [x] Full suite: 442 passing (was 429)
- [x] `npm run build` clean

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)