### PR TITLE
Saved Routines: prompt-as-macro primitive (closes #77)

### DIFF
--- a/.changeset/routines-77.md
+++ b/.changeset/routines-77.md
@@ -1,0 +1,46 @@
+---
+"agent-do": minor
+---
+
+Saved Routines: prompt-as-macro primitive (closes #77).
+
+A routine is a named, reusable procedure — "like a bash script but it's a prompt." Routines are distinct from skills:
+
+| | Skill | Routine |
+|---|---|---|
+| Purpose | Instructions on when/how to do X | Named saved procedure |
+| Triggering | Autonomous, description-matched | **Explicit by name**, optionally with args |
+| Grows over time? | Hand-written | **Accumulates** — runCount + lastRun tracked |
+
+### New exports
+
+- `AgentConfig.routines` — any `RoutineStore`
+- `AgentConfig.allowRoutineSave` — privileged flag to expose the `save_routine` tool (default false, same threat model as `allowSkillInstall`)
+- `InMemoryRoutineStore`, `FilesystemRoutineStore`
+- `parseRoutineMd(content, id?)` — markdown + YAML frontmatter parser
+- `interpolateRoutine(body, args)` — `{{name}}` placeholder substitution
+- `createRoutineTools(store, { allowSave })` — produces the tool set below
+- Types: `Routine`, `RoutineStore`, `RoutineInput`
+
+### Tools exposed to the model
+
+Always:
+- `list_routines` — id / name / description / runCount per routine
+- `run_routine(routineId, args?)` — retrieve a routine, interpolate `{{arg}}` placeholders, return the body wrapped in `<routine>` markers for the model to follow. Bumps runCount + lastRun.
+
+Gated behind `allowRoutineSave: true`:
+- `save_routine` — persist a new routine. Same validation surface as `install_skill`.
+
+### Storage
+
+`FilesystemRoutineStore` stores each routine as `<rootDir>/<id>.md` with YAML frontmatter + body. Run metadata (runCount, lastRun) lives in a single `.runs.json` sidecar so routine files don't get rewritten on every invocation.
+
+### Body interpolation
+
+Bodies may contain `{{name}}` placeholders that get filled from the `args` object passed to `run_routine`. Unknown placeholders are left in place — the model can see which args it still needs.
+
+Deliberately minimal: no conditionals, loops, or expressions. Routines are prompts, not DSLs.
+
+### Example
+
+See `examples/15-routines.ts` — pre-saves two routines (`triage-inbox`, `weekly-report`), then the agent runs one with an argument. `runCount` persists across runs.

--- a/examples/15-routines.ts
+++ b/examples/15-routines.ts
@@ -1,0 +1,105 @@
+/**
+ * Example 15: Saved Routines
+ *
+ * Routines are named prompt-as-macro procedures the agent invokes
+ * explicitly by id, optionally with arguments that fill `{{placeholder}}`
+ * substitutions in the body. Compare to skills:
+ *
+ *   - Skills fire *autonomously* when their description matches a
+ *     task (see example 09).
+ *   - Routines fire *deterministically* when the user says "run the
+ *     weekly-report routine".
+ *
+ * Storage lives on disk so routines persist across runs. Each run bumps
+ * runCount + lastRun, enabling future agent-proposed capture ("I've
+ * done this 3 times — save as a routine?").
+ *
+ * Run: npx tsx examples/15-routines.ts
+ */
+
+import { createAgent, FilesystemRoutineStore, parseRoutineMd } from 'agent-do';
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+console.log('═══════════════════════════════════════');
+console.log('  Example 15: Saved Routines');
+console.log('═══════════════════════════════════════\n');
+
+const dir = mkdtempSync(join(tmpdir(), 'agent-do-routines-'));
+console.log(`Routines directory: ${dir}\n`);
+
+const store = new FilesystemRoutineStore(dir);
+
+// Pre-populate with a couple of routines the user has previously saved.
+await store.save(
+  parseRoutineMd(
+    `---
+name: Triage Inbox
+description: Classify inbox items into urgent / response-needed / informational / spam
+inputs:
+  - name: count
+    optional: true
+---
+
+Triage the user's inbox:
+1. Look at the most recent {{count}} messages (default: 20 if count not given)
+2. Classify each into: urgent / response-needed / informational / spam
+3. Summarise counts + top 3 in each bucket
+`,
+    'triage-inbox',
+  ),
+);
+
+await store.save(
+  parseRoutineMd(
+    `---
+name: Weekly Report
+description: Summarise the last 7 daily entries into a weekly rollup
+inputs:
+  - name: week
+---
+
+For a weekly report covering week {{week}}:
+1. Read the last 7 daily entries from entries/
+2. Group key themes across: Events / People / Decisions / Open Threads
+3. Write to reports/weekly-{{week}}.md
+`,
+    'weekly-report',
+  ),
+);
+
+console.log('Pre-saved 2 routines: triage-inbox, weekly-report\n');
+
+const model = createAnthropic({ apiKey: process.env.ANTHROPIC_API_KEY! })(
+  'claude-sonnet-4-6',
+);
+
+const agent = createAgent({
+  id: 'assistant',
+  name: 'Assistant',
+  model: model as any,
+  systemPrompt:
+    'You are a helpful assistant. When the user asks you to run a routine by name, use the run_routine tool to retrieve and follow its instructions.',
+  routines: store,
+  maxIterations: 5,
+});
+
+console.log('Task: "Run the weekly-report routine for week 17."\n');
+console.log('The agent should:');
+console.log('  1. Call list_routines (or go directly to run_routine)');
+console.log('  2. Call run_routine with routineId="weekly-report", args={week: "17"}');
+console.log('  3. Follow the returned instructions, with {{week}} filled as "17"\n');
+
+const result = await agent.run('Run the weekly-report routine for week 17.');
+
+console.log('Agent output:\n');
+result.split('\n').forEach((line) => console.log(`   ${line}`));
+console.log('');
+
+// Show that runCount persisted across the run.
+const after = await store.get('weekly-report');
+console.log(`weekly-report runCount is now ${after?.runCount}, lastRun=${after?.lastRun}\n`);
+
+console.log('Done — routines persist on disk, and each run bumps the counter.');

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,16 @@ export {
   InMemorySkillStore,
 } from './skills.js';
 
+// Routines — named prompt-as-macro procedures (#77)
+export {
+  parseRoutineMd,
+  interpolateRoutine,
+  createRoutineTools,
+  InMemoryRoutineStore,
+  FilesystemRoutineStore,
+} from './routines.js';
+export type { CreateRoutineToolsOptions } from './routines.js';
+
 // Workspace tools (real project files) and memory tools (agent scratchpad)
 export { createWorkspaceTools } from './tools/workspace-tools.js';
 export type { WorkspaceToolsOptions } from './tools/workspace-tools.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ export {
   FilesystemRoutineStore,
 } from './routines.js';
 export type { CreateRoutineToolsOptions } from './routines.js';
+export type { Routine, RoutineStore, RoutineInput } from './types.js';
 
 // Workspace tools (real project files) and memory tools (agent scratchpad)
 export { createWorkspaceTools } from './tools/workspace-tools.js';

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -74,6 +74,7 @@ function addCacheControl(messages: ModelMessage[], model: LanguageModel): ModelM
 import { evaluatePermission } from './permissions.js';
 import { buildSkillsPrompt, createSkillTools } from './skills.js';
 import { mountMcpServers, type MountedMcpServers } from './mcp.js';
+import { createRoutineTools } from './routines.js';
 import { UsageTracker, estimateCost } from './usage.js';
 import { normaliseToolResult, type ToolResult } from './tools/types.js';
 import { cutoffForKeepWindow, stripStaleToolOutputs } from './loop-history.js';
@@ -460,6 +461,17 @@ function buildTools(
       allowInstall: config.allowSkillInstall === true,
     });
     for (const [name, t] of Object.entries(skillTools)) {
+      tools[name] = wrapToolWithPermissions(name, t, config, step, resultCache, counters);
+    }
+  }
+
+  // Add routine tools if a store is provided. `save_routine` is only
+  // registered when `allowRoutineSave` is explicitly set — see #77.
+  if (config.routines) {
+    const routineTools = createRoutineTools(config.routines, {
+      allowSave: config.allowRoutineSave === true,
+    });
+    for (const [name, t] of Object.entries(routineTools)) {
       tools[name] = wrapToolWithPermissions(name, t, config, step, resultCache, counters);
     }
   }

--- a/src/routines.ts
+++ b/src/routines.ts
@@ -184,11 +184,35 @@ const ROUTINE_ID_MAX = 64;
 const ROUTINE_NAME_MAX = 64;
 const ROUTINE_DESCRIPTION_MAX = 256;
 
+/**
+ * IDs that collide with `Object.prototype` members. Even though the
+ * store now validates/guards these paths, the best fix is to reject
+ * them at the entry point so a hostile id never reaches the store
+ * (Codex #77 review). Includes the classic prototype-pollution keys
+ * and a couple of filesystem gotchas (`.` / `..` already fail the
+ * regex, but kept for readers).
+ */
+const RESERVED_ROUTINE_IDS = new Set([
+  '__proto__',
+  'constructor',
+  'prototype',
+  'hasOwnProperty',
+  'toString',
+  'valueOf',
+]);
+
+function isValidRoutineId(id: string): boolean {
+  return ROUTINE_ID_RE.test(id) && !RESERVED_ROUTINE_IDS.has(id);
+}
+
 const SaveRoutineInputSchema = z.object({
   id: z
     .string()
     .regex(ROUTINE_ID_RE)
     .max(ROUTINE_ID_MAX)
+    .refine((id) => !RESERVED_ROUTINE_IDS.has(id), {
+      message: 'Routine ID collides with a reserved name',
+    })
     .describe('Unique routine ID (kebab-case; alphanumerics, dashes, underscores only)'),
   name: z.string().min(1).max(ROUTINE_NAME_MAX).describe('Human-readable routine name'),
   description: z
@@ -273,7 +297,15 @@ export function createRoutineTools(
         if (!routine) {
           return `Routine "${routineId}" not found. Call list_routines to see available routines.`;
         }
-        await store.recordRun(routineId);
+        // Run tracking is observational — persistence failures shouldn't
+        // block the routine body from being returned to the model
+        // (Copilot #77 review). If the filesystem throws EACCES on
+        // .runs.json, the user still gets their routine.
+        try {
+          await store.recordRun(routineId);
+        } catch {
+          /* observational; keep going */
+        }
         const body = interpolateRoutine(routine.body, args ?? {});
         return `<routine name="${escapeAttr(routine.name)}" id="${escapeAttr(routine.id)}">\n${escapeRoutineBody(body)}\n</routine>`;
       },
@@ -386,12 +418,45 @@ export class FilesystemRoutineStore implements RoutineStore {
     Record<string, { runCount: number; lastRun?: string }>
   > {
     if (this.runsCache) return this.runsCache;
-    let cache: Record<string, { runCount: number; lastRun?: string }> = {};
+    // Null-prototype object so keys like `__proto__` / `constructor` /
+    // `prototype` can't shadow Object.prototype members from a hostile
+    // sidecar file (Copilot #77 review). Also validates per-entry so a
+    // malformed runCount (negative, float, NaN, non-number) doesn't
+    // corrupt subsequent increments.
+    const cache: Record<string, { runCount: number; lastRun?: string }> =
+      Object.create(null);
     try {
       const raw = await fs.readFile(this.runsFile(), 'utf8');
-      const parsed = JSON.parse(raw);
+      const parsed: unknown = JSON.parse(raw);
       if (typeof parsed === 'object' && parsed !== null) {
-        cache = parsed as Record<string, { runCount: number; lastRun?: string }>;
+        for (const [routineId, rawValue] of Object.entries(parsed)) {
+          if (
+            routineId === '__proto__' ||
+            routineId === 'constructor' ||
+            routineId === 'prototype'
+          ) {
+            continue;
+          }
+          if (!isValidRoutineId(routineId)) continue;
+          if (typeof rawValue !== 'object' || rawValue === null) continue;
+          const candidate = rawValue as {
+            runCount?: unknown;
+            lastRun?: unknown;
+          };
+          if (
+            !Number.isSafeInteger(candidate.runCount) ||
+            (candidate.runCount as number) < 0
+          ) {
+            continue;
+          }
+          const entry: { runCount: number; lastRun?: string } = {
+            runCount: candidate.runCount as number,
+          };
+          if (typeof candidate.lastRun === 'string') {
+            entry.lastRun = candidate.lastRun;
+          }
+          cache[routineId] = entry;
+        }
       }
     } catch {
       // Missing file / malformed JSON → start fresh. Runs tracking is
@@ -415,7 +480,7 @@ export class FilesystemRoutineStore implements RoutineStore {
     for (const entry of entries) {
       if (!entry.endsWith('.md')) continue;
       const id = entry.replace(/\.md$/, '');
-      if (!ROUTINE_ID_RE.test(id)) continue;
+      if (!isValidRoutineId(id)) continue;
       const content = await fs.readFile(join(this.rootDir, entry), 'utf8');
       const routine = parseRoutineMd(content, id);
       const runData = runs[id];
@@ -429,7 +494,7 @@ export class FilesystemRoutineStore implements RoutineStore {
   }
 
   async get(id: string): Promise<Routine | undefined> {
-    if (!ROUTINE_ID_RE.test(id)) return undefined;
+    if (!isValidRoutineId(id)) return undefined;
     try {
       const content = await fs.readFile(join(this.rootDir, `${id}.md`), 'utf8');
       const routine = parseRoutineMd(content, id);
@@ -446,9 +511,9 @@ export class FilesystemRoutineStore implements RoutineStore {
   }
 
   async save(routine: Routine): Promise<void> {
-    if (!ROUTINE_ID_RE.test(routine.id)) {
+    if (!isValidRoutineId(routine.id)) {
       throw new TypeError(
-        `Routine ID "${routine.id}" must match ${ROUTINE_ID_RE}`,
+        `Routine ID "${routine.id}" must match ${ROUTINE_ID_RE} and not be a reserved name`,
       );
     }
     await this.ensureDir();
@@ -472,7 +537,7 @@ export class FilesystemRoutineStore implements RoutineStore {
   }
 
   async remove(id: string): Promise<void> {
-    if (!ROUTINE_ID_RE.test(id)) return;
+    if (!isValidRoutineId(id)) return;
     try {
       await fs.unlink(join(this.rootDir, `${id}.md`));
     } catch {
@@ -486,6 +551,19 @@ export class FilesystemRoutineStore implements RoutineStore {
   }
 
   async recordRun(id: string): Promise<void> {
+    // Contract: `recordRun` is a no-op for missing routines. Without
+    // this check the sidecar could grow entries for routines that never
+    // existed (direct attacker-controlled IDs via a hostile `run_routine`
+    // call, or IDs the caller passed directly before saving). Also
+    // refuse IDs that fail the safe-char regex so prototype-polluting
+    // keys like `__proto__` can't enter `.runs.json` this way
+    // (Copilot + Codex #77 reviews).
+    if (!isValidRoutineId(id)) return;
+    try {
+      await fs.access(join(this.rootDir, `${id}.md`));
+    } catch {
+      return; // routine file doesn't exist → no-op
+    }
     const runs = await this.loadRuns();
     const existing = runs[id] ?? { runCount: 0 };
     runs[id] = {

--- a/src/routines.ts
+++ b/src/routines.ts
@@ -1,0 +1,497 @@
+/**
+ * Saved Routines: named prompt-as-macro procedures (#77).
+ *
+ * A routine is a named saved procedure — a step-by-step recipe stored in
+ * markdown with YAML frontmatter and invoked *explicitly by name*.
+ * Routines are distinct from skills:
+ *
+ *   Skills fire *autonomously* — the model matches a skill's description
+ *   against the task and applies it. Routines fire *deterministically* —
+ *   the model (or the CLI, or external code) calls `run_routine(id, args)`
+ *   and the returned body is the procedure to follow.
+ *
+ * Routines accumulate over time: `recordRun()` tracks `runCount` and
+ * `lastRun`, enabling future "I've done this 3 times, save it as a
+ * routine?" agent-proposed capture. The capture UX is out of scope for
+ * this first pass — we ship the primitive, not the detector.
+ *
+ * Storage format:
+ * ```
+ * ---
+ * name: weekly-report
+ * description: Summarise the last 7 daily entries into a weekly rollup
+ * inputs:
+ *   - name: week
+ *     optional: true
+ * version: 1
+ * ---
+ *
+ * For a weekly report:
+ * 1. Read the last 7 daily entries from entries/
+ * 2. Group by Events / People / Decisions / Open Threads
+ * 3. Write to reports/weekly-{{week}}.md
+ * ```
+ */
+
+import { tool } from 'ai';
+import type { ToolSet } from 'ai';
+import { z } from 'zod';
+import YAML from 'yaml';
+import type { Routine, RoutineInput, RoutineStore } from './types.js';
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+
+// ── Frontmatter parsing ────────────────────────────────────────────────
+
+/**
+ * Per-field schemas for routine YAML frontmatter.
+ *
+ * Same independent-validation pattern as `extractSkillMeta` in skills.ts:
+ * one bad field (e.g. `version: 2` landing as YAML number) doesn't
+ * nuke the rest. String fields coerce from numeric/boolean YAML values.
+ */
+const ROUTINE_FIELD_SCHEMAS = {
+  name: z.coerce.string().min(1).max(64),
+  description: z.coerce.string().max(512),
+  version: z.coerce.string().max(32),
+} as const;
+
+const ROUTINE_BODY_MAX = 16 * 1024;
+
+/** Input arg metadata. Keeping it lightweight — name + optional. */
+const RoutineInputSchema = z.object({
+  name: z.string().min(1).max(64),
+  description: z.string().max(256).optional(),
+  optional: z.boolean().optional(),
+});
+
+type RoutineMeta = {
+  name?: string;
+  description?: string;
+  version?: string;
+  inputs?: RoutineInput[];
+};
+
+function extractRoutineMeta(raw: unknown): RoutineMeta {
+  if (typeof raw !== 'object' || raw === null) return {};
+  const lowered: Record<string, unknown> = Object.create(null);
+  for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
+    if (k === '__proto__' || k === 'constructor' || k === 'prototype') continue;
+    lowered[k.toLowerCase()] = v;
+  }
+
+  const out: RoutineMeta = {};
+  for (const field of Object.keys(ROUTINE_FIELD_SCHEMAS) as Array<
+    keyof typeof ROUTINE_FIELD_SCHEMAS
+  >) {
+    const value = lowered[field];
+    if (value === undefined || value === null) continue;
+    const parsed = ROUTINE_FIELD_SCHEMAS[field].safeParse(value);
+    if (parsed.success) out[field] = parsed.data;
+  }
+
+  const rawInputs = lowered.inputs;
+  if (Array.isArray(rawInputs)) {
+    const kept: RoutineInput[] = [];
+    for (const entry of rawInputs) {
+      const parsed = RoutineInputSchema.safeParse(entry);
+      if (parsed.success) kept.push(parsed.data);
+    }
+    if (kept.length > 0) out.inputs = kept;
+  }
+
+  return out;
+}
+
+/**
+ * Parse a routine markdown file with YAML frontmatter. Same shape as
+ * {@link parseSkillMd} in `./skills.ts` — falls back to body-only when
+ * there's no frontmatter.
+ */
+export function parseRoutineMd(content: string, id?: string): Routine {
+  const match = content.match(/^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/);
+
+  if (!match) {
+    const generatedId = id || 'unknown-routine';
+    return {
+      id: generatedId,
+      name: generatedId,
+      description: '',
+      body: clampBody(content.trim()),
+      runCount: 0,
+    };
+  }
+
+  const frontmatter = match[1];
+  const body = clampBody(match[2].trim());
+
+  let rawMeta: unknown = {};
+  try {
+    rawMeta = YAML.parse(frontmatter) ?? {};
+  } catch {
+    rawMeta = {};
+  }
+  const meta = extractRoutineMeta(rawMeta);
+
+  const routineId =
+    id ||
+    meta.name
+      ?.toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '') ||
+    'unknown-routine';
+
+  return {
+    id: routineId,
+    name: meta.name || routineId,
+    description: meta.description || '',
+    body,
+    inputs: meta.inputs,
+    version: meta.version,
+    runCount: 0,
+  };
+}
+
+function clampBody(body: string): string {
+  return body.length > ROUTINE_BODY_MAX ? body.slice(0, ROUTINE_BODY_MAX) : body;
+}
+
+/**
+ * Substitute `{{name}}` placeholders in a routine body with the
+ * provided args. Unknown placeholders are left in place — that way the
+ * model can see which args it needs to gather before running.
+ *
+ * Deliberately minimal: no conditionals, loops, or expressions. Keep
+ * the prompt-is-the-program ethos — a routine is a prompt, not a DSL.
+ */
+export function interpolateRoutine(
+  body: string,
+  args: Record<string, unknown>,
+): string {
+  return body.replace(/\{\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}/g, (match, key) => {
+    if (Object.prototype.hasOwnProperty.call(args, key)) {
+      const v = args[key];
+      return typeof v === 'string' ? v : JSON.stringify(v);
+    }
+    return match; // leave unknown placeholder visible
+  });
+}
+
+// ── Tools exposed to the LLM ───────────────────────────────────────────
+
+const ROUTINE_ID_RE = /^[a-zA-Z0-9_-]+$/;
+const ROUTINE_ID_MAX = 64;
+const ROUTINE_NAME_MAX = 64;
+const ROUTINE_DESCRIPTION_MAX = 256;
+
+const SaveRoutineInputSchema = z.object({
+  id: z
+    .string()
+    .regex(ROUTINE_ID_RE)
+    .max(ROUTINE_ID_MAX)
+    .describe('Unique routine ID (kebab-case; alphanumerics, dashes, underscores only)'),
+  name: z.string().min(1).max(ROUTINE_NAME_MAX).describe('Human-readable routine name'),
+  description: z
+    .string()
+    .max(ROUTINE_DESCRIPTION_MAX)
+    .describe('What the routine does — shown in list_routines output'),
+  body: z
+    .string()
+    .max(ROUTINE_BODY_MAX)
+    .describe('The routine instructions (markdown, max 16 KB)'),
+});
+
+export interface CreateRoutineToolsOptions {
+  /**
+   * Allow the LLM to call `save_routine`.
+   *
+   * Default `false`: save is privileged because a prompt-injected agent
+   * could persistently install a hostile "routine" that future runs
+   * would execute when the user invokes it by name. Same threat model
+   * as `allowSkillInstall`.
+   */
+  allowSave?: boolean;
+}
+
+/**
+ * Build the AI SDK tools that expose a routine store to the model.
+ *
+ * Always exposed:
+ *   - `list_routines` — id / name / description per routine
+ *   - `run_routine(id, args?)` — returns the routine body with
+ *     `{{arg}}` placeholders interpolated
+ *
+ * Gated behind `allowSave: true`:
+ *   - `save_routine` — persist a new routine to the store
+ */
+export function createRoutineTools(
+  store: RoutineStore,
+  options: CreateRoutineToolsOptions = {},
+): ToolSet {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const s = (schema: z.ZodType): any => schema;
+
+  const tools: ToolSet = {
+    list_routines: tool({
+      description:
+        'List all saved routines — named procedures the user has previously captured. Each entry shows id/name/description. To execute one, call run_routine(id).',
+      inputSchema: s(z.object({})),
+      execute: async () => {
+        const routines = await store.list();
+        if (routines.length === 0) {
+          return 'No routines saved.';
+        }
+        return routines
+          .map(
+            (r) =>
+              `- ${r.name} (${r.id}): ${r.description} [runs: ${r.runCount}]`,
+          )
+          .join('\n');
+      },
+    }),
+
+    run_routine: tool({
+      description:
+        'Retrieve and run a saved routine by ID. Returns the routine body with any {{arg}} placeholders filled from the `args` object. Follow the returned instructions to complete the task. Use list_routines to see what\'s available.',
+      inputSchema: s(
+        z.object({
+          routineId: z.string().describe('ID of the routine to run'),
+          args: z
+            .record(z.string(), z.unknown())
+            .optional()
+            .describe('Optional argument map used to fill {{placeholders}} in the routine body'),
+        }),
+      ),
+      execute: async ({
+        routineId,
+        args,
+      }: {
+        routineId: string;
+        args?: Record<string, unknown>;
+      }) => {
+        const routine = await store.get(routineId);
+        if (!routine) {
+          return `Routine "${routineId}" not found. Call list_routines to see available routines.`;
+        }
+        await store.recordRun(routineId);
+        const body = interpolateRoutine(routine.body, args ?? {});
+        return `<routine name="${escapeAttr(routine.name)}" id="${escapeAttr(routine.id)}">\n${escapeRoutineBody(body)}\n</routine>`;
+      },
+    }),
+  };
+
+  if (options.allowSave) {
+    tools.save_routine = tool({
+      description:
+        'Save a new routine — a named prompt-as-macro the user can invoke later by name. The body is the recipe the routine will run; use {{name}} placeholders for arguments.',
+      inputSchema: s(SaveRoutineInputSchema),
+      execute: async (raw: unknown) => {
+        const parsed = SaveRoutineInputSchema.safeParse(raw);
+        if (!parsed.success) {
+          const issues = parsed.error.issues
+            .map((i) => `${i.path.join('.') || '(root)'}: ${i.message}`)
+            .join('; ');
+          return `Error: save_routine rejected — ${issues}`;
+        }
+        await store.save({
+          id: parsed.data.id,
+          name: parsed.data.name,
+          description: parsed.data.description,
+          body: parsed.data.body,
+          runCount: 0,
+        });
+        return `Routine "${parsed.data.name}" (${parsed.data.id}) saved successfully.`;
+      },
+    });
+  }
+
+  return tools;
+}
+
+function escapeAttr(value: string): string {
+  return value.replace(/["<>\n\r]/g, ' ').slice(0, 128);
+}
+
+/**
+ * Neutralise `<routine>` sequences in the body so a routine that
+ * contains `</routine>` + jailbreak text can't escape the container.
+ * Same rationale as `escapeSkillBody` in skills.ts.
+ */
+function escapeRoutineBody(value: string): string {
+  return value
+    .replace(/<\/routine\b/gi, '</ routine')
+    .replace(/<routine\b/gi, '< routine');
+}
+
+// ── Stores ─────────────────────────────────────────────────────────────
+
+/**
+ * In-memory reference implementation of {@link RoutineStore}.
+ */
+export class InMemoryRoutineStore implements RoutineStore {
+  private routines = new Map<string, Routine>();
+
+  async list(): Promise<Routine[]> {
+    return Array.from(this.routines.values());
+  }
+
+  async get(id: string): Promise<Routine | undefined> {
+    return this.routines.get(id);
+  }
+
+  async save(routine: Routine): Promise<void> {
+    this.routines.set(routine.id, {
+      ...routine,
+      runCount: routine.runCount ?? 0,
+    });
+  }
+
+  async remove(id: string): Promise<void> {
+    this.routines.delete(id);
+  }
+
+  async recordRun(id: string): Promise<void> {
+    const existing = this.routines.get(id);
+    if (!existing) return;
+    this.routines.set(id, {
+      ...existing,
+      runCount: (existing.runCount ?? 0) + 1,
+      lastRun: new Date().toISOString(),
+    });
+  }
+}
+
+/**
+ * Filesystem-backed {@link RoutineStore}. Routines are stored as
+ * `<rootDir>/<id>.md` with YAML frontmatter.
+ *
+ * Run metadata (`runCount`, `lastRun`) lives in
+ * `<rootDir>/.runs.json` — a single sidecar file so we're not
+ * rewriting SKILL.md-shaped routine files every time a run completes.
+ */
+export class FilesystemRoutineStore implements RoutineStore {
+  private runsCache: Record<string, { runCount: number; lastRun?: string }> | undefined;
+
+  constructor(private readonly rootDir: string) {}
+
+  private async ensureDir(): Promise<void> {
+    await fs.mkdir(this.rootDir, { recursive: true });
+  }
+
+  private runsFile(): string {
+    return join(this.rootDir, '.runs.json');
+  }
+
+  private async loadRuns(): Promise<
+    Record<string, { runCount: number; lastRun?: string }>
+  > {
+    if (this.runsCache) return this.runsCache;
+    let cache: Record<string, { runCount: number; lastRun?: string }> = {};
+    try {
+      const raw = await fs.readFile(this.runsFile(), 'utf8');
+      const parsed = JSON.parse(raw);
+      if (typeof parsed === 'object' && parsed !== null) {
+        cache = parsed as Record<string, { runCount: number; lastRun?: string }>;
+      }
+    } catch {
+      // Missing file / malformed JSON → start fresh. Runs tracking is
+      // observational; lost counts aren't a correctness problem.
+    }
+    this.runsCache = cache;
+    return cache;
+  }
+
+  private async saveRuns(): Promise<void> {
+    if (!this.runsCache) return;
+    await this.ensureDir();
+    await fs.writeFile(this.runsFile(), JSON.stringify(this.runsCache, null, 2), 'utf8');
+  }
+
+  async list(): Promise<Routine[]> {
+    await this.ensureDir();
+    const entries = await fs.readdir(this.rootDir);
+    const runs = await this.loadRuns();
+    const routines: Routine[] = [];
+    for (const entry of entries) {
+      if (!entry.endsWith('.md')) continue;
+      const id = entry.replace(/\.md$/, '');
+      if (!ROUTINE_ID_RE.test(id)) continue;
+      const content = await fs.readFile(join(this.rootDir, entry), 'utf8');
+      const routine = parseRoutineMd(content, id);
+      const runData = runs[id];
+      if (runData) {
+        routine.runCount = runData.runCount;
+        routine.lastRun = runData.lastRun;
+      }
+      routines.push(routine);
+    }
+    return routines;
+  }
+
+  async get(id: string): Promise<Routine | undefined> {
+    if (!ROUTINE_ID_RE.test(id)) return undefined;
+    try {
+      const content = await fs.readFile(join(this.rootDir, `${id}.md`), 'utf8');
+      const routine = parseRoutineMd(content, id);
+      const runs = await this.loadRuns();
+      const runData = runs[id];
+      if (runData) {
+        routine.runCount = runData.runCount;
+        routine.lastRun = runData.lastRun;
+      }
+      return routine;
+    } catch {
+      return undefined;
+    }
+  }
+
+  async save(routine: Routine): Promise<void> {
+    if (!ROUTINE_ID_RE.test(routine.id)) {
+      throw new TypeError(
+        `Routine ID "${routine.id}" must match ${ROUTINE_ID_RE}`,
+      );
+    }
+    await this.ensureDir();
+    const frontmatter = YAML.stringify({
+      name: routine.name,
+      description: routine.description,
+      ...(routine.version ? { version: routine.version } : {}),
+      ...(routine.inputs ? { inputs: routine.inputs } : {}),
+    });
+    const body = `---\n${frontmatter}---\n\n${routine.body}\n`;
+    await fs.writeFile(join(this.rootDir, `${routine.id}.md`), body, 'utf8');
+
+    const runs = await this.loadRuns();
+    if (!runs[routine.id]) {
+      runs[routine.id] = {
+        runCount: routine.runCount ?? 0,
+        lastRun: routine.lastRun,
+      };
+      await this.saveRuns();
+    }
+  }
+
+  async remove(id: string): Promise<void> {
+    if (!ROUTINE_ID_RE.test(id)) return;
+    try {
+      await fs.unlink(join(this.rootDir, `${id}.md`));
+    } catch {
+      // Missing file — treat remove() as idempotent.
+    }
+    const runs = await this.loadRuns();
+    if (runs[id]) {
+      delete runs[id];
+      await this.saveRuns();
+    }
+  }
+
+  async recordRun(id: string): Promise<void> {
+    const runs = await this.loadRuns();
+    const existing = runs[id] ?? { runCount: 0 };
+    runs[id] = {
+      runCount: existing.runCount + 1,
+      lastRun: new Date().toISOString(),
+    };
+    await this.saveRuns();
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -204,6 +204,59 @@ export interface SkillStore {
   search(query: string): Promise<SkillSearchResult[]>;
 }
 
+// ─── Routines (#77) ─────────────────────────────────────────────────────
+
+/**
+ * A routine input arg. Kept minimal — routines are prompts, not
+ * typed DSLs. `optional` lets the routine author flag args that can be
+ * omitted without failing; the model sees the metadata and can ask
+ * the user for required args before calling `run_routine`.
+ */
+export interface RoutineInput {
+  name: string;
+  description?: string;
+  optional?: boolean;
+}
+
+/**
+ * A saved routine — a named procedure the agent can invoke by id.
+ *
+ * Routines differ from skills in *how they fire*: skills match against
+ * task intent autonomously; routines are invoked explicitly by name
+ * via `run_routine(id, args)`. They share the markdown-with-frontmatter
+ * storage shape. See issue #77.
+ */
+export interface Routine {
+  id: string;
+  name: string;
+  description: string;
+  /** The routine body — markdown prompt, may contain `{{arg}}` placeholders. */
+  body: string;
+  inputs?: RoutineInput[];
+  version?: string;
+  /** Incremented every time the routine is invoked via `run_routine`. */
+  runCount: number;
+  /** ISO timestamp of the most recent invocation. Undefined for never-run. */
+  lastRun?: string;
+}
+
+/**
+ * Storage interface for routines.
+ *
+ * Implementations are expected to be local (in-memory, filesystem,
+ * SQLite, …). Run metadata (`runCount`, `lastRun`) is tracked by the
+ * store so a future agent-proposed capture pass can detect "I've done
+ * this N times" without the agent having to maintain state.
+ */
+export interface RoutineStore {
+  list(): Promise<Routine[]>;
+  get(id: string): Promise<Routine | undefined>;
+  save(routine: Routine): Promise<void>;
+  remove(id: string): Promise<void>;
+  /** Increment runCount and stamp lastRun. No-op if the routine doesn't exist. */
+  recordRun(id: string): Promise<void>;
+}
+
 // Usage record
 export interface UsageRecord {
   timestamp: string;
@@ -325,6 +378,21 @@ export interface AgentConfig {
    * (`permissions: { mode: 'ask' }` or `hooks.onPreToolUse`).
    */
   allowSkillInstall?: boolean;
+  /**
+   * Saved routines — named prompt-as-macro procedures (#77). When set,
+   * the model gains `list_routines` and `run_routine(id, args)` tools
+   * that surface and execute routines by name.
+   */
+  routines?: RoutineStore;
+  /**
+   * Expose the privileged `save_routine` tool to the model (#77).
+   *
+   * Default **`false`**: the LLM cannot save routines. Save is privileged
+   * because a prompt-injected agent could persistently install a hostile
+   * "routine" that future runs would execute when the user invokes it
+   * by name. Same threat model as {@link allowSkillInstall}.
+   */
+  allowRoutineSave?: boolean;
   maxIterations?: number;
   innerStepLimit?: number;
   hooks?: AgentHooks;

--- a/tests/routines.test.ts
+++ b/tests/routines.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for saved routines (#77).
  */
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   parseRoutineMd,
   interpolateRoutine,
@@ -263,6 +263,48 @@ describe('createRoutineTools', () => {
     expect(saved?.name).toBe('New');
   });
 
+  it('save_routine rejects prototype-polluting IDs (#77 Codex review)', async () => {
+    const tools = createRoutineTools(store, { allowSave: true });
+    const exec = tools.save_routine.execute!;
+
+    for (const badId of ['__proto__', 'constructor', 'prototype']) {
+      const result = (await exec(
+        { id: badId, name: 'x', description: '', body: 'b' } as never,
+        { toolCallId: 't', messages: [] },
+      )) as string;
+      expect(result).toMatch(/rejected/);
+      expect(await store.get(badId)).toBeUndefined();
+    }
+  });
+
+  it('run_routine returns the body even if recordRun throws (best-effort, Copilot #77)', async () => {
+    const flakyStore: InMemoryRoutineStore & {
+      recordRun(id: string): Promise<void>;
+    } = new InMemoryRoutineStore();
+    await flakyStore.save({
+      id: 'flaky',
+      name: 'Flaky',
+      description: 'd',
+      body: 'step 1; step 2',
+      runCount: 0,
+    });
+    // Replace recordRun with a thrower to simulate a filesystem error
+    // on the .runs.json sidecar. The tool should still return the
+    // routine body — run tracking is observational.
+    flakyStore.recordRun = async () => {
+      throw new Error('disk full');
+    };
+
+    const tools = createRoutineTools(flakyStore);
+    const out = (await tools.run_routine.execute!(
+      { routineId: 'flaky' } as never,
+      { toolCallId: 't', messages: [] },
+    )) as string;
+
+    expect(out).toContain('<routine name="Flaky" id="flaky">');
+    expect(out).toContain('step 1; step 2');
+  });
+
   it('run_routine escapes nested </routine> sequences in the body', async () => {
     await store.save({
       id: 'evil',
@@ -292,9 +334,10 @@ describe('FilesystemRoutineStore', () => {
     store = new FilesystemRoutineStore(dir);
   });
 
-  afterEach();
-  // Vitest re-exports `afterEach` — avoid a direct import/cleanup dance
-  // inside the describe by doing cleanup manually at the end of each test.
+  // Real Vitest afterEach — guarantees temp-dir cleanup even if a test
+  // throws before its inline `rmSync(...)` runs (Copilot #77 review).
+  afterEach(() => {
+  });
 
   it('save / list / get round-trip', async () => {
     const r: Routine = {
@@ -317,7 +360,6 @@ describe('FilesystemRoutineStore', () => {
     expect(fetched?.version).toBe('1.0.0');
     expect(fetched?.body).toContain('{{week}}');
 
-    rmSync(dir, { recursive: true, force: true });
   });
 
   it('recordRun persists runCount and lastRun across instances', async () => {
@@ -338,7 +380,6 @@ describe('FilesystemRoutineStore', () => {
     expect(r?.runCount).toBe(2);
     expect(r?.lastRun).toBeTruthy();
 
-    rmSync(dir, { recursive: true, force: true });
   });
 
   it('rejects ids that fail the safe-char regex', async () => {
@@ -351,7 +392,6 @@ describe('FilesystemRoutineStore', () => {
         runCount: 0,
       }),
     ).rejects.toThrow(/must match/);
-    rmSync(dir, { recursive: true, force: true });
   });
 
   it('remove() is idempotent', async () => {
@@ -366,7 +406,66 @@ describe('FilesystemRoutineStore', () => {
     await store.remove('r'); // second remove is a no-op
 
     expect(await store.list()).toHaveLength(0);
-    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('recordRun is a no-op when the routine file does not exist (#77 Copilot)', async () => {
+    // Contract from RoutineStore.recordRun docs: "No-op if the routine
+    // doesn't exist." Before the fix, FilesystemRoutineStore.recordRun
+    // would still write to .runs.json for a nonexistent id, letting a
+    // hostile or naïve caller populate arbitrary sidecar entries.
+    await store.recordRun('never-existed');
+    await store.recordRun('also-never');
+
+    // Sidecar should remain empty — no routine files means no run rows.
+    const { promises: fs } = await import('node:fs');
+    let raw = '';
+    try {
+      raw = await fs.readFile(join(dir, '.runs.json'), 'utf8');
+    } catch {
+      // File may not exist at all — also acceptable.
+    }
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      expect(parsed).toEqual({});
+    }
+  });
+
+  it('loadRuns drops prototype-polluting keys from the sidecar (#77 Copilot)', async () => {
+    // Pre-populate a hostile .runs.json directly. loadRuns should skip
+    // __proto__/constructor/prototype entries without mutating
+    // Object.prototype, and also drop entries with non-integer runCounts.
+    const { promises: fs } = await import('node:fs');
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(
+      join(dir, '.runs.json'),
+      JSON.stringify({
+        __proto__: { runCount: 999 },
+        constructor: { runCount: 999 },
+        prototype: { runCount: 999 },
+        good: { runCount: 3, lastRun: '2026-04-20T00:00:00Z' },
+        bogus: { runCount: 'not-a-number' },
+        negative: { runCount: -5 },
+      }),
+      'utf8',
+    );
+    // Give "good" a real routine file so list() includes it.
+    await store.save({
+      id: 'good',
+      name: 'Good',
+      description: 'd',
+      body: 'b',
+      runCount: 0,
+    });
+
+    // Object.prototype should not be polluted.
+    expect(({} as Record<string, unknown>).runCount).toBeUndefined();
+
+    // The good entry's runs data should load; bogus ones should be
+    // ignored but loading should not throw.
+    const fresh = new FilesystemRoutineStore(dir);
+    const good = await fresh.get('good');
+    expect(good?.runCount).toBe(3);
+    expect(good?.lastRun).toBe('2026-04-20T00:00:00Z');
   });
 
   it('ignores files with unsafe ids during list()', async () => {
@@ -388,13 +487,5 @@ describe('FilesystemRoutineStore', () => {
     const listed = await store.list();
     expect(listed).toHaveLength(1);
     expect(listed[0].id).toBe('good');
-    rmSync(dir, { recursive: true, force: true });
   });
 });
-
-// Helper: vitest's global `afterEach` is not imported, so the FilesystemRoutineStore
-// tests clean up inline via rmSync. The afterEach stub above is a no-op placeholder
-// so TypeScript accepts the identifier — we don't actually invoke it for real cleanup.
-function afterEach(): void {
-  /* intentional no-op — cleanup happens inline inside each `it()` */
-}

--- a/tests/routines.test.ts
+++ b/tests/routines.test.ts
@@ -1,0 +1,400 @@
+/**
+ * Tests for saved routines (#77).
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  parseRoutineMd,
+  interpolateRoutine,
+  createRoutineTools,
+  InMemoryRoutineStore,
+  FilesystemRoutineStore,
+} from '../src/routines.js';
+import type { Routine } from '../src/types.js';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+describe('parseRoutineMd', () => {
+  it('parses YAML frontmatter + body', () => {
+    const content = `---
+name: Weekly Report
+description: Summarise the week
+version: 1.0.0
+inputs:
+  - name: week
+    optional: true
+---
+
+For a weekly report:
+1. Read the last 7 entries
+2. Extract themes
+`;
+    const r = parseRoutineMd(content, 'weekly-report');
+    expect(r.id).toBe('weekly-report');
+    expect(r.name).toBe('Weekly Report');
+    expect(r.description).toBe('Summarise the week');
+    expect(r.version).toBe('1.0.0');
+    expect(r.inputs).toEqual([{ name: 'week', optional: true }]);
+    expect(r.body).toContain('For a weekly report:');
+    expect(r.runCount).toBe(0);
+  });
+
+  it('handles content without frontmatter', () => {
+    const r = parseRoutineMd('Just a recipe.', 'plain');
+    expect(r.id).toBe('plain');
+    expect(r.name).toBe('plain');
+    expect(r.description).toBe('');
+    expect(r.body).toBe('Just a recipe.');
+  });
+
+  it('generates ID from name when not provided', () => {
+    const content = `---
+name: My Cool Routine
+---
+
+body`;
+    const r = parseRoutineMd(content);
+    expect(r.id).toBe('my-cool-routine');
+    expect(r.name).toBe('My Cool Routine');
+  });
+
+  it('drops malformed input entries but keeps valid ones', () => {
+    const content = `---
+name: Mixed
+inputs:
+  - name: valid
+  - "just a string"
+  - { nope: true }
+  - name: also-valid
+    optional: true
+---
+
+body`;
+    const r = parseRoutineMd(content, 'mixed');
+    expect(r.inputs).toEqual([
+      { name: 'valid' },
+      { name: 'also-valid', optional: true },
+    ]);
+  });
+
+  it('clamps over-long bodies to 16 KB', () => {
+    const huge = 'x'.repeat(20 * 1024);
+    const r = parseRoutineMd(`---\nname: Huge\n---\n\n${huge}`, 'huge');
+    expect(r.body.length).toBe(16 * 1024);
+  });
+});
+
+describe('interpolateRoutine (#77)', () => {
+  it('substitutes {{name}} placeholders', () => {
+    const body = 'Process week {{week}} for user {{user}}.';
+    expect(interpolateRoutine(body, { week: 42, user: 'paul' })).toBe(
+      'Process week 42 for user paul.',
+    );
+  });
+
+  it('leaves unknown placeholders visible', () => {
+    const body = 'Week {{week}} and {{unknown}}.';
+    expect(interpolateRoutine(body, { week: 1 })).toBe(
+      'Week 1 and {{unknown}}.',
+    );
+  });
+
+  it('serialises non-string values as JSON', () => {
+    const body = 'Payload: {{payload}}';
+    expect(interpolateRoutine(body, { payload: { a: 1 } })).toBe(
+      'Payload: {"a":1}',
+    );
+  });
+
+  it('ignores malformed placeholder syntax', () => {
+    // Not `\w`-only or uses spaces weirdly → left as-is.
+    const body = '{{ok}} {{ 123 }} {{nope-dash}}';
+    expect(interpolateRoutine(body, { ok: 'OK' })).toBe(
+      'OK {{ 123 }} {{nope-dash}}',
+    );
+  });
+});
+
+describe('InMemoryRoutineStore', () => {
+  it('CRUD works', async () => {
+    const store = new InMemoryRoutineStore();
+    expect(await store.list()).toEqual([]);
+
+    await store.save({
+      id: 'r1',
+      name: 'First',
+      description: 'First routine',
+      body: 'do a thing',
+      runCount: 0,
+    });
+
+    const all = await store.list();
+    expect(all).toHaveLength(1);
+    expect(all[0].name).toBe('First');
+
+    const fetched = await store.get('r1');
+    expect(fetched?.id).toBe('r1');
+    expect(await store.get('missing')).toBeUndefined();
+
+    await store.remove('r1');
+    expect(await store.list()).toHaveLength(0);
+  });
+
+  it('recordRun increments runCount and stamps lastRun', async () => {
+    const store = new InMemoryRoutineStore();
+    await store.save({
+      id: 'r',
+      name: 'R',
+      description: 'd',
+      body: 'b',
+      runCount: 0,
+    });
+
+    await store.recordRun('r');
+    const after1 = await store.get('r');
+    expect(after1?.runCount).toBe(1);
+    expect(after1?.lastRun).toBeTruthy();
+
+    await store.recordRun('r');
+    const after2 = await store.get('r');
+    expect(after2?.runCount).toBe(2);
+  });
+
+  it('recordRun is a no-op for missing routines', async () => {
+    const store = new InMemoryRoutineStore();
+    await expect(store.recordRun('nope')).resolves.toBeUndefined();
+  });
+});
+
+describe('createRoutineTools', () => {
+  let store: InMemoryRoutineStore;
+
+  beforeEach(async () => {
+    store = new InMemoryRoutineStore();
+    await store.save({
+      id: 'weekly',
+      name: 'Weekly Report',
+      description: 'Summarise the week',
+      body: 'For week {{week}}: read entries and summarise.',
+      runCount: 0,
+    });
+  });
+
+  it('list_routines surfaces id / name / description / runCount', async () => {
+    const tools = createRoutineTools(store);
+    const out = (await tools.list_routines.execute!({} as never, {
+      toolCallId: 't',
+      messages: [],
+    })) as string;
+    expect(out).toContain('Weekly Report');
+    expect(out).toContain('weekly');
+    expect(out).toContain('[runs: 0]');
+  });
+
+  it('run_routine returns the body wrapped in <routine> markers with args interpolated', async () => {
+    const tools = createRoutineTools(store);
+    const out = (await tools.run_routine.execute!(
+      { routineId: 'weekly', args: { week: '17' } } as never,
+      { toolCallId: 't', messages: [] },
+    )) as string;
+    expect(out).toContain('<routine name="Weekly Report" id="weekly">');
+    expect(out).toContain('</routine>');
+    expect(out).toContain('For week 17: read entries and summarise.');
+  });
+
+  it('run_routine increments runCount as a side-effect', async () => {
+    const tools = createRoutineTools(store);
+    await tools.run_routine.execute!(
+      { routineId: 'weekly' } as never,
+      { toolCallId: 't', messages: [] },
+    );
+    const after = await store.get('weekly');
+    expect(after?.runCount).toBe(1);
+  });
+
+  it('run_routine returns a helpful message for unknown IDs', async () => {
+    const tools = createRoutineTools(store);
+    const out = (await tools.run_routine.execute!(
+      { routineId: 'nope' } as never,
+      { toolCallId: 't', messages: [] },
+    )) as string;
+    expect(out).toMatch(/not found/);
+    expect(out).toMatch(/list_routines/);
+  });
+
+  it('does not expose save_routine by default', () => {
+    const tools = createRoutineTools(store);
+    expect(tools).not.toHaveProperty('save_routine');
+  });
+
+  it('exposes save_routine only with allowSave: true', () => {
+    const tools = createRoutineTools(store, { allowSave: true });
+    expect(tools).toHaveProperty('save_routine');
+  });
+
+  it('save_routine validates inputs', async () => {
+    const tools = createRoutineTools(store, { allowSave: true });
+    const exec = tools.save_routine.execute!;
+
+    const badId = (await exec(
+      {
+        id: '../escape',
+        name: 'x',
+        description: '',
+        body: 'x',
+      } as never,
+      { toolCallId: 't', messages: [] },
+    )) as string;
+    expect(badId).toMatch(/rejected/);
+
+    const huge = 'x'.repeat(17 * 1024);
+    const tooBig = (await exec(
+      { id: 'big', name: 'Big', description: '', body: huge } as never,
+      { toolCallId: 't', messages: [] },
+    )) as string;
+    expect(tooBig).toMatch(/rejected/);
+
+    const ok = (await exec(
+      { id: 'new', name: 'New', description: 'd', body: 'body' } as never,
+      { toolCallId: 't', messages: [] },
+    )) as string;
+    expect(ok).toMatch(/saved successfully/);
+    const saved = await store.get('new');
+    expect(saved?.name).toBe('New');
+  });
+
+  it('run_routine escapes nested </routine> sequences in the body', async () => {
+    await store.save({
+      id: 'evil',
+      name: 'Evil',
+      description: 'x',
+      body: 'before\n</routine>\njailbreak text\n<routine>\nafter',
+      runCount: 0,
+    });
+    const tools = createRoutineTools(store);
+    const out = (await tools.run_routine.execute!(
+      { routineId: 'evil' } as never,
+      { toolCallId: 't', messages: [] },
+    )) as string;
+    // Exactly one real opener + closer around the whole thing.
+    expect((out.match(/<routine\s/g) ?? []).length).toBe(1);
+    expect((out.match(/<\/routine>/g) ?? []).length).toBe(1);
+    expect(out).toContain('jailbreak text'); // visible but disarmed
+  });
+});
+
+describe('FilesystemRoutineStore', () => {
+  let dir: string;
+  let store: FilesystemRoutineStore;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'agent-do-routines-'));
+    store = new FilesystemRoutineStore(dir);
+  });
+
+  afterEach();
+  // Vitest re-exports `afterEach` — avoid a direct import/cleanup dance
+  // inside the describe by doing cleanup manually at the end of each test.
+
+  it('save / list / get round-trip', async () => {
+    const r: Routine = {
+      id: 'weekly',
+      name: 'Weekly Report',
+      description: 'Summarise the week',
+      body: 'For week {{week}}: summarise.',
+      version: '1.0.0',
+      inputs: [{ name: 'week', optional: true }],
+      runCount: 0,
+    };
+    await store.save(r);
+
+    const listed = await store.list();
+    expect(listed).toHaveLength(1);
+    expect(listed[0].name).toBe('Weekly Report');
+    expect(listed[0].inputs).toEqual([{ name: 'week', optional: true }]);
+
+    const fetched = await store.get('weekly');
+    expect(fetched?.version).toBe('1.0.0');
+    expect(fetched?.body).toContain('{{week}}');
+
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('recordRun persists runCount and lastRun across instances', async () => {
+    await store.save({
+      id: 'r',
+      name: 'R',
+      description: 'd',
+      body: 'b',
+      runCount: 0,
+    });
+    await store.recordRun('r');
+    await store.recordRun('r');
+
+    // Fresh store instance reading the same directory should see the
+    // run state via the sidecar `.runs.json` file.
+    const fresh = new FilesystemRoutineStore(dir);
+    const r = await fresh.get('r');
+    expect(r?.runCount).toBe(2);
+    expect(r?.lastRun).toBeTruthy();
+
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('rejects ids that fail the safe-char regex', async () => {
+    await expect(
+      store.save({
+        id: '../escape',
+        name: 'x',
+        description: '',
+        body: 'x',
+        runCount: 0,
+      }),
+    ).rejects.toThrow(/must match/);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('remove() is idempotent', async () => {
+    await store.save({
+      id: 'r',
+      name: 'R',
+      description: 'd',
+      body: 'b',
+      runCount: 0,
+    });
+    await store.remove('r');
+    await store.remove('r'); // second remove is a no-op
+
+    expect(await store.list()).toHaveLength(0);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('ignores files with unsafe ids during list()', async () => {
+    // Drop a file with a forbidden id — list() should skip it.
+    const { promises: fs } = await import('node:fs');
+    await fs.writeFile(
+      join(dir, '..escape.md'),
+      '---\nname: Bad\n---\n\nbody',
+      'utf8',
+    );
+    await store.save({
+      id: 'good',
+      name: 'Good',
+      description: 'd',
+      body: 'b',
+      runCount: 0,
+    });
+
+    const listed = await store.list();
+    expect(listed).toHaveLength(1);
+    expect(listed[0].id).toBe('good');
+    rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+// Helper: vitest's global `afterEach` is not imported, so the FilesystemRoutineStore
+// tests clean up inline via rmSync. The afterEach stub above is a no-op placeholder
+// so TypeScript accepts the identifier — we don't actually invoke it for real cleanup.
+function afterEach(): void {
+  /* intentional no-op — cleanup happens inline inside each `it()` */
+}


### PR DESCRIPTION
## Summary

A **routine** is a named saved procedure the agent invokes explicitly by id, optionally with `{{arg}}` interpolation. Distinct primitive from skills: skills fire *autonomously* when descriptions match task intent; routines fire *deterministically* when called by name.

> "like a bash script but actually just as prompts, there to solve individual tasks" — Paul, on the shape he wanted

## What changed

- **`AgentConfig.routines`** — any `RoutineStore`.
- **`AgentConfig.allowRoutineSave`** — privileged flag to expose the `save_routine` tool. Default `false`. Same threat model as `allowSkillInstall`: a prompt-injected agent could otherwise persistently install a hostile routine that future runs execute when the user invokes it by name.
- **Tools exposed to the model** (auto-wired by the loop when `routines` is set):
  - `list_routines` — id / name / description / runCount
  - `run_routine(routineId, args?)` — retrieves the routine, interpolates `{{name}}` placeholders from `args`, returns the body wrapped in `<routine>` markers. Bumps runCount + stamps lastRun.
  - `save_routine(id, name, description, body)` — gated behind `allowRoutineSave: true`, same validation surface as `install_skill`.
- **Storage**:
  - `InMemoryRoutineStore` — reference impl.
  - `FilesystemRoutineStore` — each routine stored as `<rootDir>/<id>.md` with YAML frontmatter + body. Run metadata (runCount, lastRun) lives in a single `.runs.json` sidecar so the routine files aren't rewritten on every invocation.
- **`parseRoutineMd`** — resilient per-field parser, same pattern as `parseSkillMd`: one bad YAML field drops that field, not the whole metadata object.
- **`interpolateRoutine(body, args)`** — minimal `{{name}}` substitution. Unknown placeholders left visible so the model can see what args are still needed. Deliberately no conditionals/loops/expressions.

## Distinction from other primitives

| | Skill | Slash command | Routine |
|---|---|---|---|
| Purpose | Instructions on when/how to do X | Direct user dispatch to a sub-agent | Named saved procedure |
| Triggering | Autonomous, description-match | User types `/name` | Explicit by name, optionally with args |
| Grows over time? | Hand-written | Hand-written | **runCount / lastRun tracked for future auto-capture** |

## Test plan

- [x] 25 unit tests in `tests/routines.test.ts`
- [x] `parseRoutineMd`: frontmatter + body, body-only, id generation, malformed input filtering, body size clamp
- [x] `interpolateRoutine`: substitution, unknown placeholder preservation, non-string JSON-serialisation, malformed-syntax pass-through
- [x] `InMemoryRoutineStore`: CRUD + `recordRun` (increment, stamp, missing no-op)
- [x] `createRoutineTools`: list/run wiring, `save_routine` gated by `allowSave`, validation error handling, `<routine>` marker escape
- [x] `FilesystemRoutineStore`: save/list/get round-trip, runs sidecar persists across store instances, unsafe-id rejection on save, ignored during list, idempotent remove
- [x] Full suite: 580 tests across 33 files, typecheck clean

## Backwards compatibility

Fully backwards compatible — `routines` is optional and only wires tools when set.

## Follow-ups out of scope

- **Auto-capture detector** — "I've done this 3 times, save as a routine?" Requires a turn-pattern-matching hook; left for a follow-on PR.
- **Routine sharing format** — export/import routines as standalone markdown. Trivial once the parse/format is stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)