### PR TITLE
MCP (Model Context Protocol) server mounting (closes #75)

### DIFF
--- a/.changeset/mcp-mounting-75.md
+++ b/.changeset/mcp-mounting-75.md
@@ -1,0 +1,52 @@
+---
+"agent-do": minor
+---
+
+MCP (Model Context Protocol) server mounting (closes #75).
+
+agent-do can now mount external MCP servers and expose their tools to the model alongside local tools. Three transports supported: stdio (subprocess), SSE (legacy HTTP long-polling), and streamable HTTP.
+
+New `AgentConfig.mcpServers` option:
+
+```ts
+const agent = createAgent({
+  model,
+  mcpServers: [
+    {
+      name: 'fs',
+      transport: {
+        type: 'stdio',
+        command: 'npx',
+        args: ['-y', '@modelcontextprotocol/server-filesystem', '/tmp'],
+      },
+      allowedTools: ['read_text_file', 'list_directory'],
+    },
+    {
+      name: 'search',
+      transport: { type: 'http', url: 'https://example.com/mcp' },
+    },
+  ],
+});
+```
+
+### Design
+
+- **Tool namespacing** — discovered tools are renamed `mcp__<server>__<tool>` so two servers exposing a same-named tool don't collide. `namespacedToolName()` exported for use in logs / debug output.
+- **Lifecycle handled by the loop** — `runAgentLoop` and `streamAgentLoop` mount servers before starting and close them in a `finally` block. Subprocesses don't leak on abort/error/completion.
+- **All-or-nothing mount** — if any server fails to connect, previously-connected servers are closed before the error propagates. No half-mounted state.
+- **Optional `allowedTools` filter** — expose only a subset of a server's tools to the model. Useful when a server offers many tools but the agent needs a couple.
+- **Permissions + hooks apply uniformly** — MCP tools go through the same `wrapToolWithPermissions` path as local tools, so `onPreToolUse` / `onPostToolUse` fire for them, permissions gate them, and `toolLimits` count them.
+- **Content flattening** — MCP tool responses can be mixed content (text, images, embedded resources). Today we flatten to concatenated text with short descriptors for non-text parts (`[image: image/png]`, `[resource: <uri>]`).
+
+### New exports
+
+- `mountMcpServers(configs)` → `{ tools, toolOrigins, close }` — standalone mounting helper for callers who don't want the loop's lifecycle management.
+- `namespacedToolName(server, tool)` — build the namespaced name without duplicating the `mcp__` convention.
+- `MCP_TOOL_PREFIX = 'mcp__'` — the stable prefix constant.
+- Types: `McpServerConfig`, `McpTransportConfig`, `MountedMcpServers`.
+
+### Dependencies
+
+Adds `@modelcontextprotocol/sdk` as a runtime dependency.
+
+Example: see `examples/14-mcp.ts` — mounts the filesystem reference server against a sandbox directory.

--- a/examples/14-mcp.ts
+++ b/examples/14-mcp.ts
@@ -1,0 +1,83 @@
+/**
+ * Example 14: MCP (Model Context Protocol) servers
+ *
+ * Mount an external MCP server and let the agent use its tools.
+ * agent-do auto-namespaces discovered tools as `mcp__<server>__<tool>`
+ * and handles the server lifecycle (spawn on run, close on completion,
+ * close on error/abort so subprocesses don't leak).
+ *
+ * This example uses the official filesystem reference server. Install
+ * it first:
+ *
+ *   npm install -g @modelcontextprotocol/server-filesystem
+ *
+ * …or use `npx` in the transport config (shown below) so the SDK
+ * downloads it on demand.
+ *
+ * Run: npx tsx examples/14-mcp.ts
+ */
+
+import { createAgent } from 'agent-do';
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { tmpdir } from 'node:os';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+console.log('═══════════════════════════════════════');
+console.log('  Example 14: MCP server mounting');
+console.log('═══════════════════════════════════════\n');
+
+// Set up a sandbox directory with a couple of files so the filesystem
+// MCP server has something to poke at.
+const sandbox = mkdtempSync(join(tmpdir(), 'agent-do-mcp-'));
+writeFileSync(
+  join(sandbox, 'notes.md'),
+  '# Notes\n\n- buy milk\n- book doctor appointment\n- renew passport\n',
+);
+writeFileSync(
+  join(sandbox, 'todo.md'),
+  '# TODO\n\n- [ ] Finish the report\n- [x] Reply to Alice\n- [ ] Book flights\n',
+);
+console.log(`Sandbox directory: ${sandbox}\n`);
+
+const model = createAnthropic({ apiKey: process.env.ANTHROPIC_API_KEY! })(
+  'claude-sonnet-4-6',
+);
+
+// Mount the filesystem MCP server, scoped to our sandbox directory.
+// Tools will be discovered at run-start and exposed to the model as
+// mcp__fs__read_text_file, mcp__fs__list_directory, etc.
+const agent = createAgent({
+  id: 'fs-assistant',
+  name: 'Filesystem Assistant',
+  model: model as any,
+  systemPrompt:
+    'You are a helpful assistant with read-only access to a small workspace of markdown files. Use the filesystem tools to answer questions about the files.',
+  mcpServers: [
+    {
+      name: 'fs',
+      transport: {
+        type: 'stdio',
+        command: 'npx',
+        args: ['-y', '@modelcontextprotocol/server-filesystem', sandbox],
+      },
+      // Scope down to the safe subset — the filesystem server also
+      // exposes write and edit tools, but for this demo we only need
+      // to read.
+      allowedTools: ['read_text_file', 'list_directory', 'directory_tree'],
+    },
+  ],
+  maxIterations: 5,
+});
+
+console.log('Task: "What TODOs do I have left?"\n');
+console.log('The agent should call mcp__fs__list_directory to find todo.md,');
+console.log('then mcp__fs__read_text_file to load it, then filter to open items.\n');
+
+const result = await agent.run('What TODOs do I have left?');
+
+console.log('Agent output:\n');
+result.split('\n').forEach((line) => console.log(`   ${line}`));
+console.log('');
+
+console.log('Done — MCP servers are automatically closed when the run ends.');

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@ai-sdk/anthropic": "3.0.71",
         "@ai-sdk/google": "3.0.64",
         "@ai-sdk/openai": "3.0.53",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "ai": "^6.0.168",
         "ignore": "^7.0.5",
         "yaml": "^2.8.3",
@@ -414,31 +415,6 @@
         "prettier": "^2.7.1"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -462,6 +438,18 @@
         "@shikijs/themes": "^3.23.0",
         "@shikijs/types": "^3.23.0",
         "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
       }
     },
     "node_modules/@inquirer/external-editor": {
@@ -563,6 +551,46 @@
       },
       "engines": {
         "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -1146,6 +1174,19 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/ai": {
       "version": "6.0.168",
       "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.168.tgz",
@@ -1162,6 +1203,39 @@
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-colors": {
@@ -1234,6 +1308,30 @@
         "node": ">=4"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
@@ -1260,6 +1358,44 @@
         "node": ">=8"
       }
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -1277,6 +1413,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1284,11 +1442,45 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -1305,6 +1497,32 @@
       "integrity": "sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/detect-indent": {
       "version": "6.1.0",
@@ -1349,6 +1567,35 @@
         "node": ">=10"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/enquirer": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
@@ -1376,11 +1623,47 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
     "node_modules/esprima": {
@@ -1407,6 +1690,27 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/eventsource-parser": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.7.tgz",
@@ -1426,11 +1730,79 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/extendable-error": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/extendable-error/-/extendable-error-0.1.7.tgz",
       "integrity": "sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -1449,6 +1821,22 @@
       "engines": {
         "node": ">=8.6.0"
       }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -1473,6 +1861,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -1485,6 +1894,24 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/fs-extra": {
@@ -1515,6 +1942,52 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/glob-parent": {
@@ -1561,12 +2034,78 @@
         "node": ">= 4"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/human-id": {
       "version": "4.1.3",
@@ -1582,7 +2121,6 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
       "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -1602,6 +2140,30 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/is-extglob": {
@@ -1637,6 +2199,12 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/is-subdir": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-subdir/-/is-subdir-1.2.0.tgz",
@@ -1664,8 +2232,16 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
@@ -1685,6 +2261,18 @@
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/jsonfile": {
       "version": "4.0.0",
@@ -2022,12 +2610,42 @@
         "markdown-it": "bin/markdown-it.mjs"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/mdurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -2051,6 +2669,31 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/minimatch": {
@@ -2079,6 +2722,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -2096,6 +2745,15 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/node-fetch": {
@@ -2119,6 +2777,27 @@
         }
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -2129,6 +2808,27 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
     },
     "node_modules/outdent": {
       "version": "0.5.0",
@@ -2209,6 +2909,15 @@
         "quansync": "^0.2.7"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -2223,10 +2932,19 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/path-type": {
@@ -2276,6 +2994,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.10",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
@@ -2321,6 +3048,19 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/punycode.js": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
@@ -2329,6 +3069,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/quansync": {
@@ -2369,6 +3124,30 @@
       ],
       "license": "MIT"
     },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/read-yaml-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-yaml-file/-/read-yaml-file-1.1.0.tgz",
@@ -2407,6 +3186,15 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-from": {
@@ -2464,6 +3252,22 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -2492,7 +3296,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -2508,11 +3311,61 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -2525,10 +3378,81 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -2595,6 +3519,15 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/std-env": {
       "version": "4.1.0",
@@ -2728,6 +3661,15 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -2742,6 +3684,20 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/typedoc": {
       "version": "0.28.19",
@@ -2820,12 +3776,31 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/vite": {
       "version": "8.0.8",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -3036,7 +4011,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -3065,6 +4039,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
     "node_modules/yaml": {
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
@@ -3088,6 +4068,15 @@
       "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@ai-sdk/anthropic": "3.0.71",
         "@ai-sdk/google": "3.0.64",
         "@ai-sdk/openai": "3.0.53",
-        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@modelcontextprotocol/sdk": "1.29.0",
         "ai": "^6.0.168",
         "ignore": "^7.0.5",
         "yaml": "^2.8.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,10 @@
       "name": "agent-do",
       "version": "0.2.0",
       "dependencies": {
-        "@ai-sdk/anthropic": "3.0.71",
-        "@ai-sdk/google": "3.0.64",
-        "@ai-sdk/openai": "3.0.53",
-        "@modelcontextprotocol/sdk": "1.29.0",
+        "@ai-sdk/anthropic": "^3.0.0",
+        "@ai-sdk/google": "^3.0.0",
+        "@ai-sdk/openai": "^3.0.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "ai": "^6.0.168",
         "ignore": "^7.0.5",
         "yaml": "^2.8.3",
@@ -413,6 +413,31 @@
         "fs-extra": "^7.0.1",
         "human-id": "^4.1.1",
         "prettier": "^2.7.1"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {

--- a/package.json
+++ b/package.json
@@ -52,9 +52,10 @@
     "prepublishOnly": "npm run typecheck && npm test && npm run build"
   },
   "dependencies": {
-    "@ai-sdk/anthropic": "3.0.71",
-    "@ai-sdk/google": "3.0.64",
-    "@ai-sdk/openai": "3.0.53",
+    "@ai-sdk/anthropic": "^3.0.0",
+    "@ai-sdk/google": "^3.0.0",
+    "@ai-sdk/openai": "^3.0.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "ai": "^6.0.168",
     "ignore": "^7.0.5",
     "yaml": "^2.8.3",

--- a/package.json
+++ b/package.json
@@ -52,10 +52,10 @@
     "prepublishOnly": "npm run typecheck && npm test && npm run build"
   },
   "dependencies": {
-    "@ai-sdk/anthropic": "3.0.71",
-    "@ai-sdk/google": "3.0.64",
-    "@ai-sdk/openai": "3.0.53",
-    "@modelcontextprotocol/sdk": "1.29.0",
+    "@ai-sdk/anthropic": "^3.0.0",
+    "@ai-sdk/google": "^3.0.0",
+    "@ai-sdk/openai": "^3.0.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "ai": "^6.0.168",
     "ignore": "^7.0.5",
     "yaml": "^2.8.3",

--- a/package.json
+++ b/package.json
@@ -52,10 +52,10 @@
     "prepublishOnly": "npm run typecheck && npm test && npm run build"
   },
   "dependencies": {
-    "@ai-sdk/anthropic": "^3.0.0",
-    "@ai-sdk/google": "^3.0.0",
-    "@ai-sdk/openai": "^3.0.0",
-    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@ai-sdk/anthropic": "3.0.71",
+    "@ai-sdk/google": "3.0.64",
+    "@ai-sdk/openai": "3.0.53",
+    "@modelcontextprotocol/sdk": "1.29.0",
     "ai": "^6.0.168",
     "ignore": "^7.0.5",
     "yaml": "^2.8.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,18 @@
 export { createAgent } from './agent.js';
 export { runAgentLoop, streamAgentLoop } from './loop.js';
 
+// MCP (Model Context Protocol) — mount external tool servers
+export {
+  mountMcpServers,
+  namespacedToolName,
+  MCP_TOOL_PREFIX,
+} from './mcp.js';
+export type {
+  McpServerConfig,
+  McpTransportConfig,
+  MountedMcpServers,
+} from './mcp.js';
+
 // Permissions
 export { evaluatePermission } from './permissions.js';
 

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -73,6 +73,7 @@ function addCacheControl(messages: ModelMessage[], model: LanguageModel): ModelM
 }
 import { evaluatePermission } from './permissions.js';
 import { buildSkillsPrompt, createSkillTools } from './skills.js';
+import { mountMcpServers, type MountedMcpServers } from './mcp.js';
 import { UsageTracker, estimateCost } from './usage.js';
 import { normaliseToolResult, type ToolResult } from './tools/types.js';
 import { cutoffForKeepWindow, stripStaleToolOutputs } from './loop-history.js';
@@ -557,7 +558,36 @@ export function buildOnStepFinish(
 }
 
 /**
+ * Mount any MCP servers declared on `config`, returning a config with
+ * the discovered tools merged in alongside the caller's local tools,
+ * plus the mounted-servers handle so the caller can close them.
+ *
+ * Returns `{ config: original, mcp: undefined }` when `mcpServers` is
+ * absent or empty — zero-overhead path for the common case.
+ */
+async function mountConfigMcp(
+  config: AgentConfig,
+): Promise<{ config: AgentConfig; mcp: MountedMcpServers | undefined }> {
+  if (!config.mcpServers || config.mcpServers.length === 0) {
+    return { config, mcp: undefined };
+  }
+  const mcp = await mountMcpServers(config.mcpServers);
+  // Local tools win on name collisions — the caller's explicit `tools`
+  // map is authoritative, and MCP servers can't silently shadow a local
+  // tool just by naming something the same. Server-side tools always
+  // live under the `mcp__<server>__` prefix so collisions only happen if
+  // the caller's local tool is already named with that prefix, which
+  // would be their choice.
+  const mergedTools = { ...mcp.tools, ...(config.tools ?? {}) };
+  return { config: { ...config, tools: mergedTools }, mcp };
+}
+
+/**
  * Run the agent loop and return the final result.
+ *
+ * If `config.mcpServers` is set, the servers are mounted at the start
+ * and closed after the run completes (or errors) so the caller doesn't
+ * have to manage their lifecycle manually.
  */
 export async function runAgentLoop(
   config: AgentConfig,
@@ -565,7 +595,12 @@ export async function runAgentLoop(
   context?: string,
   history?: ConversationMessage[],
 ): Promise<RunResult> {
-  return runAgentLoopDirect(config, task, context, history);
+  const { config: resolvedConfig, mcp } = await mountConfigMcp(config);
+  try {
+    return await runAgentLoopDirect(resolvedConfig, task, context, history);
+  } finally {
+    if (mcp) await mcp.close();
+  }
 }
 
 /**
@@ -808,8 +843,32 @@ async function runAgentLoopDirect(
 
 /**
  * Stream the agent loop, yielding progress events.
+ *
+ * If `config.mcpServers` is set, the servers are mounted at the start
+ * and closed after the generator completes (or the caller returns early),
+ * so MCP subprocesses don't leak.
  */
 export async function* streamAgentLoop(
+  config: AgentConfig,
+  task: string,
+  context?: string,
+  history?: ConversationMessage[],
+): AsyncGenerator<ProgressEvent> {
+  const { config: resolvedConfig, mcp } = await mountConfigMcp(config);
+  try {
+    yield* streamAgentLoopDirect(resolvedConfig, task, context, history);
+  } finally {
+    if (mcp) await mcp.close();
+  }
+}
+
+/**
+ * Direct (non-MCP-managing) implementation of {@link streamAgentLoop}.
+ * Kept as a private function so MCP lifecycle is handled exactly once
+ * by the exported entry point; external callers should stick to
+ * `streamAgentLoop`.
+ */
+async function* streamAgentLoopDirect(
   config: AgentConfig,
   task: string,
   context?: string,

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -24,6 +24,7 @@ import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { dynamicTool, jsonSchema, type ToolSet } from 'ai';
 import { createRequire } from 'node:module';
+import { wrapForModel } from './tools/content-guards.js';
 
 /**
  * Library version used in the MCP `Client` handshake metadata (what the
@@ -243,7 +244,19 @@ export async function mountMcpServers(
                 name: mcpTool.name,
                 arguments: (args ?? {}) as Record<string, unknown>,
               });
-              return formatMcpToolResult(result);
+              const body = formatMcpToolResult(result);
+              // Wrap in `<tool_output>` markers with injection-marker
+              // redaction — MCP responses come from a third party we
+              // don't control, so a hostile or compromised server could
+              // try to inject "ignore previous instructions" / fake
+              // `<system>` tags / similar. `wrapForModel` is the same
+              // guard file_tools and memory_tools already use; using it
+              // uniformly means MCP output is held to the same
+              // trust-boundary contract.
+              return wrapForModel(body, {
+                tool: toolName,
+                path: `${config.name}:${mcpTool.name}`,
+              }).content;
             } catch (error) {
               const msg =
                 error instanceof Error ? error.message : String(error);

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -1,0 +1,259 @@
+/**
+ * MCP (Model Context Protocol) server mounting.
+ *
+ * Spawns / connects to MCP servers, lists their tools, and wraps each one
+ * as a Vercel AI SDK dynamic tool so the agent loop can invoke them
+ * alongside local tools (and hooks / permissions / usage tracking apply
+ * uniformly). See issue #75.
+ *
+ * Design choices:
+ *   - Tools are namespaced as `mcp__<server>__<tool>` so two servers
+ *     exposing a same-named tool don't collide.
+ *   - Each tool uses `dynamicTool` + `jsonSchema(...)` so we can plumb
+ *     through the server's declared input schema without a compile-time
+ *     zod round-trip.
+ *   - `mountMcpServers` is all-or-nothing: if any server fails to connect,
+ *     previously-connected servers are closed before the error propagates.
+ *     Half-mounted state is a footgun that's hard to reason about in the
+ *     agent loop's shutdown path.
+ */
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { dynamicTool, jsonSchema, type ToolSet } from 'ai';
+
+/**
+ * A single MCP server to mount. `name` is the namespace used to prefix
+ * tool names (`mcp__<name>__<tool>`); it must be unique across the set.
+ * Must match `^[a-zA-Z0-9_-]+$` so the generated tool names are safe
+ * across every provider's naming rules.
+ */
+export interface McpServerConfig {
+  /** Unique namespace for this server. Tools become `mcp__<name>__<tool>`. */
+  name: string;
+  transport: McpTransportConfig;
+  /**
+   * Per-tool name filter. If set, only tools whose bare name matches are
+   * exposed to the model. Useful when a server offers dozens of tools
+   * but the agent only needs a couple.
+   */
+  allowedTools?: string[];
+}
+
+export type McpTransportConfig =
+  | {
+      type: 'stdio';
+      command: string;
+      args?: string[];
+      env?: Record<string, string>;
+      cwd?: string;
+    }
+  | {
+      type: 'sse';
+      url: string;
+      headers?: Record<string, string>;
+    }
+  | {
+      type: 'http';
+      url: string;
+      headers?: Record<string, string>;
+    };
+
+/**
+ * Result of {@link mountMcpServers}. `tools` is a {@link ToolSet} that
+ * callers merge into their existing tools. `close()` releases every
+ * server's transport and should be called on agent shutdown to avoid
+ * leaked subprocesses.
+ */
+export interface MountedMcpServers {
+  tools: ToolSet;
+  /** Tool name → server namespace, for debugging / logging. */
+  toolOrigins: Record<string, string>;
+  close: () => Promise<void>;
+}
+
+const NAMESPACE_RE = /^[a-zA-Z0-9_-]+$/;
+/** Prefix applied to every MCP-sourced tool name. Also used by loop.ts for logging. */
+export const MCP_TOOL_PREFIX = 'mcp__';
+
+/**
+ * Build the namespaced tool name. Exported so tests and debug output can
+ * reuse the convention without re-deriving it.
+ */
+export function namespacedToolName(serverName: string, toolName: string): string {
+  return `${MCP_TOOL_PREFIX}${serverName}__${toolName}`;
+}
+
+/**
+ * Connect to each MCP server in `configs`, list their tools, and return
+ * them merged as a single {@link ToolSet}.
+ *
+ * Lifecycle contract:
+ *   - All-or-nothing: if any server's `connect()` or `listTools()` throws,
+ *     previously-connected servers are closed before the error propagates.
+ *   - The returned `close()` is idempotent; calling it twice is a no-op.
+ *   - Tools invoked after `close()` resolve with an error string rather
+ *     than throwing (same shape as other execute errors in agent-do).
+ */
+export async function mountMcpServers(
+  configs: McpServerConfig[],
+): Promise<MountedMcpServers> {
+  // Validate up front — surface bad names as TypeErrors before any
+  // subprocess spawns, so the caller gets a deterministic failure.
+  const seen = new Set<string>();
+  for (const config of configs) {
+    if (!NAMESPACE_RE.test(config.name)) {
+      throw new TypeError(
+        `MCP server name "${config.name}" must match ${NAMESPACE_RE}`,
+      );
+    }
+    if (seen.has(config.name)) {
+      throw new TypeError(`Duplicate MCP server name "${config.name}"`);
+    }
+    seen.add(config.name);
+  }
+
+  const clients: Client[] = [];
+  const tools: ToolSet = {};
+  const toolOrigins: Record<string, string> = {};
+  let closed = false;
+
+  const closeAll = async (): Promise<void> => {
+    if (closed) return;
+    closed = true;
+    // Close in reverse mount order — if a server depends on a shared
+    // resource owned by an earlier one, this minimises the chance
+    // of partial-shutdown noise.
+    await Promise.allSettled(
+      [...clients].reverse().map((c) =>
+        c.close().catch(() => {
+          /* close errors are non-fatal — we're already tearing down */
+        }),
+      ),
+    );
+  };
+
+  try {
+    for (const config of configs) {
+      const client = new Client({
+        name: 'agent-do',
+        version: '0.2.0',
+      });
+
+      const transport = createTransport(config.transport);
+      await client.connect(transport);
+      clients.push(client);
+
+      const { tools: mcpTools } = await client.listTools();
+      for (const mcpTool of mcpTools) {
+        if (
+          config.allowedTools &&
+          !config.allowedTools.includes(mcpTool.name)
+        ) {
+          continue;
+        }
+
+        const toolName = namespacedToolName(config.name, mcpTool.name);
+        toolOrigins[toolName] = config.name;
+
+        // Dynamic tool: schema is not known at compile time, so we route
+        // through `jsonSchema()` to get a Schema the AI SDK can pass to
+        // providers. `additionalProperties: false` defaults aren't
+        // trusted here — the server owns the contract.
+        const schema = jsonSchema(
+          (mcpTool.inputSchema ?? {
+            type: 'object',
+            properties: {},
+          }) as Parameters<typeof jsonSchema>[0],
+        );
+
+        tools[toolName] = dynamicTool({
+          description:
+            mcpTool.description ??
+            `MCP tool "${mcpTool.name}" from server "${config.name}".`,
+          inputSchema: schema,
+          execute: async (args: unknown) => {
+            if (closed) {
+              return `Error: MCP server "${config.name}" is closed.`;
+            }
+            try {
+              const result = await client.callTool({
+                name: mcpTool.name,
+                arguments: (args ?? {}) as Record<string, unknown>,
+              });
+              return formatMcpToolResult(result);
+            } catch (error) {
+              const msg =
+                error instanceof Error ? error.message : String(error);
+              return `Error calling ${toolName}: ${msg}`;
+            }
+          },
+        });
+      }
+    }
+  } catch (error) {
+    await closeAll();
+    throw error;
+  }
+
+  return {
+    tools,
+    toolOrigins,
+    close: closeAll,
+  };
+}
+
+function createTransport(config: McpTransportConfig) {
+  switch (config.type) {
+    case 'stdio':
+      return new StdioClientTransport({
+        command: config.command,
+        args: config.args,
+        env: config.env,
+        cwd: config.cwd,
+      });
+    case 'sse':
+      return new SSEClientTransport(new URL(config.url), {
+        requestInit: config.headers ? { headers: config.headers } : undefined,
+      });
+    case 'http':
+      return new StreamableHTTPClientTransport(new URL(config.url), {
+        requestInit: config.headers ? { headers: config.headers } : undefined,
+      });
+  }
+}
+
+/**
+ * Render an MCP tool result into the string shape agent-do's loop
+ * expects. MCP tools can return mixed content (text, images, embedded
+ * resources); today we flatten to text concatenation. Non-text parts
+ * get a short descriptor so the model at least knows something else
+ * came back.
+ */
+function formatMcpToolResult(result: unknown): string {
+  const content = (result as { content?: unknown }).content;
+  if (!Array.isArray(content)) {
+    return typeof result === 'string' ? result : JSON.stringify(result);
+  }
+  const parts: string[] = [];
+  for (const part of content as Array<Record<string, unknown>>) {
+    if (part.type === 'text' && typeof part.text === 'string') {
+      parts.push(part.text);
+    } else if (part.type === 'image') {
+      parts.push(`[image: ${part.mimeType ?? 'unknown'}]`);
+    } else if (part.type === 'resource') {
+      const uri =
+        (part.resource as { uri?: string } | undefined)?.uri ?? 'unknown';
+      parts.push(`[resource: ${uri}]`);
+    } else {
+      parts.push(`[${part.type ?? 'unknown'} part]`);
+    }
+  }
+  const body = parts.join('\n');
+  if ((result as { isError?: boolean }).isError) {
+    return `Tool error: ${body}`;
+  }
+  return body;
+}

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -23,6 +23,30 @@ import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { dynamicTool, jsonSchema, type ToolSet } from 'ai';
+import { createRequire } from 'node:module';
+
+/**
+ * Library version used in the MCP `Client` handshake metadata (what the
+ * server sees as the connecting client). Resolved at module load from
+ * the real `package.json` so the value tracks the release version
+ * without a second source of truth to keep in sync (Copilot #75 review).
+ *
+ * Best-effort: if the JSON read fails (unlikely in a normal install,
+ * but possible in some bundled-runtime / edge-runtime configs), fall
+ * back to a known-stale constant. The server uses this purely for
+ * logging — a stale value is informational drift, not a correctness
+ * issue — so the fallback shouldn't throw and interrupt the mount.
+ */
+const LIB_VERSION: string = (() => {
+  try {
+    const require = createRequire(import.meta.url);
+    const pkg = require('../package.json') as { version?: string };
+    if (typeof pkg.version === 'string') return pkg.version;
+  } catch {
+    // fall through to the literal
+  }
+  return '0.0.0';
+})();
 
 /**
  * A single MCP server to mount. `name` is the namespace used to prefix
@@ -74,8 +98,19 @@ export interface MountedMcpServers {
   close: () => Promise<void>;
 }
 
-const NAMESPACE_RE = /^[a-zA-Z0-9_-]+$/;
-/** Prefix applied to every MCP-sourced tool name. Also used by loop.ts for logging. */
+/**
+ * Regex for acceptable MCP server namespaces *and* tool names.
+ *
+ * Excludes `__` (two underscores) specifically because the tool name
+ * assembled as `mcp__<server>__<tool>` uses `__` as the separator;
+ * allowing it inside either segment lets distinct `(server, tool)`
+ * pairs collapse to the same key (e.g. `server="a", tool="b__c"` and
+ * `server="a__b", tool="c"` both flatten to `mcp__a__b__c`). The
+ * later registration would silently overwrite the earlier one,
+ * hiding tools or mis-routing calls (Codex #75 review).
+ */
+const NAMESPACE_RE = /^(?!.*__)[a-zA-Z0-9_-]+$/;
+/** Prefix applied to every MCP-sourced tool name. */
 export const MCP_TOOL_PREFIX = 'mcp__';
 
 /**
@@ -139,12 +174,18 @@ export async function mountMcpServers(
     for (const config of configs) {
       const client = new Client({
         name: 'agent-do',
-        version: '0.2.0',
+        version: LIB_VERSION,
       });
+
+      // Track the client *before* `connect()` (Copilot #75 review). If
+      // `connect()` throws after the transport has already spawned a
+      // subprocess / opened a socket, `closeAll()` needs to close this
+      // client to release the resource — otherwise we leak on the
+      // all-or-nothing failure path.
+      clients.push(client);
 
       const transport = createTransport(config.transport);
       await client.connect(transport);
-      clients.push(client);
 
       const { tools: mcpTools } = await client.listTools();
       for (const mcpTool of mcpTools) {
@@ -155,7 +196,26 @@ export async function mountMcpServers(
           continue;
         }
 
+        // Reject tool names that contain the `__` separator — same
+        // rationale as the server namespace (a `tool.name` with `__`
+        // would collide with other (server, tool) pairs when flattened
+        // to `mcp__<server>__<tool>`). Codex #75.
+        if (!NAMESPACE_RE.test(mcpTool.name)) {
+          throw new TypeError(
+            `MCP server "${config.name}" exposes tool "${mcpTool.name}" which does not match ${NAMESPACE_RE} — names containing "__" or other unsafe characters would collide in the namespaced tool set.`,
+          );
+        }
+
         const toolName = namespacedToolName(config.name, mcpTool.name);
+        // Belt-and-braces: guard against the regex missing anything by
+        // also detecting duplicate computed names. With `__` excluded
+        // from both segments this should be unreachable, but a future
+        // regex weakening would still get caught here.
+        if (toolName in tools) {
+          throw new TypeError(
+            `MCP tool name collision for "${toolName}" (server "${config.name}", tool "${mcpTool.name}"). A tool with this namespaced name is already registered.`,
+          );
+        }
         toolOrigins[toolName] = config.name;
 
         // Dynamic tool: schema is not known at compile time, so we route

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import type { LanguageModel, ModelMessage, ToolSet } from 'ai';
+import type { McpServerConfig } from './mcp.js';
 
 // Progress events emitted during agent execution
 export interface ProgressEvent {
@@ -297,6 +298,20 @@ export interface AgentConfig {
   model: LanguageModel;
   systemPrompt?: string; // Raw system prompt (CLAUDE.md content)
   tools?: ToolSet;
+  /**
+   * MCP (Model Context Protocol) servers to mount for this run (#75).
+   *
+   * Each entry spawns / connects to an MCP server; its tools are
+   * namespaced as `mcp__<server>__<tool>` and merged into `tools`
+   * before the loop starts. Permissions, hooks, usage tracking, and
+   * `toolLimits` apply to MCP tools exactly as they do to local tools.
+   *
+   * The lifecycle is managed by the loop: servers are mounted once at
+   * the start of each `run()` / `stream()` call and closed on
+   * completion, abort, or error. See `src/mcp.ts` for transport
+   * details (stdio, sse, streamable HTTP).
+   */
+  mcpServers?: McpServerConfig[];
   skills?: SkillStore;
   /**
    * Expose the privileged `install_skill` tool to the model (#24, H-05).

--- a/tests/mcp.test.ts
+++ b/tests/mcp.test.ts
@@ -178,7 +178,12 @@ describe('mountMcpServers (#75)', () => {
       name: 'read_file',
       arguments: { path: '/tmp/foo' },
     });
-    expect(result).toBe('stubbed');
+    // MCP tool output is wrapped in `<tool_output>` markers so the
+    // model treats it as untrusted data from a third-party server
+    // (matches the file_tools / memory_tools convention).
+    expect(result).toContain('<tool_output tool="mcp__fs__read_file" path="fs:read_file">');
+    expect(result).toContain('stubbed');
+    expect(result).toContain('</tool_output>');
 
     await mounted.close();
   });
@@ -228,7 +233,9 @@ describe('mountMcpServers (#75)', () => {
       { toolCallId: 't', messages: [] },
     )) as string;
 
-    expect(result).toBe('line one\nline two\n[image: image/png]');
+    expect(result).toContain('line one\nline two\n[image: image/png]');
+    expect(result).toContain('<tool_output');
+    expect(result).toContain('</tool_output>');
     await mounted.close();
   });
 
@@ -249,8 +256,11 @@ describe('mountMcpServers (#75)', () => {
       { toolCallId: 't', messages: [] },
     )) as string;
 
-    expect(result).toMatch(/^Tool error:/);
+    // "Tool error:" sits inside the <tool_output> wrapper, not at the
+    // very start of the string any more.
+    expect(result).toContain('Tool error:');
     expect(result).toContain('permission denied');
+    expect(result).toContain('<tool_output');
     await mounted.close();
   });
 
@@ -268,6 +278,9 @@ describe('mountMcpServers (#75)', () => {
       { toolCallId: 't', messages: [] },
     )) as string;
 
+    // The error path returns the raw error string (no <tool_output>
+    // wrap) because wrapForModel is only applied on the success path.
+    // It's a synthesised library message, not untrusted server content.
     expect(result).toMatch(/^Error calling mcp__srv__flaky:/);
     expect(result).toContain('connection reset');
     await mounted.close();

--- a/tests/mcp.test.ts
+++ b/tests/mcp.test.ts
@@ -274,8 +274,11 @@ describe('mountMcpServers (#75)', () => {
   });
 
   it('closes all clients on failed mount (all-or-nothing)', async () => {
-    // First server connects fine, second throws. We expect the first
-    // client to be closed and the whole call to reject.
+    // First server connects fine, second throws. Both clients should be
+    // closed — the first because it succeeded, the second because its
+    // transport may have spawned a subprocess before `connect()` threw.
+    // Copilot #75 review: clients must be tracked *before* connect() so
+    // the failing client is included in the teardown list.
     let connectCount = 0;
     stubClient.connect.mockImplementation(async () => {
       connectCount++;
@@ -291,12 +294,45 @@ describe('mountMcpServers (#75)', () => {
       ]),
     ).rejects.toThrow(/boom/);
 
-    // The first client got created and connected; after the failure
-    // we expect it to be closed so no subprocess leaks.
-    expect(stubClient.close).toHaveBeenCalled();
+    // The stub is shared, so every tracked Client's `close()` call
+    // hits the same mock. With push-before-connect, both client-a
+    // (successful) and client-b (failed mid-connect) are tracked,
+    // and closeAll should call close on both.
+    expect(stubClient.close).toHaveBeenCalledTimes(2);
 
     stubClient.connect.mockReset();
     stubClient.connect.mockResolvedValue(undefined);
+  });
+
+  it('rejects server names containing "__" to prevent tool-key collisions', async () => {
+    await expect(
+      mountMcpServers([
+        { name: 'a__b', transport: { type: 'stdio', command: 'noop' } },
+      ]),
+    ).rejects.toThrow(/must match/);
+  });
+
+  it('rejects MCP tools whose names contain "__" (collision guard, Codex #75)', async () => {
+    stubClient.listTools.mockResolvedValue({
+      tools: [
+        {
+          name: 'ok_name',
+          description: 'good',
+          inputSchema: { type: 'object', properties: {} },
+        },
+        {
+          name: 'bad__name',
+          description: 'ambiguous',
+          inputSchema: { type: 'object', properties: {} },
+        },
+      ],
+    });
+
+    await expect(
+      mountMcpServers([
+        { name: 'srv', transport: { type: 'stdio', command: 'noop' } },
+      ]),
+    ).rejects.toThrow(/match/);
   });
 
   it('close() is idempotent', async () => {

--- a/tests/mcp.test.ts
+++ b/tests/mcp.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Tests for MCP server mounting (#75).
+ *
+ * These tests exercise the tool-adapter logic without spinning real MCP
+ * subprocesses: each test stubs the minimum client/transport surface,
+ * then validates that `mountMcpServers` wires tools correctly and that
+ * lifecycle (close, error-during-mount) behaves as advertised.
+ *
+ * For a real-subprocess smoke test, run `examples/14-mcp.ts` against
+ * any official MCP server binary.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  namespacedToolName,
+  MCP_TOOL_PREFIX,
+} from '../src/mcp.js';
+
+// Stub the MCP SDK's Client so we don't spawn subprocesses. Vitest's
+// `vi.mock` rewires the ESM import — every `new Client(...)` in the
+// module under test returns the stub instance configured below.
+const stubClient = vi.hoisted(() => {
+  type Tool = Record<string, unknown>;
+  type ListToolsResult = { tools: Tool[] };
+  type ContentPart = Record<string, unknown>;
+  type CallToolResult = { content: ContentPart[]; isError?: boolean } | Record<string, unknown>;
+  const state = {
+    connect: vi.fn<(_: unknown) => Promise<void>>(async () => {}),
+    listTools: vi.fn<() => Promise<ListToolsResult>>(async () => ({ tools: [] })),
+    callTool: vi.fn<(_: unknown) => Promise<CallToolResult>>(async () => ({
+      content: [{ type: 'text', text: 'stubbed' }],
+    })),
+    close: vi.fn<() => Promise<void>>(async () => {}),
+  };
+  return state;
+});
+
+vi.mock('@modelcontextprotocol/sdk/client/index.js', () => {
+  function Client(this: unknown) {
+    // Each `new Client(...)` returns the shared stub — tests run
+    // sequentially so per-test mock state is isolated by `beforeEach`.
+    Object.assign(this as object, stubClient);
+  }
+  return { Client };
+});
+
+// Transport stubs — just need to be constructable.
+vi.mock('@modelcontextprotocol/sdk/client/stdio.js', () => {
+  function StdioClientTransport() {}
+  return { StdioClientTransport };
+});
+vi.mock('@modelcontextprotocol/sdk/client/sse.js', () => {
+  function SSEClientTransport() {}
+  return { SSEClientTransport };
+});
+vi.mock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => {
+  function StreamableHTTPClientTransport() {}
+  return { StreamableHTTPClientTransport };
+});
+
+// Import after mocks so the module resolves the stubs.
+const { mountMcpServers } = await import('../src/mcp.js');
+
+describe('namespacedToolName', () => {
+  it('prefixes tool names with mcp__<server>__', () => {
+    expect(namespacedToolName('gmail', 'send')).toBe('mcp__gmail__send');
+    expect(namespacedToolName('calendar', 'list-events')).toBe(
+      'mcp__calendar__list-events',
+    );
+  });
+
+  it('exports a stable MCP_TOOL_PREFIX constant', () => {
+    expect(MCP_TOOL_PREFIX).toBe('mcp__');
+    expect(namespacedToolName('x', 'y').startsWith(MCP_TOOL_PREFIX)).toBe(
+      true,
+    );
+  });
+});
+
+describe('mountMcpServers (#75)', () => {
+  beforeEach(() => {
+    stubClient.connect.mockClear();
+    stubClient.listTools.mockClear();
+    stubClient.callTool.mockClear();
+    stubClient.close.mockClear();
+    stubClient.listTools.mockResolvedValue({ tools: [] });
+    stubClient.callTool.mockResolvedValue({
+      content: [{ type: 'text', text: 'stubbed' }],
+    });
+  });
+
+  it('rejects invalid server names', async () => {
+    await expect(
+      mountMcpServers([
+        {
+          name: 'bad name with spaces',
+          transport: { type: 'stdio', command: 'noop' },
+        },
+      ]),
+    ).rejects.toThrow(/must match/);
+  });
+
+  it('rejects duplicate server names', async () => {
+    await expect(
+      mountMcpServers([
+        { name: 'fs', transport: { type: 'stdio', command: 'noop' } },
+        { name: 'fs', transport: { type: 'stdio', command: 'noop' } },
+      ]),
+    ).rejects.toThrow(/Duplicate/);
+  });
+
+  it('namespaces discovered tools with mcp__<server>__<tool>', async () => {
+    stubClient.listTools.mockResolvedValue({
+      tools: [
+        {
+          name: 'read_file',
+          description: 'Read a file',
+          inputSchema: {
+            type: 'object',
+            properties: { path: { type: 'string' } },
+          },
+        },
+        {
+          name: 'write_file',
+          description: 'Write a file',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              path: { type: 'string' },
+              content: { type: 'string' },
+            },
+          },
+        },
+      ],
+    });
+
+    const mounted = await mountMcpServers([
+      { name: 'fs', transport: { type: 'stdio', command: 'noop' } },
+    ]);
+
+    expect(Object.keys(mounted.tools).sort()).toEqual([
+      'mcp__fs__read_file',
+      'mcp__fs__write_file',
+    ]);
+    expect(mounted.toolOrigins).toEqual({
+      mcp__fs__read_file: 'fs',
+      mcp__fs__write_file: 'fs',
+    });
+
+    await mounted.close();
+  });
+
+  it('invokes the MCP callTool with the bare (un-namespaced) name', async () => {
+    stubClient.listTools.mockResolvedValue({
+      tools: [
+        {
+          name: 'read_file',
+          description: 'Read a file',
+          inputSchema: {
+            type: 'object',
+            properties: { path: { type: 'string' } },
+          },
+        },
+      ],
+    });
+
+    const mounted = await mountMcpServers([
+      { name: 'fs', transport: { type: 'stdio', command: 'noop' } },
+    ]);
+
+    const tool = mounted.tools.mcp__fs__read_file;
+    // AI SDK tool execute signature is (input, toolCallOptions).
+    const result = await tool.execute!({ path: '/tmp/foo' } as never, {
+      toolCallId: 't1',
+      messages: [],
+    });
+
+    expect(stubClient.callTool).toHaveBeenCalledWith({
+      name: 'read_file',
+      arguments: { path: '/tmp/foo' },
+    });
+    expect(result).toBe('stubbed');
+
+    await mounted.close();
+  });
+
+  it('filters tools by allowedTools when set', async () => {
+    stubClient.listTools.mockResolvedValue({
+      tools: [
+        { name: 'read', description: 'r', inputSchema: { type: 'object', properties: {} } },
+        { name: 'write', description: 'w', inputSchema: { type: 'object', properties: {} } },
+        { name: 'delete', description: 'd', inputSchema: { type: 'object', properties: {} } },
+      ],
+    });
+
+    const mounted = await mountMcpServers([
+      {
+        name: 'fs',
+        transport: { type: 'stdio', command: 'noop' },
+        allowedTools: ['read', 'write'],
+      },
+    ]);
+
+    expect(Object.keys(mounted.tools).sort()).toEqual([
+      'mcp__fs__read',
+      'mcp__fs__write',
+    ]);
+
+    await mounted.close();
+  });
+
+  it('flattens content parts into a single text string', async () => {
+    stubClient.listTools.mockResolvedValue({
+      tools: [{ name: 'echo', description: 'e', inputSchema: { type: 'object', properties: {} } }],
+    });
+    stubClient.callTool.mockResolvedValue({
+      content: [
+        { type: 'text', text: 'line one' },
+        { type: 'text', text: 'line two' },
+        { type: 'image', mimeType: 'image/png' },
+      ],
+    });
+
+    const mounted = await mountMcpServers([
+      { name: 'srv', transport: { type: 'stdio', command: 'noop' } },
+    ]);
+    const result = (await mounted.tools.mcp__srv__echo.execute!(
+      {} as never,
+      { toolCallId: 't', messages: [] },
+    )) as string;
+
+    expect(result).toBe('line one\nline two\n[image: image/png]');
+    await mounted.close();
+  });
+
+  it('surfaces error results with a "Tool error:" prefix', async () => {
+    stubClient.listTools.mockResolvedValue({
+      tools: [{ name: 'fail', description: 'f', inputSchema: { type: 'object', properties: {} } }],
+    });
+    stubClient.callTool.mockResolvedValue({
+      isError: true,
+      content: [{ type: 'text', text: 'permission denied' }],
+    });
+
+    const mounted = await mountMcpServers([
+      { name: 'srv', transport: { type: 'stdio', command: 'noop' } },
+    ]);
+    const result = (await mounted.tools.mcp__srv__fail.execute!(
+      {} as never,
+      { toolCallId: 't', messages: [] },
+    )) as string;
+
+    expect(result).toMatch(/^Tool error:/);
+    expect(result).toContain('permission denied');
+    await mounted.close();
+  });
+
+  it('returns an error string (not a throw) when the server callTool throws', async () => {
+    stubClient.listTools.mockResolvedValue({
+      tools: [{ name: 'flaky', description: 'f', inputSchema: { type: 'object', properties: {} } }],
+    });
+    stubClient.callTool.mockRejectedValue(new Error('connection reset'));
+
+    const mounted = await mountMcpServers([
+      { name: 'srv', transport: { type: 'stdio', command: 'noop' } },
+    ]);
+    const result = (await mounted.tools.mcp__srv__flaky.execute!(
+      {} as never,
+      { toolCallId: 't', messages: [] },
+    )) as string;
+
+    expect(result).toMatch(/^Error calling mcp__srv__flaky:/);
+    expect(result).toContain('connection reset');
+    await mounted.close();
+  });
+
+  it('closes all clients on failed mount (all-or-nothing)', async () => {
+    // First server connects fine, second throws. We expect the first
+    // client to be closed and the whole call to reject.
+    let connectCount = 0;
+    stubClient.connect.mockImplementation(async () => {
+      connectCount++;
+      if (connectCount === 2) {
+        throw new Error('boom');
+      }
+    });
+
+    await expect(
+      mountMcpServers([
+        { name: 'a', transport: { type: 'stdio', command: 'noop' } },
+        { name: 'b', transport: { type: 'stdio', command: 'noop' } },
+      ]),
+    ).rejects.toThrow(/boom/);
+
+    // The first client got created and connected; after the failure
+    // we expect it to be closed so no subprocess leaks.
+    expect(stubClient.close).toHaveBeenCalled();
+
+    stubClient.connect.mockReset();
+    stubClient.connect.mockResolvedValue(undefined);
+  });
+
+  it('close() is idempotent', async () => {
+    stubClient.listTools.mockResolvedValue({ tools: [] });
+    const mounted = await mountMcpServers([
+      { name: 'srv', transport: { type: 'stdio', command: 'noop' } },
+    ]);
+    await mounted.close();
+    await mounted.close(); // second close should be a no-op
+    // Each connected client should be closed exactly once despite two
+    // close() calls.
+    expect(stubClient.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('execute after close returns an error string', async () => {
+    stubClient.listTools.mockResolvedValue({
+      tools: [{ name: 'x', description: 'x', inputSchema: { type: 'object', properties: {} } }],
+    });
+    const mounted = await mountMcpServers([
+      { name: 'srv', transport: { type: 'stdio', command: 'noop' } },
+    ]);
+    await mounted.close();
+
+    const result = (await mounted.tools.mcp__srv__x.execute!(
+      {} as never,
+      { toolCallId: 't', messages: [] },
+    )) as string;
+    expect(result).toMatch(/closed/);
+  });
+});


### PR DESCRIPTION
## Summary

Agents built with agent-do can now mount external MCP servers at runtime — the tools those servers expose are discovered, namespaced, and merged into the agent's toolset automatically. Supports all three standard MCP transports (stdio, SSE, streamable HTTP).

### What changed

- **`AgentConfig.mcpServers`** — new optional array:
  \`\`\`ts
  mcpServers: [
    {
      name: 'fs',
      transport: {
        type: 'stdio',
        command: 'npx',
        args: ['-y', '@modelcontextprotocol/server-filesystem', '/tmp'],
      },
      allowedTools: ['read_text_file', 'list_directory'],
    },
    { name: 'search', transport: { type: 'http', url: 'https://example.com/mcp' } },
    { name: 'legacy',  transport: { type: 'sse',  url: 'https://example.com/mcp' } },
  ]
  \`\`\`
- **Tool namespacing** — `mcp__<server>__<tool>`. `namespacedToolName()` exported for log/debug output.
- **Lifecycle handled by the loop** — `runAgentLoop` and `streamAgentLoop` mount servers before the loop starts and close them in a \`finally\` block. No subprocess leaks on abort/error/completion.
- **All-or-nothing mount** — if any server fails to connect, previously-connected servers are closed before the error propagates. No half-mounted state in the agent loop.
- **Optional `allowedTools` filter** — expose only a subset of a server's tools.
- **Permissions, hooks, usage tracking, and `toolLimits` apply uniformly** — MCP tools flow through the existing \`wrapToolWithPermissions\` pipeline.
- **Content flattening** — mixed-content MCP responses (text + images + embedded resources) flatten to concatenated text with short descriptors for non-text parts (\`[image: image/png]\`, \`[resource: <uri>]\`).

### New exports

- \`mountMcpServers(configs)\` → \`{ tools, toolOrigins, close }\` — standalone helper for callers who want their own lifecycle management.
- \`namespacedToolName(server, tool)\`
- \`MCP_TOOL_PREFIX = 'mcp__'\`
- Types: \`McpServerConfig\`, \`McpTransportConfig\`, \`MountedMcpServers\`

### Dependencies

Adds \`@modelcontextprotocol/sdk\` as a runtime dependency.

### Backwards compatibility

Fully backwards compatible — \`mcpServers\` is optional and the mount path short-circuits when it's absent or empty, so there's zero overhead for callers who don't use it.

## Test plan

- [x] 13 unit tests for \`mountMcpServers\` + \`namespacedToolName\` in \`tests/mcp.test.ts\` using stubbed MCP Client
- [x] Namespace validation (regex enforcement + duplicate detection)
- [x] Tool discovery and namespacing
- [x] \`allowedTools\` filter honoured
- [x] Content flattening: text-only, text+image, error results with \`isError: true\`
- [x] Error passthrough: server \`callTool\` throws → execute returns error string (no unhandled rejection)
- [x] All-or-nothing mount: failed second server → first is closed
- [x] \`close()\` idempotent
- [x] Execute-after-close returns an error string, doesn't throw
- [x] Full suite passes: 568 tests across 33 files, typecheck clean
- [ ] Manual smoke: run \`examples/14-mcp.ts\` against \`@modelcontextprotocol/server-filesystem\` (requires \`npx\` network access)

## Notes

- Paul already flagged he'd rather ship demos before a full template pack abstraction (#78), so this MCP support is the unblock for the three planned demos (chief-of-staff uses Gmail/Calendar MCP, research uses WebSearch MCP, etc.).
- Built on the official \`@modelcontextprotocol/sdk\` \`Client\` class and the three standard transport classes — no custom wire format handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)