### PR TITLE
[C-01] Stop hard-coding accept-all in the CLI (closes #17)

### DIFF
--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -42,6 +42,22 @@ export interface ParsedArgs {
   output: 'console' | 'json' | 'csv';
   compare?: string[];
   concurrency: number;
+  /**
+   * Accept every tool call without prompting (#17, C-01).
+   *
+   * Previously the CLI hard-coded this behaviour. The default now asks
+   * for confirmation on destructive tools (write, edit, delete) in TTY
+   * mode and denies them in non-TTY mode. `--accept-all` restores the
+   * old "full yolo" behaviour for scripted pipelines that need it —
+   * but the operator now has to opt in explicitly.
+   */
+  acceptAll: boolean;
+  /**
+   * Comma-separated list of tool names that bypass the confirmation
+   * prompt (e.g. `--allow write_file,memory_write`). Useful for
+   * semi-automated sessions where some destructive tools are expected.
+   */
+  allow: string[];
 }
 
 /**
@@ -69,6 +85,8 @@ export function parseArgs(argv: string[]): ParsedArgs {
     includeSensitive: false,
     output: 'console',
     concurrency: 1,
+    acceptAll: false,
+    allow: [],
   };
 
   const positional: string[] = [];
@@ -148,6 +166,11 @@ export function parseArgs(argv: string[]): ParsedArgs {
       if (isNaN(args.concurrency) || args.concurrency < 1) {
         throw new Error('--concurrency must be a positive integer');
       }
+    } else if (arg === '--accept-all' || arg === '--yes' || arg === '-y') {
+      args.acceptAll = true;
+    } else if (arg === '--allow') {
+      const val = requireValue(argv, ++i, '--allow');
+      args.allow.push(...val.split(',').map((s) => s.trim()).filter(Boolean));
     } else if (arg.startsWith('-')) {
       throw new Error(`Unknown option: ${arg}. Use --help for usage.`);
     } else {

--- a/src/cli/permission-handler.ts
+++ b/src/cli/permission-handler.ts
@@ -84,9 +84,15 @@ export function buildCliPermissions(
     if (READ_ONLY_TOOLS.has(req.toolName)) return true;
     if (sessionApproved.has(req.toolName)) return true;
 
-    if (!stdin.isTTY) {
+    // Both sides must be a TTY. Codex #68 P2: if only stdin is a TTY
+    // but stderr is redirected (e.g. `2>agent.log`), the prompt text
+    // goes to the log file — the operator sees the agent "hang" at
+    // the question and has no idea what to do. Fail closed in that
+    // case and tell them to use `--accept-all` / `--allow`.
+    if (!stdin.isTTY || !stderr.isTTY) {
       stderr.write(
-        `\n[agent-do] Denying destructive call ${req.toolName} — non-interactive session. ` +
+        `\n[agent-do] Denying destructive call ${req.toolName} — non-interactive session ` +
+        `(stdin ${stdin.isTTY ? 'OK' : 'not a TTY'}, stderr ${stderr.isTTY ? 'OK' : 'not a TTY'}). ` +
         `Pass --accept-all or --allow ${req.toolName} to auto-approve.\n`,
       );
       return false;
@@ -120,20 +126,37 @@ export function buildCliPermissions(
   };
 }
 
+/** Maximum length of any single string value inside the args preview. */
+const PREVIEW_VALUE_MAX = 80;
+/** Overall cap on the rendered preview string. */
+const PREVIEW_MAX = 120;
+
 /**
- * One-line preview of the tool args for the prompt. Truncates long
- * values so a prompt-injected agent can't flood the operator's terminal
- * with thousands of lines before showing the question.
+ * One-line preview of the tool args for the prompt. Per Copilot #68:
+ * the earlier implementation called `JSON.stringify(args)` on the full
+ * payload and only truncated afterwards, which for a `write_file`
+ * content argument near the 1 MB cap meant allocating ~1 MB of JSON
+ * just to slice off 117 bytes of it.
+ *
+ * The new approach pre-truncates each string leaf to `PREVIEW_VALUE_MAX`
+ * before serialising, and caps the final string at `PREVIEW_MAX`. Work
+ * is bounded by the number of keys in the args object, not by the size
+ * of any single value.
  */
 function previewArgs(args: unknown): string {
   if (args === undefined || args === null) return '';
   let text: string;
   try {
-    text = JSON.stringify(args);
+    text = JSON.stringify(args, (_key, value) => {
+      if (typeof value === 'string' && value.length > PREVIEW_VALUE_MAX) {
+        return value.slice(0, PREVIEW_VALUE_MAX - 3) + '...';
+      }
+      return value;
+    });
   } catch {
     text = String(args);
   }
-  if (text.length > 120) text = text.slice(0, 117) + '...';
+  if (text.length > PREVIEW_MAX) text = text.slice(0, PREVIEW_MAX - 3) + '...';
   return text;
 }
 

--- a/src/cli/permission-handler.ts
+++ b/src/cli/permission-handler.ts
@@ -1,0 +1,140 @@
+/**
+ * CLI permission handler (#17, C-01).
+ *
+ * The CLI used to hard-code `permissions: { mode: 'accept-all' }` on
+ * every agent it built. Combined with C-02 (prompt injection via file
+ * contents) and H-04 (unrestricted cwd access), that meant a hostile
+ * file in the working tree could trigger `write_file` / `delete_file`
+ * / `memory_write` silently.
+ *
+ * The new default asks before running destructive tools:
+ *
+ * - **Read-only tools** (`read_file`, `list_directory`, `grep_file`,
+ *   `find_files`, `memory_read`, `memory_list`) auto-approve. Prompting
+ *   for every file read would make the CLI unusable.
+ * - **Destructive tools** prompt the operator once per (tool, session)
+ *   with "yes / no / always". An "always" answer caches the approval
+ *   for the rest of the run.
+ * - **Non-TTY mode** (CI, shell pipes) denies destructive calls unless
+ *   the operator explicitly passed `--accept-all` or listed the tool in
+ *   `--allow`. Fail closed.
+ * - **Explicit opt-in** via `--accept-all` skips every prompt. `--allow
+ *   a,b` caches approval for specific tools up front.
+ */
+
+import * as readline from 'node:readline';
+import type { PermissionConfig } from '../types.js';
+
+/**
+ * Tools that don't mutate the filesystem / memory store. Auto-approved
+ * so the operator doesn't get prompted for every `read_file`. Anything
+ * not in this list is treated as potentially destructive.
+ */
+const READ_ONLY_TOOLS: ReadonlySet<string> = new Set([
+  'read_file',
+  'list_directory',
+  'grep_file',
+  'find_files',
+  'memory_read',
+  'memory_list',
+  'memory_search',
+  'memory_exists',
+  'search_skills',
+  'list_skills',
+]);
+
+export interface BuildPermissionsOptions {
+  acceptAll: boolean;
+  allow: string[];
+  /** Override for tests — defaults to `process.stdin`. */
+  stdin?: NodeJS.ReadStream;
+  /** Override for tests — defaults to `process.stderr`. */
+  stderr?: NodeJS.WriteStream;
+}
+
+/**
+ * Build a PermissionConfig for the CLI. Three code paths:
+ *
+ * 1. `--accept-all` → classic `mode: 'accept-all'`. Nothing is prompted.
+ *    The operator knows what they asked for.
+ * 2. `--allow x,y` → `mode: 'ask'` with `x` and `y` listed as `'always'`
+ *    in the per-tool map. The handler still prompts for everything else.
+ * 3. Default → `mode: 'ask'` with a TTY-backed handler. Read-only tools
+ *    are silently approved; destructive tools prompt; non-TTY fails
+ *    closed.
+ */
+export function buildCliPermissions(
+  opts: BuildPermissionsOptions,
+): PermissionConfig {
+  if (opts.acceptAll) {
+    return { mode: 'accept-all' };
+  }
+
+  const tools: Record<string, 'always'> = {};
+  for (const t of opts.allow) tools[t] = 'always';
+
+  const stdin = opts.stdin ?? process.stdin;
+  const stderr = opts.stderr ?? process.stderr;
+  const sessionApproved = new Set<string>();
+
+  const onPermissionRequest = async (req: {
+    toolName: string;
+    args: unknown;
+  }): Promise<boolean> => {
+    if (READ_ONLY_TOOLS.has(req.toolName)) return true;
+    if (sessionApproved.has(req.toolName)) return true;
+
+    if (!stdin.isTTY) {
+      stderr.write(
+        `\n[agent-do] Denying destructive call ${req.toolName} — non-interactive session. ` +
+        `Pass --accept-all or --allow ${req.toolName} to auto-approve.\n`,
+      );
+      return false;
+    }
+
+    const argsPreview = previewArgs(req.args);
+    const rl = readline.createInterface({ input: stdin, output: stderr });
+    try {
+      const answer: string = await new Promise((resolve) => {
+        rl.question(
+          `\n[agent-do] Agent wants to call ${req.toolName}(${argsPreview}).\n` +
+          `           Allow? [y]es / [n]o / [a]lways (this session): `,
+          resolve,
+        );
+      });
+      const trimmed = answer.trim().toLowerCase();
+      if (trimmed.startsWith('a')) {
+        sessionApproved.add(req.toolName);
+        return true;
+      }
+      return trimmed.startsWith('y');
+    } finally {
+      rl.close();
+    }
+  };
+
+  return {
+    mode: 'ask',
+    tools: Object.keys(tools).length > 0 ? tools : undefined,
+    onPermissionRequest,
+  };
+}
+
+/**
+ * One-line preview of the tool args for the prompt. Truncates long
+ * values so a prompt-injected agent can't flood the operator's terminal
+ * with thousands of lines before showing the question.
+ */
+function previewArgs(args: unknown): string {
+  if (args === undefined || args === null) return '';
+  let text: string;
+  try {
+    text = JSON.stringify(args);
+  } catch {
+    text = String(args);
+  }
+  if (text.length > 120) text = text.slice(0, 117) + '...';
+  return text;
+}
+
+export { READ_ONLY_TOOLS };

--- a/src/cli/prompt.ts
+++ b/src/cli/prompt.ts
@@ -18,6 +18,7 @@ import { createAgent } from '../agent.js';
 import { createWorkspaceTools } from '../tools/workspace-tools.js';
 import { createMemoryTools } from '../tools/memory-tools.js';
 import { FilesystemMemoryStore } from '../stores/filesystem.js';
+import { buildCliPermissions } from './permission-handler.js';
 import type { ProgressEvent, ConversationMessage } from '../types.js';
 import type { ToolSet } from 'ai';
 
@@ -60,7 +61,10 @@ export async function runPromptMode(args: ParsedArgs): Promise<void> {
     systemPrompt: args.systemPrompt,
     tools,
     maxIterations: args.maxIterations,
-    permissions: { mode: 'accept-all' },
+    permissions: buildCliPermissions({
+      acceptAll: args.acceptAll,
+      allow: args.allow,
+    }),
     usage: { enabled: true },
     // Only materialise the full ToolResult on `tool-result` events when
     // the user explicitly asked for it (`--show-content`). Defaults to

--- a/src/cli/script.ts
+++ b/src/cli/script.ts
@@ -58,11 +58,34 @@ export async function runScriptMode(args: ParsedArgs): Promise<void> {
   let agent: Agent;
 
   if (typeof exported.run === 'function' && typeof exported.stream === 'function') {
-    // It's an Agent instance
+    // It's an Agent instance. The script already built its own
+    // permissions surface — the CLI can't retrofit `--accept-all` /
+    // `--allow` / the prompt handler onto a pre-built agent, so warn
+    // the operator that the CLI policy is NOT in force. (Codex #68
+    // P1: silently ignoring the flags was worse than not applying
+    // them in the first place; now the operator sees the mismatch.)
+    if (!args.json && (args.acceptAll || args.allow.length > 0)) {
+      process.stderr.write(
+        `[agent-do] Note: ${args.file} exports a pre-built Agent instance, so ` +
+        `--accept-all and --allow have no effect. Export a config object instead ` +
+        `if you want the CLI permission policy to apply.\n`,
+      );
+    }
     agent = exported as unknown as Agent;
   } else if (exported.model && exported.id) {
-    // It's an AgentConfig — create agent from it
-    agent = createAgent(exported as any);
+    // It's an AgentConfig — create agent from it. Inject CLI
+    // permissions unless the config explicitly sets its own. Codex
+    // #68 P1: without this, a config-object export silently inherits
+    // the old "accept-all" default when the CLI caller expected the
+    // new ask policy.
+    const cfg = { ...(exported as Record<string, unknown>) };
+    if (cfg.permissions === undefined) {
+      cfg.permissions = buildCliPermissions({
+        acceptAll: args.acceptAll,
+        allow: args.allow,
+      });
+    }
+    agent = createAgent(cfg as any);
   } else if (exported.systemPrompt || exported.name) {
     // Simple config — resolve model from provider/args
     const model = await resolveModel(

--- a/src/cli/script.ts
+++ b/src/cli/script.ts
@@ -25,6 +25,7 @@ import { createAgent } from '../agent.js';
 import { createWorkspaceTools } from '../tools/workspace-tools.js';
 import { createMemoryTools } from '../tools/memory-tools.js';
 import { FilesystemMemoryStore } from '../stores/filesystem.js';
+import { buildCliPermissions } from './permission-handler.js';
 import type { Agent } from '../types.js';
 import type { ToolSet } from 'ai';
 
@@ -110,7 +111,7 @@ export async function runScriptMode(args: ParsedArgs): Promise<void> {
       systemPrompt: (exported.systemPrompt as string) ?? args.systemPrompt,
       tools,
       maxIterations: (exported.maxIterations as number) ?? args.maxIterations,
-      permissions: { mode: 'accept-all' },
+      permissions: buildCliPermissions({ acceptAll: args.acceptAll, allow: args.allow }),
       usage: { enabled: true },
       emitFullResult: args.showContent,
     });
@@ -190,7 +191,7 @@ async function runSavedAgent(
     systemPrompt: saved.systemPrompt,
     tools,
     maxIterations: saved.maxIterations,
-    permissions: { mode: 'accept-all' },
+    permissions: buildCliPermissions({ acceptAll: args.acceptAll, allow: args.allow }),
     usage: { enabled: true },
     emitFullResult: args.showContent,
   });

--- a/tests/cli-permissions.test.ts
+++ b/tests/cli-permissions.test.ts
@@ -47,7 +47,9 @@ describe('buildCliPermissions', () => {
     return r as unknown as NodeJS.ReadStream;
   }
 
-  function mockStderr(): { stream: NodeJS.WriteStream; written: string[] } {
+  function mockStderr(
+    isTTY = true,
+  ): { stream: NodeJS.WriteStream; written: string[] } {
     const written: string[] = [];
     const w = new Writable({
       write(chunk: Buffer | string, _enc, cb) {
@@ -55,6 +57,7 @@ describe('buildCliPermissions', () => {
         cb();
       },
     });
+    (w as unknown as { isTTY: boolean }).isTTY = isTTY;
     return { stream: w as unknown as NodeJS.WriteStream, written };
   }
 
@@ -100,6 +103,25 @@ describe('buildCliPermissions', () => {
       acceptAll: false,
       allow: [],
       stdin: mockStdin(false),
+      stderr,
+    });
+    const ok = await cfg.onPermissionRequest!({
+      toolName: 'write_file',
+      args: { path: 'a.txt' },
+    });
+    expect(ok).toBe(false);
+    expect(written.join('')).toMatch(/non-interactive/);
+  });
+
+  it('denies when stderr is redirected even if stdin is a TTY (Codex #68 P2)', async () => {
+    // If only stdin is a TTY but stderr is piped to a file (common:
+    // `agent-do ... 2>log`), the prompt goes to the log and the
+    // operator appears to see the agent hang. Fail closed.
+    const { stream: stderr, written } = mockStderr(false);
+    const cfg = buildCliPermissions({
+      acceptAll: false,
+      allow: [],
+      stdin: mockStdin(true, ['y']), // would answer yes if we prompted
       stderr,
     });
     const ok = await cfg.onPermissionRequest!({
@@ -188,6 +210,32 @@ describe('buildCliPermissions', () => {
     expect(promptText).toMatch(/\.\.\./);
     expect(promptText.length).toBeLessThan(huge.length + 500);
   });
+
+  it('truncates per-value, not just the final string (Copilot #68)', async () => {
+    // A write_file with a 1 MB `content` argument used to be fully
+    // stringified before truncation — allocating ~1 MB just to slice
+    // it. The new implementation caps each string leaf at 80 chars
+    // via a JSON.stringify replacer so large payloads never enter
+    // the final buffer.
+    const { stream: stderr, written } = mockStderr();
+    const stdin = mockStdin(true, ['n']);
+    const cfg = buildCliPermissions({
+      acceptAll: false,
+      allow: [],
+      stdin,
+      stderr,
+    });
+    const megabyte = 'x'.repeat(1024 * 1024);
+    await cfg.onPermissionRequest!({
+      toolName: 'write_file',
+      args: { path: 'a.txt', content: megabyte },
+    });
+    const promptText = written.join('');
+    // The prompt must stay bounded even though the value was 1 MB.
+    expect(promptText.length).toBeLessThan(500);
+    // The path must still be visible (not truncated to an ellipsis).
+    expect(promptText).toContain('a.txt');
+  });
 });
 
 // ─── #17 C-01: evaluatePermission end-to-end ────────────────────────────
@@ -210,8 +258,3 @@ describe('buildCliPermissions + evaluatePermission integration', () => {
     expect(await evaluatePermission('delete_file', {}, cfg)).toBe(true);
   });
 });
-
-// Coverage note: the end-to-end "stdin-pipe non-TTY refuses write" test
-// lives in the unit-level test above; writing it through evaluatePermission
-// would re-test the evaluatePermission branching rather than the handler.
-it.skip('placeholder for future end-to-end pipe test via runAgentLoop', () => {});

--- a/tests/cli-permissions.test.ts
+++ b/tests/cli-permissions.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Readable, Writable } from 'node:stream';
+import { parseArgs } from '../src/cli/args.js';
+import {
+  buildCliPermissions,
+  READ_ONLY_TOOLS,
+} from '../src/cli/permission-handler.js';
+import { evaluatePermission } from '../src/permissions.js';
+
+// ─── #17 C-01: flag parsing ─────────────────────────────────────────────
+
+describe('parseArgs: --accept-all / --yes / --allow', () => {
+  it('defaults to acceptAll=false, allow=[]', () => {
+    const args = parseArgs([]);
+    expect(args.acceptAll).toBe(false);
+    expect(args.allow).toEqual([]);
+  });
+
+  it('parses --accept-all, --yes, -y as aliases', () => {
+    expect(parseArgs(['--accept-all']).acceptAll).toBe(true);
+    expect(parseArgs(['--yes']).acceptAll).toBe(true);
+    expect(parseArgs(['-y']).acceptAll).toBe(true);
+  });
+
+  it('parses --allow as a comma-separated list', () => {
+    const args = parseArgs(['--allow', 'write_file,memory_write']);
+    expect(args.allow).toEqual(['write_file', 'memory_write']);
+  });
+});
+
+// ─── #17 C-01: buildCliPermissions ──────────────────────────────────────
+
+describe('buildCliPermissions', () => {
+  // Helpers that simulate a TTY stdin and capture stderr writes.
+  function mockStdin(isTTY: boolean, answers: string[] = []): NodeJS.ReadStream {
+    // Vitest / node readline uses `createInterface({ input })`. The
+    // interface reads line-by-line from the stream. Feed the answers
+    // as separate lines. The Readable implementation below is the
+    // standard "push strings then null to end" pattern.
+    const r = new Readable({
+      read() {
+        for (const ans of answers) this.push(ans + '\n');
+        this.push(null);
+      },
+    });
+    (r as unknown as { isTTY: boolean }).isTTY = isTTY;
+    return r as unknown as NodeJS.ReadStream;
+  }
+
+  function mockStderr(): { stream: NodeJS.WriteStream; written: string[] } {
+    const written: string[] = [];
+    const w = new Writable({
+      write(chunk: Buffer | string, _enc, cb) {
+        written.push(chunk.toString());
+        cb();
+      },
+    });
+    return { stream: w as unknown as NodeJS.WriteStream, written };
+  }
+
+  it('--accept-all returns { mode: "accept-all" }', () => {
+    const cfg = buildCliPermissions({ acceptAll: true, allow: [] });
+    expect(cfg.mode).toBe('accept-all');
+  });
+
+  it('default is mode: "ask" with a prompt handler', () => {
+    const cfg = buildCliPermissions({ acceptAll: false, allow: [] });
+    expect(cfg.mode).toBe('ask');
+    expect(typeof cfg.onPermissionRequest).toBe('function');
+  });
+
+  it('--allow seeds per-tool "always" entries', () => {
+    const cfg = buildCliPermissions({
+      acceptAll: false,
+      allow: ['write_file', 'delete_file'],
+    });
+    expect(cfg.tools?.write_file).toBe('always');
+    expect(cfg.tools?.delete_file).toBe('always');
+  });
+
+  it('auto-approves read-only tools without prompting', async () => {
+    const { stream: stderr, written } = mockStderr();
+    const cfg = buildCliPermissions({
+      acceptAll: false,
+      allow: [],
+      stdin: mockStdin(true, []),
+      stderr,
+    });
+    for (const tool of READ_ONLY_TOOLS) {
+      const ok = await cfg.onPermissionRequest!({ toolName: tool, args: {} });
+      expect(ok).toBe(true);
+    }
+    // No prompt should have been written.
+    expect(written.join('')).toBe('');
+  });
+
+  it('denies destructive tools in non-TTY mode (fail closed)', async () => {
+    const { stream: stderr, written } = mockStderr();
+    const cfg = buildCliPermissions({
+      acceptAll: false,
+      allow: [],
+      stdin: mockStdin(false),
+      stderr,
+    });
+    const ok = await cfg.onPermissionRequest!({
+      toolName: 'write_file',
+      args: { path: 'a.txt' },
+    });
+    expect(ok).toBe(false);
+    expect(written.join('')).toMatch(/non-interactive/);
+  });
+
+  it('prompts on TTY and approves on "y"', async () => {
+    const { stream: stderr } = mockStderr();
+    const cfg = buildCliPermissions({
+      acceptAll: false,
+      allow: [],
+      stdin: mockStdin(true, ['y']),
+      stderr,
+    });
+    const ok = await cfg.onPermissionRequest!({
+      toolName: 'write_file',
+      args: { path: 'a.txt' },
+    });
+    expect(ok).toBe(true);
+  });
+
+  it('prompts on TTY and denies on "n"', async () => {
+    const { stream: stderr } = mockStderr();
+    const cfg = buildCliPermissions({
+      acceptAll: false,
+      allow: [],
+      stdin: mockStdin(true, ['n']),
+      stderr,
+    });
+    const ok = await cfg.onPermissionRequest!({
+      toolName: 'delete_file',
+      args: { path: 'x' },
+    });
+    expect(ok).toBe(false);
+  });
+
+  it('"always" caches approval for the rest of the session', async () => {
+    const { stream: stderr } = mockStderr();
+    // Three calls: first answers "always", next two should not prompt.
+    const stdin = mockStdin(true, ['always']);
+    const cfg = buildCliPermissions({
+      acceptAll: false,
+      allow: [],
+      stdin,
+      stderr,
+    });
+    const first = await cfg.onPermissionRequest!({
+      toolName: 'write_file',
+      args: { path: 'a' },
+    });
+    expect(first).toBe(true);
+    // Subsequent calls should auto-approve — no stdin line consumed.
+    const second = await cfg.onPermissionRequest!({
+      toolName: 'write_file',
+      args: { path: 'b' },
+    });
+    const third = await cfg.onPermissionRequest!({
+      toolName: 'write_file',
+      args: { path: 'c' },
+    });
+    expect(second).toBe(true);
+    expect(third).toBe(true);
+  });
+
+  it('truncates long args in the prompt preview', async () => {
+    const { stream: stderr, written } = mockStderr();
+    const stdin = mockStdin(true, ['n']);
+    const cfg = buildCliPermissions({
+      acceptAll: false,
+      allow: [],
+      stdin,
+      stderr,
+    });
+    const huge = 'a'.repeat(500);
+    await cfg.onPermissionRequest!({
+      toolName: 'write_file',
+      args: { content: huge },
+    });
+    const promptText = written.join('');
+    // The prompt contains args but not all 500 chars (truncated to ~120).
+    expect(promptText).toMatch(/write_file\(/);
+    expect(promptText).toMatch(/\.\.\./);
+    expect(promptText.length).toBeLessThan(huge.length + 500);
+  });
+});
+
+// ─── #17 C-01: evaluatePermission end-to-end ────────────────────────────
+
+describe('buildCliPermissions + evaluatePermission integration', () => {
+  it('--allow entries skip the prompt via tools[...] = "always"', async () => {
+    const cfg = buildCliPermissions({
+      acceptAll: false,
+      allow: ['write_file'],
+    });
+    // The per-tool "always" is checked before `onPermissionRequest`, so
+    // the handler (which would deny in non-TTY) is never invoked.
+    const ok = await evaluatePermission('write_file', { path: 'x' }, cfg);
+    expect(ok).toBe(true);
+  });
+
+  it('--accept-all lets every tool through', async () => {
+    const cfg = buildCliPermissions({ acceptAll: true, allow: [] });
+    expect(await evaluatePermission('write_file', {}, cfg)).toBe(true);
+    expect(await evaluatePermission('delete_file', {}, cfg)).toBe(true);
+  });
+});
+
+// Coverage note: the end-to-end "stdin-pipe non-TTY refuses write" test
+// lives in the unit-level test above; writing it through evaluatePermission
+// would re-test the evaluatePermission branching rather than the handler.
+it.skip('placeholder for future end-to-end pipe test via runAgentLoop', () => {});

--- a/tests/cli-render.test.ts
+++ b/tests/cli-render.test.ts
@@ -22,6 +22,8 @@ function makeArgs(overrides: Partial<ParsedArgs> = {}): ParsedArgs {
     includeSensitive: false,
     output: 'console',
     concurrency: 1,
+    acceptAll: false,
+    allow: [],
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary
The CLI used to set `permissions: { mode: 'accept-all' }` on every agent it built, bypassing the permission system so C-02 prompt injections + H-04 cwd access could trigger `write_file` / `delete_file` / `memory_write` silently.

New default is `mode: 'ask'` with a TTY-backed handler:
- Read-only tools (read/list/grep/find + memory_read/list/search/exists + skills read tools) auto-approve.
- Destructive tools prompt `[y]es / [n]o / [a]lways (this session)`; \"always\" caches for the run.
- Non-TTY denies destructive calls fail-closed and tells the operator to use `--accept-all` or `--allow`.
- Args preview in the prompt is truncated at ~120 chars so an injected agent can't flood the terminal before the question.

New flags:
- `--accept-all` (aliases `--yes`, `-y`) — classic behaviour, explicit opt-in.
- `--allow tool_a,tool_b` — seed per-tool `'always'` entries.

All three CLI entry points (`runPromptMode`, `runScriptMode`, `runSavedAgent`) now route through `buildCliPermissions` in `src/cli/permission-handler.ts`.

## Note on `--yes` / `-y`
PR #66 (C-03) also introduces `--yes` / `-y` for the script-import confirmation prompt. Both uses mean \"don't prompt me\" in the same session, so when both PRs merge, the same flag serves both purposes. Merge conflict on `args.ts` is expected — resolved by keeping both `--script` (C-03) and `--accept-all`/`--allow` (C-01) branches and a shared `--yes`/`-y` that sets both `args.yes` and `args.acceptAll`. I can handle the rebase once the earlier PR merges.

## Test plan
- [x] 14 new tests in `tests/cli-permissions.test.ts` covering flag parsing, mode selection, read-only auto-approve, non-TTY denial, TTY y/n/always branches, session-approval caching, args-preview truncation, integration with `evaluatePermission`
- [x] Full suite: 443 passing + 1 skipped placeholder (was 429)
- [x] `npm run build` clean

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)