### PR TITLE
Two template-pack demos: chief-of-staff + engineering-team (#78)

### DIFF
--- a/demos/chief-of-staff/README.md
+++ b/demos/chief-of-staff/README.md
@@ -38,6 +38,15 @@ sandbox/        — created on first run
   tasks.md
 ```
 
+All four roles (master + 3 specialists) bind their file tools with
+`agentId: ''` — the workspace-root mode documented in
+`src/stores/agent-id.ts`. That's why every specialist reads/writes
+directly in `sandbox/` rather than a per-agent subdirectory
+(`sandbox/master/`, `sandbox/executive-assistant/`, …). This is a
+single shared workspace by design — the orthogonal-policy pattern
+(`priority-map.md` / `auto-resolver.md`) only works if every role
+sees the same files.
+
 ## Extensions (what the pack abstraction would bundle)
 
 When #78 (template packs) lands, this shape becomes:

--- a/demos/chief-of-staff/README.md
+++ b/demos/chief-of-staff/README.md
@@ -1,0 +1,52 @@
+# Chief of Staff demo
+
+Founder's chief of staff pattern ([inspired by clawchief](https://github.com/snarktank/clawchief)), built on agent-do's orchestrator. Master agent coordinates three specialists — Executive Assistant, Business Development, Task Manager — against a shared workspace of markdown files.
+
+## What it shows
+
+- **Policy-as-markdown**: `priority-map.md` + `auto-resolver.md` get re-read at the start of every run and ground every decision. Orthogonal policy files (priorities vs resolution modes) so each can evolve independently.
+- **Source-of-truth rule**: no resolving from memory alone; specialists always check the current state of `inbox.md` / `tracker.md` / `tasks.md` before acting.
+- **Silence contract**: if there's nothing to do, the master responds with `OK` and calls no tools — cheap to run on a cron.
+- **Role-handoff pattern**: each specialist has a narrow brief and defers to the others when a signal isn't theirs.
+
+## Setup
+
+```sh
+export ANTHROPIC_API_KEY=sk-ant-...
+npm install
+npm start
+# Or with an explicit instruction:
+npm start "Triage the inbox and add follow-ups to tasks.md"
+```
+
+First run seeds `./sandbox/` with mock `inbox.md`, `tracker.md`, `tasks.md` plus the two policy files.
+
+## What's mocked vs real
+
+- **Inbox / tracker / tasks** — markdown files in `sandbox/`. In production you'd replace `inbox.md` with a Gmail MCP mount (`mcp__gmail__list_messages`, `mcp__gmail__get_message`). The pattern is identical; only the tool surface changes.
+- **Scheduling** — in production the EA worker would get a Calendar MCP (`mcp__calendar__list_events`, `mcp__calendar__suggest_time`).
+
+## Structure
+
+```
+index.ts        — master + 3 workers wired to one shared FilesystemMemoryStore
+sandbox/        — created on first run
+  priority-map.md
+  auto-resolver.md
+  inbox.md
+  tracker.md
+  tasks.md
+```
+
+## Extensions (what the pack abstraction would bundle)
+
+When #78 (template packs) lands, this shape becomes:
+
+```ts
+await createTemplatePack('chief-of-staff', {
+  owner: 'Paul Kinlan',
+  mcpServers: { gmail: {...}, calendar: {...} },
+});
+```
+
+…and the pack manifest codifies: the three role prompts, the two policy files, the shared workspace layout, and the cron schedule for a scheduled inbox sweep.

--- a/demos/chief-of-staff/index.ts
+++ b/demos/chief-of-staff/index.ts
@@ -139,11 +139,17 @@ seed('tasks.md', TASKS);
 //  File stores (workspace tools for each role)
 // ═══════════════════════════════════════════════
 
+// FilesystemMemoryStore scopes paths to `{baseDir}/{agentId}/`. Using
+// `agentId: ''` puts all roles at the workspace root — which is what we
+// want here because every specialist reads/writes the same shared
+// files (priority-map.md, inbox.md, tracker.md, tasks.md) seeded above.
+// Binding to 'master' would send reads/writes to `sandbox/master/*`,
+// missing the seeded source-of-truth files entirely.
 const store = new FilesystemMemoryStore(SANDBOX_DIR);
-const masterFileTools = createFileTools(store, 'master');
-const eaFileTools = createFileTools(store, 'master'); // shared workspace
-const bdFileTools = createFileTools(store, 'master');
-const taskFileTools = createFileTools(store, 'master');
+const masterFileTools = createFileTools(store, '');
+const eaFileTools = createFileTools(store, '');
+const bdFileTools = createFileTools(store, '');
+const taskFileTools = createFileTools(store, '');
 
 // ═══════════════════════════════════════════════
 //  Build the orchestrator

--- a/demos/chief-of-staff/index.ts
+++ b/demos/chief-of-staff/index.ts
@@ -1,0 +1,298 @@
+/**
+ * Demo: Chief of Staff
+ *
+ * A "founder's chief of staff" — master agent coordinates three
+ * specialists (Executive Assistant, Business Development, Task Manager)
+ * against a shared workspace of markdown files.
+ *
+ * This demo shows the *shape* of the clawchief pattern adapted to
+ * agent-do — policy modules as markdown injected into the system
+ * prompt, deterministic handoffs between roles, and a single
+ * source-of-truth workspace each role reads before acting.
+ *
+ * Running the demo creates a workspace in ./sandbox/ with seed files:
+ *   - priority-map.md      (policy: who/what matters, P0-P3 levels)
+ *   - auto-resolver.md     (policy: when to act vs escalate)
+ *   - inbox.md             (mock inbox — replace with Gmail MCP later)
+ *   - tracker.md           (BD lead tracker)
+ *   - tasks.md             (live TODO list)
+ *
+ * Run:
+ *   export ANTHROPIC_API_KEY=sk-ant-...
+ *   npm start
+ *   # Or pass a specific instruction:
+ *   npm start "Triage the inbox and add follow-ups to tasks.md"
+ */
+
+import * as readline from 'node:readline';
+import { writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import {
+  createOrchestrator,
+  createFileTools,
+} from 'agent-do';
+import { FilesystemMemoryStore } from 'agent-do/stores/filesystem';
+import { createAnthropic } from '@ai-sdk/anthropic';
+
+// ═══════════════════════════════════════════════
+//  Configuration
+// ═══════════════════════════════════════════════
+
+const SANDBOX_DIR = resolve('sandbox');
+const MASTER_MODEL = 'claude-sonnet-4-6';
+const WORKER_MODEL = 'claude-haiku-4-5';
+
+const apiKey = process.env.ANTHROPIC_API_KEY;
+if (!apiKey) {
+  console.error('Error: ANTHROPIC_API_KEY environment variable is required.');
+  process.exit(1);
+}
+
+const provider = createAnthropic({ apiKey });
+
+// ═══════════════════════════════════════════════
+//  Seed the workspace on first run
+// ═══════════════════════════════════════════════
+
+mkdirSync(SANDBOX_DIR, { recursive: true });
+
+function seed(filename: string, content: string): void {
+  const path = resolve(SANDBOX_DIR, filename);
+  if (!existsSync(path)) {
+    writeFileSync(path, content, 'utf8');
+    console.log(`  seeded: ${filename}`);
+  }
+}
+
+const PRIORITY_MAP = `# Priority Map
+
+Ordering rules for what gets the chief of staff's attention first.
+
+## Levels
+- **P0 (drop everything):** CEO, board, regulators, security incidents, legal notices
+- **P1 (same day):** direct reports, active customers, active deals > $50K
+- **P2 (this week):** prospects, vendors, partner check-ins, newsletter signups
+- **P3 (when time permits):** cold outreach, PR pitches, generic recruiter mail
+
+## Routing rules (signal → handoff)
+- New lead or outreach → delegate to **business-development**
+- Calendar / scheduling request → delegate to **executive-assistant**
+- New TODO or status update → delegate to **task-manager**
+- Any P0 → surface to the principal immediately, do not auto-resolve
+`;
+
+const AUTO_RESOLVER = `# Auto-resolver
+
+How the chief of staff decides to act on each signal. Four modes:
+
+- **auto-resolve:** act without asking (P2/P3 informational, out-of-office replies, calendar confirmations matching a standing preference)
+- **draft-and-ask:** write the reply/action but wait for approval (P1 customer replies, new commitments, anything touching money)
+- **escalate:** surface directly to the principal, do not draft (P0 items, conflicts in priority-map, legal/compliance signals)
+- **ignore:** filter spam, confirmed duplicates, no-reply newsletters
+
+## Source-of-truth rule
+Never auto-resolve from memory alone. Always re-read the current state of inbox.md / tracker.md / tasks.md before acting. If a file disagrees with what you remember, trust the file.
+`;
+
+const INBOX = `# Inbox (mock)
+
+- [ ] (P0) CEO: "Can you pull together the board deck updates by EOD Friday?"
+- [ ] (P1) Alice Chen (alice@bigcustomer.com): "We're hitting 500 errors on the /export endpoint since last Tuesday. Can we jump on a call?"
+- [ ] (P2) Recruiter at Talent.co: "Have a senior staff eng role you might be interested in"
+- [ ] (P2) Stripe: "Monthly billing statement is ready"
+- [ ] (P3) Cold pitch: "AI SDR tool, 30% close rate, demo Tuesday?"
+- [ ] (P1) Bob Smith (bob@newprospect.io): "Saw your talk at Conf '26 — would love 30 mins to explore a partnership"
+`;
+
+const TRACKER = `# BD Tracker
+
+| Lead | Company | Status | Next touch | Owner |
+|------|---------|--------|-----------|-------|
+| Alice Chen | BigCustomer Inc | Active customer, urgent issue | Reply today | Principal |
+| Bob Smith | NewProspect.io | Inbound interest | Schedule intro | EA |
+`;
+
+const TASKS = `# Tasks
+
+## Principal
+- [ ] Update board deck (due Fri)
+- [ ] Review Q2 hiring plan
+- [ ] Renew passport
+
+## Assistant
+- [ ] Schedule Bob Smith intro
+- [ ] File Stripe statement
+`;
+
+console.log('=======================================================');
+console.log('  Chief of Staff demo');
+console.log('=======================================================\n');
+console.log(`  Workspace: ${SANDBOX_DIR}`);
+
+seed('priority-map.md', PRIORITY_MAP);
+seed('auto-resolver.md', AUTO_RESOLVER);
+seed('inbox.md', INBOX);
+seed('tracker.md', TRACKER);
+seed('tasks.md', TASKS);
+
+// ═══════════════════════════════════════════════
+//  File stores (workspace tools for each role)
+// ═══════════════════════════════════════════════
+
+const store = new FilesystemMemoryStore(SANDBOX_DIR);
+const masterFileTools = createFileTools(store, 'master');
+const eaFileTools = createFileTools(store, 'master'); // shared workspace
+const bdFileTools = createFileTools(store, 'master');
+const taskFileTools = createFileTools(store, 'master');
+
+// ═══════════════════════════════════════════════
+//  Build the orchestrator
+// ═══════════════════════════════════════════════
+
+const policyPreamble = `Before acting, read priority-map.md and auto-resolver.md. They
+define the rules for what to do with each signal. Ground every
+decision in the actual contents of inbox.md / tracker.md / tasks.md —
+do not resolve from memory alone.`;
+
+const orchestrator = createOrchestrator({
+  master: {
+    id: 'master',
+    name: 'Chief of Staff',
+    model: provider(MASTER_MODEL) as any,
+    systemPrompt: `You are the principal's chief of staff, coordinating three specialists against a shared workspace.
+
+${policyPreamble}
+
+Your specialists:
+- **executive-assistant**: inbox triage, scheduling, meeting notes. Classifies every inbox item into one of P0/P1/P2/P3 and one of auto-resolve/draft-and-ask/escalate/ignore.
+- **business-development**: lead tracking, follow-up cadence, outreach. Owns tracker.md.
+- **task-manager**: keeps tasks.md up to date. Handles new action items, completions, and archival.
+
+Workflow:
+1. Re-read priority-map.md and auto-resolver.md at the start of every run.
+2. Read whichever of inbox.md / tracker.md / tasks.md is relevant.
+3. Delegate to ONE specialist per sub-task via delegate_task (pass the specialist the file contents they need).
+4. Consolidate their outputs, write updates back to the workspace, and summarise what changed.
+
+Silence contract: if there is nothing actionable in this run, respond with "OK" and do not call any tools.`,
+    tools: masterFileTools,
+    maxIterations: 10,
+    hooks: {
+      onPreToolUse: async (event) => {
+        if (event.toolName === 'delegate_task') {
+          const args = event.args as { agentId: string; task: string };
+          const preview = args.task.slice(0, 100);
+          console.log(`  >> master → ${args.agentId}: ${preview}${args.task.length > 100 ? '...' : ''}`);
+        } else if (event.toolName === 'write_file') {
+          const args = event.args as { path: string };
+          console.log(`  >> master updating ${args.path}`);
+        }
+        return { decision: 'allow' };
+      },
+      onComplete: async (event) => {
+        console.log('');
+        console.log('-------------------------------------------------------');
+        console.log(`  done — ${event.totalSteps} steps, $${event.usage.totalCost.toFixed(4)}`);
+      },
+    },
+    usage: { enabled: true },
+  },
+  workers: [
+    {
+      id: 'executive-assistant',
+      name: 'Executive Assistant',
+      model: provider(WORKER_MODEL) as any,
+      systemPrompt: `You are the principal's executive assistant. You triage the inbox and handle scheduling.
+
+${policyPreamble}
+
+Deliverables:
+- For each inbox item: classify priority (P0-P3) and resolution mode (auto-resolve / draft-and-ask / escalate / ignore) per auto-resolver.md.
+- Produce a structured summary with three sections: "Escalate now", "Draft reply (needs approval)", "Auto-resolved".
+- NEVER send replies directly — draft and ask.`,
+      tools: eaFileTools,
+      maxIterations: 3,
+    },
+    {
+      id: 'business-development',
+      name: 'Business Development',
+      model: provider(WORKER_MODEL) as any,
+      systemPrompt: `You are the principal's BD / CRM owner.
+
+${policyPreamble}
+
+Deliverables:
+- New leads from the inbox or handed off from EA → append a row to tracker.md with initial status + next-touch date.
+- Apply follow-up cadence: 2 days after first touch, 5 days after second, 7 days after third; stop after 3.
+- Return a short report of what you added or updated.
+
+Defer to executive-assistant when a signal is scheduling/calendar-only.`,
+      tools: bdFileTools,
+      maxIterations: 3,
+    },
+    {
+      id: 'task-manager',
+      name: 'Task Manager',
+      model: provider(WORKER_MODEL) as any,
+      systemPrompt: `You are the principal's task manager. You own tasks.md.
+
+${policyPreamble}
+
+Deliverables:
+- New action items → append under the correct owner section (Principal / Assistant).
+- Completions → check the box and move to a "Completed" section at the bottom.
+- Return the updated tasks.md content after your edits.`,
+      tools: taskFileTools,
+      maxIterations: 3,
+    },
+  ],
+});
+
+// ═══════════════════════════════════════════════
+//  Run
+// ═══════════════════════════════════════════════
+
+async function getInstruction(): Promise<string> {
+  const args = process.argv.slice(2);
+  if (args.length > 0) return args.join(' ');
+  return new Promise((resolve) => {
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+    rl.question('\n  What should the chief of staff work on? ', (answer) => {
+      rl.close();
+      resolve(answer.trim());
+    });
+  });
+}
+
+const instruction =
+  (await getInstruction()) ||
+  'Do a standard pass: triage the inbox, update the BD tracker with any new leads, and keep tasks.md current.';
+
+console.log('');
+console.log('=======================================================');
+console.log('  Instruction');
+console.log('=======================================================');
+console.log(`  ${instruction}\n`);
+
+let finalText = '';
+for await (const event of orchestrator.stream(instruction)) {
+  switch (event.type) {
+    case 'text':
+      finalText += event.content;
+      break;
+    case 'error':
+      console.log(`  [error] ${event.content}`);
+      break;
+  }
+}
+
+console.log('');
+console.log('=======================================================');
+console.log('  Chief of Staff report');
+console.log('=======================================================');
+console.log(finalText);
+console.log('');
+console.log(`  Workspace (check your changes): ${SANDBOX_DIR}`);

--- a/demos/chief-of-staff/package-lock.json
+++ b/demos/chief-of-staff/package-lock.json
@@ -1,0 +1,687 @@
+{
+  "name": "agent-do-demo-chief-of-staff",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "agent-do-demo-chief-of-staff",
+      "dependencies": {
+        "agent-do": "file:../../"
+      },
+      "devDependencies": {
+        "@ai-sdk/anthropic": "^3.0.0",
+        "tsx": "^4.0.0"
+      }
+    },
+    "../..": {
+      "version": "0.2.0",
+      "dependencies": {
+        "@ai-sdk/anthropic": "^3.0.0",
+        "@ai-sdk/google": "^3.0.0",
+        "@ai-sdk/openai": "^3.0.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "ai": "^6.0.168",
+        "ignore": "^7.0.5",
+        "yaml": "^2.8.3",
+        "zod": "^4.3.6"
+      },
+      "bin": {
+        "agent-do": "dist/src/cli.js"
+      },
+      "devDependencies": {
+        "@changesets/changelog-github": "^0.6.0",
+        "@changesets/cli": "^2.31.0",
+        "@types/node": "^25.6.0",
+        "typedoc": "^0.28.0",
+        "typedoc-plugin-markdown": "^4.4.0",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.4"
+      },
+      "peerDependencies": {
+        "@ai-sdk/anthropic": "^3.0.0",
+        "@ai-sdk/google": "^3.0.0",
+        "@ai-sdk/openai": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@ai-sdk/anthropic": {
+          "optional": true
+        },
+        "@ai-sdk/google": {
+          "optional": true
+        },
+        "@ai-sdk/openai": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ai-sdk/anthropic": {
+      "version": "3.0.71",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.71.tgz",
+      "integrity": "sha512-bUWOzrzR0gJKJO/PLGMR4uH2dqEgqGhrsCV+sSpk4KtOEnUQlfjZI/F7BFlqSvVpFbjdgYRRLysAeEZpJ6S1lg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.23.tgz",
+      "integrity": "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/agent-do": {
+      "resolved": "../..",
+      "link": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "dev": true,
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/demos/chief-of-staff/package.json
+++ b/demos/chief-of-staff/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "agent-do-demo-chief-of-staff",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx index.ts"
+  },
+  "dependencies": {
+    "agent-do": "file:../../"
+  },
+  "devDependencies": {
+    "@ai-sdk/anthropic": "^3.0.0",
+    "tsx": "^4.0.0"
+  }
+}

--- a/demos/engineering-team/README.md
+++ b/demos/engineering-team/README.md
@@ -1,0 +1,46 @@
+# Engineering Team demo
+
+Sprint-ordered pipeline for planning a feature ([inspired by garrytan/gstack](https://github.com/garrytan/gstack)). Master runs 5 phases in order, each handed off to a specialist that produces a written artifact the next phase consumes.
+
+## The pipeline
+
+```
+Think   → office-hours        → 01-design-doc.md     (6 forcing questions)
+Plan    → plan-eng-review     → 02-plan.md           (ASCII diagrams, edge cases, test matrix)
+Review  → investigate         → 03-investigation.md  (existing code paths, invariants, risks)
+Test    → qa                  → 04-test-plan.md      (red-team the plan, acceptance criteria)
+Ship    → release-engineer    → 05-rollout.md        (stages, metrics, rollback)
+```
+
+## What it shows
+
+- **Sprint-ordered pipeline** — each phase strictly follows the previous; specialists consume the prior phase's artifact as input.
+- **Specialist role prompts** — opinionated stances baked into each system prompt (QA's "lean pessimistic", Investigator's "Iron Law: no fixes without investigation", Release Engineer's "3 AM rollback test").
+- **Forcing questions as scaffolding** — office-hours doesn't design; it interrogates. The 6-question template is the forcing function.
+- **Shared workspace** — every artifact lives in `./sprint/` so phases can reference each other explicitly.
+
+## Setup
+
+```sh
+export ANTHROPIC_API_KEY=sk-ant-...
+npm install
+npm start "Add an audit log for write operations"
+# Or run interactively:
+npm start
+```
+
+## Structure
+
+```
+index.ts        — master + 5 phase workers, wired to one FilesystemMemoryStore
+sprint/         — created on first run
+  01-design-doc.md      (from office-hours)
+  02-plan.md            (from plan-eng-review)
+  03-investigation.md   (from investigate)
+  04-test-plan.md       (from qa)
+  05-rollout.md         (from release-engineer)
+```
+
+## Role-pair idea (not implemented here)
+
+gstack uses a role-pair pattern: plan-time twins (`plan-design-review`, `plan-devex-review`, `plan-eng-review`) paired with audit-time twins (`design-review`, `devex-review`, `review`) that score the built result against what the plan predicted. This demo only runs the plan-time phases. The audit pair would run after implementation and would be a natural extension once the engineering-team pack abstracts this pipeline (#78).

--- a/demos/engineering-team/README.md
+++ b/demos/engineering-team/README.md
@@ -41,6 +41,14 @@ sprint/         — created on first run
   05-rollout.md         (from release-engineer)
 ```
 
+All six roles (master + 5 phase workers) bind their file tools with
+`agentId: ''` — the workspace-root mode documented in
+`src/stores/agent-id.ts`. That's why every phase's artifact lands
+directly in `sprint/` rather than `sprint/master/` or
+`sprint/office-hours/`. The pipeline depends on each phase reading
+the previous phase's output by name, so a single shared workspace
+is the whole point.
+
 ## Role-pair idea (not implemented here)
 
 gstack uses a role-pair pattern: plan-time twins (`plan-design-review`, `plan-devex-review`, `plan-eng-review`) paired with audit-time twins (`design-review`, `devex-review`, `review`) that score the built result against what the plan predicted. This demo only runs the plan-time phases. The audit pair would run after implementation and would be a natural extension once the engineering-team pack abstracts this pipeline (#78).

--- a/demos/engineering-team/index.ts
+++ b/demos/engineering-team/index.ts
@@ -47,9 +47,14 @@ const provider = createAnthropic({ apiKey });
 
 mkdirSync(SPRINT_DIR, { recursive: true });
 
+// `agentId: ''` mounts both master and workers at the workspace root
+// (SPRINT_DIR) so every phase's artifact lands in `sprint/01-…` through
+// `sprint/05-…` as documented. Binding to 'master' would send writes
+// to `sprint/master/*` — the README and final console output would
+// then point at the wrong place.
 const store = new FilesystemMemoryStore(SPRINT_DIR);
-const masterFileTools = createFileTools(store, 'master');
-const workerFileTools = createFileTools(store, 'master'); // shared workspace
+const masterFileTools = createFileTools(store, '');
+const workerFileTools = createFileTools(store, '');
 
 // ═══════════════════════════════════════════════
 //  Build the orchestrator

--- a/demos/engineering-team/index.ts
+++ b/demos/engineering-team/index.ts
@@ -1,0 +1,248 @@
+/**
+ * Demo: Engineering Team
+ *
+ * A sprint-ordered pipeline of specialist roles that runs a single
+ * feature request from "idea" to "ship plan" — inspired by
+ * garrytan/gstack's engineering-team taxonomy. Master coordinates the
+ * phases; each phase has one specialist that produces an artifact
+ * the next phase consumes.
+ *
+ * Pipeline:
+ *   Think    — office-hours         (6 forcing questions → design doc)
+ *   Plan     — plan-eng-review      (ASCII diagrams, edge cases, test matrix)
+ *   Review   — investigate          ("Iron Law: no fixes without investigation")
+ *   Test     — qa                   (red-team the plan, list holes)
+ *   Ship     — release-engineer     (rollout, canary, rollback plan)
+ *
+ * The demo writes intermediate + final artifacts to ./sprint/.
+ *
+ * Run:
+ *   export ANTHROPIC_API_KEY=sk-ant-...
+ *   npm start "Add an audit log for write operations"
+ *   npm start   # prompts for a feature
+ */
+
+import * as readline from 'node:readline';
+import { mkdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { createOrchestrator, createFileTools } from 'agent-do';
+import { FilesystemMemoryStore } from 'agent-do/stores/filesystem';
+import { createAnthropic } from '@ai-sdk/anthropic';
+
+// ═══════════════════════════════════════════════
+//  Configuration
+// ═══════════════════════════════════════════════
+
+const SPRINT_DIR = resolve('sprint');
+const MASTER_MODEL = 'claude-sonnet-4-6';
+const WORKER_MODEL = 'claude-haiku-4-5';
+
+const apiKey = process.env.ANTHROPIC_API_KEY;
+if (!apiKey) {
+  console.error('Error: ANTHROPIC_API_KEY environment variable is required.');
+  process.exit(1);
+}
+
+const provider = createAnthropic({ apiKey });
+
+mkdirSync(SPRINT_DIR, { recursive: true });
+
+const store = new FilesystemMemoryStore(SPRINT_DIR);
+const masterFileTools = createFileTools(store, 'master');
+const workerFileTools = createFileTools(store, 'master'); // shared workspace
+
+// ═══════════════════════════════════════════════
+//  Build the orchestrator
+// ═══════════════════════════════════════════════
+
+const orchestrator = createOrchestrator({
+  master: {
+    id: 'master',
+    name: 'Tech Lead',
+    model: provider(MASTER_MODEL) as any,
+    systemPrompt: `You are the tech lead running a 5-phase engineering sprint on a single feature request.
+
+Phases must happen in order. Each phase hands off a written artifact to the next via the shared workspace.
+
+1. **Think** → delegate to office-hours. Output: 01-design-doc.md — answers 6 forcing questions (Who is this for? What's the smallest version that proves it? What would make this a 10x improvement? What could go wrong? What are we explicitly not doing? How will we know it worked?). Write the file.
+2. **Plan** → delegate to plan-eng-review. Input: 01-design-doc.md. Output: 02-plan.md — ASCII system diagrams, edge cases, test matrix.
+3. **Review** → delegate to investigate. Input: 02-plan.md. Output: 03-investigation.md — existing code paths this touches, prior bugs in the neighbourhood, load-bearing invariants. Follow the Iron Law: no fix recommendations without first investigating what's actually there.
+4. **Test** → delegate to qa. Input: 02-plan.md + 03-investigation.md. Output: 04-test-plan.md — red-team the plan, identify holes, propose test cases (unit + integration + failure modes).
+5. **Ship** → delegate to release-engineer. Input: all prior artifacts. Output: 05-rollout.md — staged rollout, canary metrics to watch, abort criteria, rollback plan.
+
+After all five artifacts exist, produce a short final summary: what we're building, the top 3 risks surfaced, and the go/no-go recommendation.
+
+Do NOT skip phases. Do NOT write the artifacts yourself — each specialist writes theirs.`,
+    tools: masterFileTools,
+    maxIterations: 12,
+    hooks: {
+      onPreToolUse: async (event) => {
+        if (event.toolName === 'delegate_task') {
+          const args = event.args as { agentId: string };
+          console.log(`\n  ── phase: ${args.agentId} ──`);
+        } else if (event.toolName === 'write_file') {
+          const args = event.args as { path: string };
+          console.log(`  >> master writing ${args.path}`);
+        }
+        return { decision: 'allow' };
+      },
+      onPostToolUse: async (event) => {
+        if (event.toolName === 'delegate_task') {
+          const args = event.args as { agentId: string };
+          console.log(`     ${args.agentId} done (${event.durationMs}ms)`);
+        }
+      },
+      onComplete: async (event) => {
+        console.log('\n-------------------------------------------------------');
+        console.log(`  sprint complete — ${event.totalSteps} steps, $${event.usage.totalCost.toFixed(4)}`);
+      },
+    },
+    usage: { enabled: true },
+  },
+  workers: [
+    {
+      id: 'office-hours',
+      name: 'Office Hours (Think)',
+      model: provider(WORKER_MODEL) as any,
+      systemPrompt: `You run "office hours" for the tech lead. You answer six forcing questions about a feature request before any design work starts.
+
+Write 01-design-doc.md with exactly these sections:
+1. Who is this for?
+2. What's the smallest version that proves the hypothesis?
+3. What would make this a 10x improvement (not 10%)?
+4. What could go wrong? (failure modes, abuse cases)
+5. What are we explicitly NOT doing? (scope fences)
+6. How will we know it worked? (measurable criteria)
+
+Be concrete. Cite specifics, not generalities.`,
+      tools: workerFileTools,
+      maxIterations: 3,
+    },
+    {
+      id: 'plan-eng-review',
+      name: 'Engineering Plan Review',
+      model: provider(WORKER_MODEL) as any,
+      systemPrompt: `You are a senior engineer doing a plan review BEFORE any code gets written.
+
+Read 01-design-doc.md. Write 02-plan.md with:
+- **System diagram** (ASCII) — components, data flow, trust boundaries.
+- **Data model** — new/changed tables, columns, indices. Migration plan.
+- **Edge cases** — list of at least 8. For each: detection + handling.
+- **Test matrix** — unit / integration / load / failure / security. What gets tested in each layer and why.
+- **Non-goals** — things this plan deliberately does not solve.
+
+Be specific. No hand-waving.`,
+      tools: workerFileTools,
+      maxIterations: 3,
+    },
+    {
+      id: 'investigate',
+      name: 'Investigator',
+      model: provider(WORKER_MODEL) as any,
+      systemPrompt: `You are the debugger/investigator. You do not propose fixes until you understand what's there.
+
+**Iron Law:** no recommendations without first investigating.
+
+Read 02-plan.md. Write 03-investigation.md with:
+- **Code paths this touches** — files, functions, entry points.
+- **Prior art** — similar features that exist; patterns to reuse or avoid.
+- **Load-bearing invariants** — things the current code assumes to be true that this plan must preserve.
+- **Known bugs in the neighbourhood** — from git log / issues.
+- **Risk assessment** — concrete things that could break, ranked by likelihood and blast radius.
+
+If you can't investigate something properly, say so explicitly ("Unable to verify X without access to Y").`,
+      tools: workerFileTools,
+      maxIterations: 3,
+    },
+    {
+      id: 'qa',
+      name: 'QA',
+      model: provider(WORKER_MODEL) as any,
+      systemPrompt: `You are QA. Your job is to find the holes — red-team the plan, don't bless it.
+
+Read 02-plan.md and 03-investigation.md. Write 04-test-plan.md with:
+- **Test cases** — at least 12, mixing happy paths, edge cases, adversarial inputs, and failure-mode recovery.
+- **What the plan missed** — your independent list of scenarios the plan-eng-review didn't cover.
+- **Browser / OS / version matrix** if relevant.
+- **Acceptance criteria** — what "done" looks like, measurable.
+
+Lean pessimistic. If something can't be tested cheaply, flag it.`,
+      tools: workerFileTools,
+      maxIterations: 3,
+    },
+    {
+      id: 'release-engineer',
+      name: 'Release Engineer',
+      model: provider(WORKER_MODEL) as any,
+      systemPrompt: `You are the release engineer. You design the rollout plan and the rollback.
+
+Read all prior artifacts (01-05 up to this point). Write 05-rollout.md with:
+- **Stages** — canary percentage, bake time, promotion gates.
+- **Metrics to watch** — specific signals, thresholds, dashboards.
+- **Abort criteria** — when we stop the rollout, who decides.
+- **Rollback plan** — exact steps, tested or not, data migration reversibility.
+- **Comms** — who gets notified at which milestone (eng, support, customers).
+
+The test: if this rollout goes sideways at 3 AM, could the on-call engineer execute the rollback from this doc alone? If not, rewrite until they can.`,
+      tools: workerFileTools,
+      maxIterations: 3,
+    },
+  ],
+});
+
+// ═══════════════════════════════════════════════
+//  Run
+// ═══════════════════════════════════════════════
+
+async function getFeature(): Promise<string> {
+  const args = process.argv.slice(2);
+  if (args.length > 0) return args.join(' ');
+  return new Promise((resolve) => {
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+    rl.question('\n  What feature are we planning? ', (answer) => {
+      rl.close();
+      resolve(answer.trim());
+    });
+  });
+}
+
+const feature = await getFeature();
+
+if (!feature) {
+  console.error('  Error: no feature provided.');
+  process.exit(1);
+}
+
+console.log('=======================================================');
+console.log('  Engineering team sprint');
+console.log('=======================================================');
+console.log(`  Feature: ${feature}`);
+console.log(`  Workspace: ${SPRINT_DIR}\n`);
+
+const task = `Run the full 5-phase engineering sprint on this feature request:
+
+"${feature}"
+
+Delegate each phase to its specialist, in order. Verify each artifact exists before moving to the next phase. Produce a final summary at the end.`;
+
+let finalText = '';
+for await (const event of orchestrator.stream(task)) {
+  switch (event.type) {
+    case 'text':
+      finalText += event.content;
+      break;
+    case 'error':
+      console.log(`  [error] ${event.content}`);
+      break;
+  }
+}
+
+console.log('\n=======================================================');
+console.log('  Tech lead summary');
+console.log('=======================================================');
+console.log(finalText);
+console.log('');
+console.log(`  Artifacts: ${SPRINT_DIR}/01-design-doc.md … 05-rollout.md`);

--- a/demos/engineering-team/package-lock.json
+++ b/demos/engineering-team/package-lock.json
@@ -1,0 +1,687 @@
+{
+  "name": "agent-do-demo-engineering-team",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "agent-do-demo-engineering-team",
+      "dependencies": {
+        "agent-do": "file:../../"
+      },
+      "devDependencies": {
+        "@ai-sdk/anthropic": "^3.0.0",
+        "tsx": "^4.0.0"
+      }
+    },
+    "../..": {
+      "version": "0.2.0",
+      "dependencies": {
+        "@ai-sdk/anthropic": "^3.0.0",
+        "@ai-sdk/google": "^3.0.0",
+        "@ai-sdk/openai": "^3.0.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "ai": "^6.0.168",
+        "ignore": "^7.0.5",
+        "yaml": "^2.8.3",
+        "zod": "^4.3.6"
+      },
+      "bin": {
+        "agent-do": "dist/src/cli.js"
+      },
+      "devDependencies": {
+        "@changesets/changelog-github": "^0.6.0",
+        "@changesets/cli": "^2.31.0",
+        "@types/node": "^25.6.0",
+        "typedoc": "^0.28.0",
+        "typedoc-plugin-markdown": "^4.4.0",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.4"
+      },
+      "peerDependencies": {
+        "@ai-sdk/anthropic": "^3.0.0",
+        "@ai-sdk/google": "^3.0.0",
+        "@ai-sdk/openai": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@ai-sdk/anthropic": {
+          "optional": true
+        },
+        "@ai-sdk/google": {
+          "optional": true
+        },
+        "@ai-sdk/openai": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ai-sdk/anthropic": {
+      "version": "3.0.71",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.71.tgz",
+      "integrity": "sha512-bUWOzrzR0gJKJO/PLGMR4uH2dqEgqGhrsCV+sSpk4KtOEnUQlfjZI/F7BFlqSvVpFbjdgYRRLysAeEZpJ6S1lg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.23.tgz",
+      "integrity": "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/agent-do": {
+      "resolved": "../..",
+      "link": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "dev": true,
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/demos/engineering-team/package.json
+++ b/demos/engineering-team/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "agent-do-demo-engineering-team",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx index.ts"
+  },
+  "dependencies": {
+    "agent-do": "file:../../"
+  },
+  "devDependencies": {
+    "@ai-sdk/anthropic": "^3.0.0",
+    "tsx": "^4.0.0"
+  }
+}


### PR DESCRIPTION
## Summary

Two standalone demos that show the shape of each template pack *before* we abstract them. Per the plan agreed on #78, this is "demos first, pack later — see what actually repeats before deciding the manifest surface."

### demos/chief-of-staff

Master + 3 specialists (Executive Assistant, Business Development, Task Manager) coordinating against a shared markdown workspace. Inspired by [snarktank/clawchief](https://github.com/snarktank/clawchief).

- Policy-as-markdown: \`priority-map.md\` + \`auto-resolver.md\` re-read at the start of every run, ground every decision
- Source-of-truth rule: specialists never resolve from memory, always re-read the live file
- Silence contract: \`OK\` if nothing to do — cheap to run on a cron
- Mock \`inbox.md\` / \`tracker.md\` / \`tasks.md\` in \`sandbox/\`; swap for Gmail / Calendar MCP later

### demos/engineering-team

5-phase sprint pipeline with specialist role prompts, inspired by [garrytan/gstack](https://github.com/garrytan/gstack):

\`\`\`
Think   → office-hours        → 01-design-doc.md      (6 forcing questions)
Plan    → plan-eng-review     → 02-plan.md            (diagrams, edges, test matrix)
Review  → investigate         → 03-investigation.md   (Iron Law: no fixes w/o investigation)
Test    → qa                  → 04-test-plan.md       (red-team the plan)
Ship    → release-engineer    → 05-rollout.md         (3 AM rollback test)
\`\`\`

Each phase produces a numbered markdown artifact the next phase consumes. The specialist role prompts bake in opinionated stances (QA leans pessimistic, Investigator enforces "no fixes without investigation", Release Engineer's doc has to be executable at 3 AM).

## What these demos teach us for #78

Running both side-by-side should surface what's actually common enough to abstract. Candidates I can already see:

- **Shared workspace dir pattern** — both demos create a sandbox directory and thread it through \`FilesystemMemoryStore\` + \`createFileTools\` to every role
- **Policy preamble** — chief-of-staff has it; engineering-team doesn't (but could — something like "PR template rules", "code review checklist")
- **Numbered-artifact handoff** — engineering-team uses \`01-… 05-\`; chief-of-staff doesn't (it's more stateful). Different shapes → pack manifests should NOT force a single convention
- **Role prompts as first-class units** — both demos have 3-5 system-prompt blocks that feel like they want their own files (e.g. \`roles/executive-assistant.md\`)

## Not included yet (waiting on sibling PRs)

- **Skills** — these demos don't use \`AgentConfig.skills\` yet. Once #74 lands, roles could ship with skill packs mounted alongside the prompt.
- **MCP** — chief-of-staff uses markdown mocks for inbox/calendar/tasks. Once #75 lands (now on main), swap \`inbox.md\` for \`mcp__gmail__list_messages\` and \`tracker.md\` for a CRM MCP.
- **Routines** — engineering-team's 5-phase pipeline is a natural routine. Once #77 lands, the pipeline could be saved as a \`run_routine('engineering-sprint', { feature })\` macro.

## Test plan

- [ ] Manual: \`cd demos/chief-of-staff && npm install && npm start\` with \`ANTHROPIC_API_KEY\`, verify the 3-specialist delegation flow produces a structured report and updates \`sandbox/tracker.md\` / \`sandbox/tasks.md\`
- [ ] Manual: \`cd demos/engineering-team && npm install && npm start "Add rate limiting to the public API"\`, verify all 5 phase artifacts (\`01-\` through \`05-\`) are written in sequence
- [x] Nothing in \`src/\` changed → existing test suite untouched (589 tests still pass on main)

## Why branched off main (not off the other feature PRs)

These demos use only primitives available on main today (orchestrator, skills store as system-prompt, file tools). That means they can land independently and be enhanced as the other PRs merge. Concrete enhancement paths listed in each README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)