### PR TITLE
Multi-provider support across all demos

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -23,10 +23,10 @@ Then install each demo's dependencies (using subshells so your working directory
 Each demo auto-detects which AI SDK provider to use from the environment. Set an API key for Anthropic, Google, or OpenAI:
 
 ```bash
-export ANTHROPIC_API_KEY=sk-ant-...    # picks Anthropic (claude-sonnet-4-6 / claude-haiku-4-5)
-export GOOGLE_API_KEY=...              # picks Google    (gemini-2.5-pro   / gemini-2.5-flash)
-#  …or GEMINI_API_KEY, accepted as an alias
-export OPENAI_API_KEY=sk-...           # picks OpenAI    (gpt-5            / gpt-5-mini)
+export ANTHROPIC_API_KEY=sk-ant-...              # picks Anthropic (claude-sonnet-4-6 / claude-haiku-4-5)
+export GOOGLE_GENERATIVE_AI_API_KEY=...          # picks Google    (gemini-2.5-pro   / gemini-2.5-flash)
+#   …or GOOGLE_API_KEY / GEMINI_API_KEY, both accepted as aliases
+export OPENAI_API_KEY=sk-...                     # picks OpenAI    (gpt-5            / gpt-5-mini)
 ```
 
 If more than one is set, the demos pick **anthropic → google → openai** in that order. To force a specific provider (useful when you have multiple keys set), set `DEMO_PROVIDER`:

--- a/demos/README.md
+++ b/demos/README.md
@@ -18,10 +18,27 @@ Then install each demo's dependencies (using subshells so your working directory
 (cd demos/code-reviewer && npm install)
 ```
 
-Make sure your `ANTHROPIC_API_KEY` environment variable is set:
+### Choose a model provider
+
+Each demo auto-detects which AI SDK provider to use from the environment. Set an API key for Anthropic, Google, or OpenAI:
 
 ```bash
-export ANTHROPIC_API_KEY=sk-ant-...
+export ANTHROPIC_API_KEY=sk-ant-...    # picks Anthropic (claude-sonnet-4-6 / claude-haiku-4-5)
+export GOOGLE_API_KEY=...              # picks Google    (gemini-2.5-pro   / gemini-2.5-flash)
+#  …or GEMINI_API_KEY, accepted as an alias
+export OPENAI_API_KEY=sk-...           # picks OpenAI    (gpt-5            / gpt-5-mini)
+```
+
+If more than one is set, the demos pick **anthropic → google → openai** in that order. To force a specific provider (useful when you have multiple keys set), set `DEMO_PROVIDER`:
+
+```bash
+DEMO_PROVIDER=google npm start
+```
+
+You can also override the default model IDs for a run:
+
+```bash
+DEMO_MASTER_MODEL=claude-opus-4-6 DEMO_WORKER_MODEL=claude-sonnet-4-6 npm start
 ```
 
 ## Demos

--- a/demos/assistant/README.md
+++ b/demos/assistant/README.md
@@ -19,12 +19,16 @@ A multi-turn interactive assistant that persists files to disk, streams response
 # Install demo dependencies
 npm install
 
-# Set your API key
-export ANTHROPIC_API_KEY=sk-ant-...
+# Set an API key for any supported provider:
+export ANTHROPIC_API_KEY=sk-ant-...            # Anthropic (default)
+# export GOOGLE_GENERATIVE_AI_API_KEY=...      # Google / Gemini
+# export OPENAI_API_KEY=sk-...                 # OpenAI
 
 # Start the assistant
 npm start
 ```
+
+This demo auto-detects the provider from whichever API key is set. To force a specific provider when multiple keys are present, set `DEMO_PROVIDER=anthropic|google|openai`. See [demos/README.md](../README.md#choose-a-model-provider) for the full env surface.
 
 ## What to expect
 

--- a/demos/assistant/index.ts
+++ b/demos/assistant/index.ts
@@ -24,7 +24,7 @@ import {
   type RunUsage,
 } from 'agent-do';
 import { FilesystemMemoryStore } from 'agent-do/stores/filesystem';
-import { createAnthropic } from '@ai-sdk/anthropic';
+import { resolveProvider, announce } from './provider.js';
 
 // ═══════════════════════════════════════════════
 //  Configuration
@@ -32,7 +32,6 @@ import { createAnthropic } from '@ai-sdk/anthropic';
 
 const AGENT_ID = 'assistant';
 const DATA_DIR = '.data';
-const MODEL_ID = 'claude-sonnet-4-6';
 
 // ═══════════════════════════════════════════════
 //  Session state
@@ -48,15 +47,12 @@ let messageCount = 0;
 //  Setup
 // ═══════════════════════════════════════════════
 
-const apiKey = process.env.ANTHROPIC_API_KEY;
-if (!apiKey) {
-  console.error('Error: ANTHROPIC_API_KEY environment variable is required.');
-  console.error('  export ANTHROPIC_API_KEY=sk-ant-...');
-  process.exit(1);
-}
-
-const provider = createAnthropic({ apiKey });
-const model = provider(MODEL_ID);
+// Resolve provider from env — Anthropic / Google / OpenAI. See
+// ./provider.ts for the full env surface (DEMO_PROVIDER to force,
+// per-provider key vars, DEMO_MASTER_MODEL override).
+const resolved = await resolveProvider();
+announce(resolved);
+const model = resolved.model(resolved.defaults.master);
 
 // Persistent filesystem store
 const store = new FilesystemMemoryStore(DATA_DIR);
@@ -89,7 +85,7 @@ const hooks: AgentHooks = {
 const agent = createAgent({
   id: AGENT_ID,
   name: 'Assistant',
-  model: model as any,
+  model,
   systemPrompt: `You are a helpful interactive assistant with access to a persistent filesystem.
 
 You can:

--- a/demos/assistant/package-lock.json
+++ b/demos/assistant/package-lock.json
@@ -10,27 +10,90 @@
       },
       "devDependencies": {
         "@ai-sdk/anthropic": "^3.0.0",
+        "@ai-sdk/google": "^3.0.0",
+        "@ai-sdk/openai": "^3.0.0",
         "tsx": "^4.0.0"
       }
     },
     "../..": {
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
-        "ai": "^6.0.0",
-        "zod": "^3.23.0"
+        "@ai-sdk/anthropic": "^3.0.0",
+        "@ai-sdk/google": "^3.0.0",
+        "@ai-sdk/openai": "^3.0.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "ai": "^6.0.168",
+        "ignore": "^7.0.5",
+        "yaml": "^2.8.3",
+        "zod": "^4.3.6"
+      },
+      "bin": {
+        "agent-do": "dist/src/cli.js"
       },
       "devDependencies": {
+        "@changesets/changelog-github": "^0.6.0",
+        "@changesets/cli": "^2.31.0",
         "@types/node": "^25.6.0",
         "typedoc": "^0.28.0",
         "typedoc-plugin-markdown": "^4.4.0",
-        "typescript": "^5.5.0",
-        "vitest": "^3.0.0"
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.4"
+      },
+      "peerDependencies": {
+        "@ai-sdk/anthropic": "^3.0.0",
+        "@ai-sdk/google": "^3.0.0",
+        "@ai-sdk/openai": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@ai-sdk/anthropic": {
+          "optional": true
+        },
+        "@ai-sdk/google": {
+          "optional": true
+        },
+        "@ai-sdk/openai": {
+          "optional": true
+        }
       }
     },
     "node_modules/@ai-sdk/anthropic": {
       "version": "3.0.69",
       "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.69.tgz",
       "integrity": "sha512-LshR7X3pFugY0o41G2VKTmg1XoGpSl7uoYWfzk6zjVZLhCfeFiwgpOga+eTV4XY1VVpZwKVqRnkDbIL7K2eH5g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/google": {
+      "version": "3.0.64",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-3.0.64.tgz",
+      "integrity": "sha512-CbR82EgGPNrj/6q0HtclwuCqe0/pDShyv3nWDP/A9DroujzWXnLMlUJVrgPOsg4b40zQCwwVs2XSKCxvt/4QaA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/openai": {
+      "version": "3.0.53",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.53.tgz",
+      "integrity": "sha512-Wld+Rbc05KaUn08uBt06eEuwcgalcIFtIl32Yp+GxuZXUQwOb6YeAuq+C6da4ch6BurFoqEaLemJVwjBb7x+PQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/demos/assistant/package.json
+++ b/demos/assistant/package.json
@@ -10,6 +10,8 @@
   },
   "devDependencies": {
     "@ai-sdk/anthropic": "^3.0.0",
+    "@ai-sdk/google": "^3.0.0",
+    "@ai-sdk/openai": "^3.0.0",
     "tsx": "^4.0.0"
   }
 }

--- a/demos/assistant/provider.ts
+++ b/demos/assistant/provider.ts
@@ -1,0 +1,130 @@
+/**
+ * Provider resolution for demos.
+ *
+ * Picks a model provider (Anthropic / Google / OpenAI) based on env:
+ *
+ *   DEMO_PROVIDER=anthropic | google | openai  (explicit choice)
+ *
+ * If `DEMO_PROVIDER` is unset, auto-picks the first provider whose API
+ * key is available, in order anthropic → google → openai. Fails with a
+ * readable error if nothing is set.
+ *
+ * Per-provider env vars:
+ *   ANTHROPIC_API_KEY
+ *   GOOGLE_API_KEY  (or GEMINI_API_KEY — both accepted)
+ *   OPENAI_API_KEY
+ *
+ * Per-demo model overrides (optional):
+ *   DEMO_MASTER_MODEL
+ *   DEMO_WORKER_MODEL
+ *
+ * The SDKs are imported dynamically so installing only the provider you
+ * actually want keeps the demo usable.
+ */
+
+import type { LanguageModel } from 'ai';
+
+export type Provider = 'anthropic' | 'google' | 'openai';
+
+export interface ResolvedProvider {
+  name: Provider;
+  model: (id: string) => LanguageModel;
+  defaults: { master: string; worker: string };
+}
+
+const DEFAULTS: Record<Provider, { master: string; worker: string }> = {
+  anthropic: { master: 'claude-sonnet-4-6', worker: 'claude-haiku-4-5' },
+  google: { master: 'gemini-2.5-pro', worker: 'gemini-2.5-flash' },
+  openai: { master: 'gpt-5', worker: 'gpt-5-mini' },
+};
+
+function envHas(name: Provider): boolean {
+  if (name === 'anthropic') return Boolean(process.env.ANTHROPIC_API_KEY);
+  if (name === 'google') return Boolean(process.env.GOOGLE_API_KEY || process.env.GEMINI_API_KEY);
+  return Boolean(process.env.OPENAI_API_KEY);
+}
+
+export async function resolveProvider(): Promise<ResolvedProvider> {
+  const requested = (process.env.DEMO_PROVIDER ?? '').toLowerCase();
+  let chosen: Provider | null = null;
+
+  if (requested === 'anthropic' || requested === 'google' || requested === 'openai') {
+    if (!envHas(requested)) {
+      console.error(
+        `Error: DEMO_PROVIDER=${requested} but the corresponding API key is not set.`,
+      );
+      console.error(missingKeyHint(requested));
+      process.exit(1);
+    }
+    chosen = requested;
+  } else if (requested !== '') {
+    console.error(`Error: DEMO_PROVIDER="${requested}" is not recognised. Use one of: anthropic, google, openai.`);
+    process.exit(1);
+  } else {
+    for (const candidate of ['anthropic', 'google', 'openai'] as Provider[]) {
+      if (envHas(candidate)) {
+        chosen = candidate;
+        break;
+      }
+    }
+  }
+
+  if (!chosen) {
+    console.error('Error: No provider API key found.');
+    console.error('  Set one of: ANTHROPIC_API_KEY, GOOGLE_API_KEY (or GEMINI_API_KEY), OPENAI_API_KEY.');
+    console.error('  Optionally set DEMO_PROVIDER=anthropic|google|openai to force a choice.');
+    process.exit(1);
+  }
+
+  const defaults = {
+    master: process.env.DEMO_MASTER_MODEL || DEFAULTS[chosen].master,
+    worker: process.env.DEMO_WORKER_MODEL || DEFAULTS[chosen].worker,
+  };
+
+  switch (chosen) {
+    case 'anthropic': {
+      const { createAnthropic } = await import('@ai-sdk/anthropic');
+      const provider = createAnthropic({ apiKey: process.env.ANTHROPIC_API_KEY! });
+      return {
+        name: 'anthropic',
+        // Cast through unknown because each provider's model type is
+        // branded separately; LanguageModel is the unified interface
+        // agent-do takes.
+        model: (id) => provider(id) as unknown as LanguageModel,
+        defaults,
+      };
+    }
+    case 'google': {
+      const { createGoogleGenerativeAI } = await import('@ai-sdk/google');
+      const apiKey = process.env.GOOGLE_API_KEY || process.env.GEMINI_API_KEY!;
+      const provider = createGoogleGenerativeAI({ apiKey });
+      return {
+        name: 'google',
+        model: (id) => provider(id) as unknown as LanguageModel,
+        defaults,
+      };
+    }
+    case 'openai': {
+      const { createOpenAI } = await import('@ai-sdk/openai');
+      const provider = createOpenAI({ apiKey: process.env.OPENAI_API_KEY! });
+      return {
+        name: 'openai',
+        model: (id) => provider(id) as unknown as LanguageModel,
+        defaults,
+      };
+    }
+  }
+}
+
+function missingKeyHint(provider: Provider): string {
+  if (provider === 'anthropic') return '  Set ANTHROPIC_API_KEY=sk-ant-...';
+  if (provider === 'google') return '  Set GOOGLE_API_KEY (or GEMINI_API_KEY).';
+  return '  Set OPENAI_API_KEY=sk-...';
+}
+
+export function announce(resolved: ResolvedProvider): void {
+  // eslint-disable-next-line no-console
+  console.log(
+    `  Provider: ${resolved.name} (master=${resolved.defaults.master}, worker=${resolved.defaults.worker})`,
+  );
+}

--- a/demos/assistant/provider.ts
+++ b/demos/assistant/provider.ts
@@ -9,17 +9,21 @@
  * key is available, in order anthropic → google → openai. Fails with a
  * readable error if nothing is set.
  *
- * Per-provider env vars:
+ * Per-provider env vars (matches the main CLI's convention — see
+ * src/cli/resolve-model.ts):
  *   ANTHROPIC_API_KEY
- *   GOOGLE_API_KEY  (or GEMINI_API_KEY — both accepted)
+ *   GOOGLE_GENERATIVE_AI_API_KEY   (canonical)
+ *     GOOGLE_API_KEY               (alias, also accepted)
+ *     GEMINI_API_KEY               (alias, also accepted)
  *   OPENAI_API_KEY
  *
  * Per-demo model overrides (optional):
  *   DEMO_MASTER_MODEL
  *   DEMO_WORKER_MODEL
  *
- * The SDKs are imported dynamically so installing only the provider you
- * actually want keeps the demo usable.
+ * The SDKs are imported dynamically so only the selected provider is
+ * imported and initialised at runtime — the unused providers stay out
+ * of the process even though they're present in node_modules.
  */
 
 import type { LanguageModel } from 'ai';
@@ -38,10 +42,32 @@ const DEFAULTS: Record<Provider, { master: string; worker: string }> = {
   openai: { master: 'gpt-5', worker: 'gpt-5-mini' },
 };
 
+/**
+ * Minimum plausible API-key length. The main CLI uses the same floor
+ * (src/cli/resolve-model.ts `value.length < 4`) so an obviously empty
+ * or placeholder value ("x", "123") produces a clean error instead of
+ * a confusing 4xx from the provider.
+ */
+const MIN_KEY_LENGTH = 4;
+
+function keyFor(name: Provider): string | undefined {
+  if (name === 'anthropic') {
+    return process.env.ANTHROPIC_API_KEY;
+  }
+  if (name === 'google') {
+    // Accept the canonical name first, then the two common aliases.
+    return (
+      process.env.GOOGLE_GENERATIVE_AI_API_KEY ||
+      process.env.GOOGLE_API_KEY ||
+      process.env.GEMINI_API_KEY
+    );
+  }
+  return process.env.OPENAI_API_KEY;
+}
+
 function envHas(name: Provider): boolean {
-  if (name === 'anthropic') return Boolean(process.env.ANTHROPIC_API_KEY);
-  if (name === 'google') return Boolean(process.env.GOOGLE_API_KEY || process.env.GEMINI_API_KEY);
-  return Boolean(process.env.OPENAI_API_KEY);
+  const key = keyFor(name);
+  return Boolean(key && key.length >= MIN_KEY_LENGTH);
 }
 
 export async function resolveProvider(): Promise<ResolvedProvider> {
@@ -51,7 +77,7 @@ export async function resolveProvider(): Promise<ResolvedProvider> {
   if (requested === 'anthropic' || requested === 'google' || requested === 'openai') {
     if (!envHas(requested)) {
       console.error(
-        `Error: DEMO_PROVIDER=${requested} but the corresponding API key is not set.`,
+        `Error: DEMO_PROVIDER=${requested} but the corresponding API key is not set (or shorter than ${MIN_KEY_LENGTH} chars).`,
       );
       console.error(missingKeyHint(requested));
       process.exit(1);
@@ -71,7 +97,10 @@ export async function resolveProvider(): Promise<ResolvedProvider> {
 
   if (!chosen) {
     console.error('Error: No provider API key found.');
-    console.error('  Set one of: ANTHROPIC_API_KEY, GOOGLE_API_KEY (or GEMINI_API_KEY), OPENAI_API_KEY.');
+    console.error('  Set one of:');
+    console.error('    ANTHROPIC_API_KEY');
+    console.error('    GOOGLE_GENERATIVE_AI_API_KEY (or GOOGLE_API_KEY / GEMINI_API_KEY)');
+    console.error('    OPENAI_API_KEY');
     console.error('  Optionally set DEMO_PROVIDER=anthropic|google|openai to force a choice.');
     process.exit(1);
   }
@@ -84,7 +113,7 @@ export async function resolveProvider(): Promise<ResolvedProvider> {
   switch (chosen) {
     case 'anthropic': {
       const { createAnthropic } = await import('@ai-sdk/anthropic');
-      const provider = createAnthropic({ apiKey: process.env.ANTHROPIC_API_KEY! });
+      const provider = createAnthropic({ apiKey: keyFor('anthropic')! });
       return {
         name: 'anthropic',
         // Cast through unknown because each provider's model type is
@@ -96,8 +125,7 @@ export async function resolveProvider(): Promise<ResolvedProvider> {
     }
     case 'google': {
       const { createGoogleGenerativeAI } = await import('@ai-sdk/google');
-      const apiKey = process.env.GOOGLE_API_KEY || process.env.GEMINI_API_KEY!;
-      const provider = createGoogleGenerativeAI({ apiKey });
+      const provider = createGoogleGenerativeAI({ apiKey: keyFor('google')! });
       return {
         name: 'google',
         model: (id) => provider(id) as unknown as LanguageModel,
@@ -106,7 +134,7 @@ export async function resolveProvider(): Promise<ResolvedProvider> {
     }
     case 'openai': {
       const { createOpenAI } = await import('@ai-sdk/openai');
-      const provider = createOpenAI({ apiKey: process.env.OPENAI_API_KEY! });
+      const provider = createOpenAI({ apiKey: keyFor('openai')! });
       return {
         name: 'openai',
         model: (id) => provider(id) as unknown as LanguageModel,
@@ -118,7 +146,9 @@ export async function resolveProvider(): Promise<ResolvedProvider> {
 
 function missingKeyHint(provider: Provider): string {
   if (provider === 'anthropic') return '  Set ANTHROPIC_API_KEY=sk-ant-...';
-  if (provider === 'google') return '  Set GOOGLE_API_KEY (or GEMINI_API_KEY).';
+  if (provider === 'google') {
+    return '  Set GOOGLE_GENERATIVE_AI_API_KEY=... (or GOOGLE_API_KEY / GEMINI_API_KEY).';
+  }
   return '  Set OPENAI_API_KEY=sk-...';
 }
 

--- a/demos/chief-of-staff/README.md
+++ b/demos/chief-of-staff/README.md
@@ -12,7 +12,11 @@ Founder's chief of staff pattern ([inspired by clawchief](https://github.com/sna
 ## Setup
 
 ```sh
-export ANTHROPIC_API_KEY=sk-ant-...
+# Set an API key for any supported provider:
+export ANTHROPIC_API_KEY=sk-ant-...            # Anthropic (default)
+# export GOOGLE_GENERATIVE_AI_API_KEY=...      # Google / Gemini
+# export OPENAI_API_KEY=sk-...                 # OpenAI
+
 npm install
 npm start
 # Or with an explicit instruction:
@@ -20,6 +24,8 @@ npm start "Triage the inbox and add follow-ups to tasks.md"
 ```
 
 First run seeds `./sandbox/` with mock `inbox.md`, `tracker.md`, `tasks.md` plus the two policy files.
+
+This demo auto-detects the provider from whichever API key is set. To force a specific provider when multiple keys are present, set `DEMO_PROVIDER=anthropic|google|openai`. See [demos/README.md](../README.md#choose-a-model-provider) for the full env surface.
 
 ## What's mocked vs real
 

--- a/demos/chief-of-staff/index.ts
+++ b/demos/chief-of-staff/index.ts
@@ -32,23 +32,17 @@ import {
   createFileTools,
 } from 'agent-do';
 import { FilesystemMemoryStore } from 'agent-do/stores/filesystem';
-import { createAnthropic } from '@ai-sdk/anthropic';
+import { resolveProvider, announce } from './provider.js';
 
 // ═══════════════════════════════════════════════
 //  Configuration
 // ═══════════════════════════════════════════════
 
 const SANDBOX_DIR = resolve('sandbox');
-const MASTER_MODEL = 'claude-sonnet-4-6';
-const WORKER_MODEL = 'claude-haiku-4-5';
 
-const apiKey = process.env.ANTHROPIC_API_KEY;
-if (!apiKey) {
-  console.error('Error: ANTHROPIC_API_KEY environment variable is required.');
-  process.exit(1);
-}
-
-const provider = createAnthropic({ apiKey });
+// Resolve provider from env — Anthropic / Google / OpenAI. See
+// ./provider.ts for DEMO_PROVIDER + per-provider key vars.
+const resolved = await resolveProvider();
 
 // ═══════════════════════════════════════════════
 //  Seed the workspace on first run
@@ -127,6 +121,7 @@ const TASKS = `# Tasks
 console.log('=======================================================');
 console.log('  Chief of Staff demo');
 console.log('=======================================================\n');
+announce(resolved);
 console.log(`  Workspace: ${SANDBOX_DIR}`);
 
 seed('priority-map.md', PRIORITY_MAP);
@@ -164,7 +159,7 @@ const orchestrator = createOrchestrator({
   master: {
     id: 'master',
     name: 'Chief of Staff',
-    model: provider(MASTER_MODEL) as any,
+    model: resolved.model(resolved.defaults.master),
     systemPrompt: `You are the principal's chief of staff, coordinating three specialists against a shared workspace.
 
 ${policyPreamble}
@@ -207,7 +202,7 @@ Silence contract: if there is nothing actionable in this run, respond with "OK" 
     {
       id: 'executive-assistant',
       name: 'Executive Assistant',
-      model: provider(WORKER_MODEL) as any,
+      model: resolved.model(resolved.defaults.worker),
       systemPrompt: `You are the principal's executive assistant. You triage the inbox and handle scheduling.
 
 ${policyPreamble}
@@ -222,7 +217,7 @@ Deliverables:
     {
       id: 'business-development',
       name: 'Business Development',
-      model: provider(WORKER_MODEL) as any,
+      model: resolved.model(resolved.defaults.worker),
       systemPrompt: `You are the principal's BD / CRM owner.
 
 ${policyPreamble}
@@ -239,7 +234,7 @@ Defer to executive-assistant when a signal is scheduling/calendar-only.`,
     {
       id: 'task-manager',
       name: 'Task Manager',
-      model: provider(WORKER_MODEL) as any,
+      model: resolved.model(resolved.defaults.worker),
       systemPrompt: `You are the principal's task manager. You own tasks.md.
 
 ${policyPreamble}

--- a/demos/chief-of-staff/package-lock.json
+++ b/demos/chief-of-staff/package-lock.json
@@ -10,6 +10,8 @@
       },
       "devDependencies": {
         "@ai-sdk/anthropic": "^3.0.0",
+        "@ai-sdk/google": "^3.0.0",
+        "@ai-sdk/openai": "^3.0.0",
         "tsx": "^4.0.0"
       }
     },
@@ -58,6 +60,40 @@
       "version": "3.0.71",
       "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.71.tgz",
       "integrity": "sha512-bUWOzrzR0gJKJO/PLGMR4uH2dqEgqGhrsCV+sSpk4KtOEnUQlfjZI/F7BFlqSvVpFbjdgYRRLysAeEZpJ6S1lg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/google": {
+      "version": "3.0.64",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-3.0.64.tgz",
+      "integrity": "sha512-CbR82EgGPNrj/6q0HtclwuCqe0/pDShyv3nWDP/A9DroujzWXnLMlUJVrgPOsg4b40zQCwwVs2XSKCxvt/4QaA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/openai": {
+      "version": "3.0.53",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.53.tgz",
+      "integrity": "sha512-Wld+Rbc05KaUn08uBt06eEuwcgalcIFtIl32Yp+GxuZXUQwOb6YeAuq+C6da4ch6BurFoqEaLemJVwjBb7x+PQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/demos/chief-of-staff/package.json
+++ b/demos/chief-of-staff/package.json
@@ -10,6 +10,8 @@
   },
   "devDependencies": {
     "@ai-sdk/anthropic": "^3.0.0",
+    "@ai-sdk/google": "^3.0.0",
+    "@ai-sdk/openai": "^3.0.0",
     "tsx": "^4.0.0"
   }
 }

--- a/demos/chief-of-staff/provider.ts
+++ b/demos/chief-of-staff/provider.ts
@@ -1,0 +1,130 @@
+/**
+ * Provider resolution for demos.
+ *
+ * Picks a model provider (Anthropic / Google / OpenAI) based on env:
+ *
+ *   DEMO_PROVIDER=anthropic | google | openai  (explicit choice)
+ *
+ * If `DEMO_PROVIDER` is unset, auto-picks the first provider whose API
+ * key is available, in order anthropic → google → openai. Fails with a
+ * readable error if nothing is set.
+ *
+ * Per-provider env vars:
+ *   ANTHROPIC_API_KEY
+ *   GOOGLE_API_KEY  (or GEMINI_API_KEY — both accepted)
+ *   OPENAI_API_KEY
+ *
+ * Per-demo model overrides (optional):
+ *   DEMO_MASTER_MODEL
+ *   DEMO_WORKER_MODEL
+ *
+ * The SDKs are imported dynamically so installing only the provider you
+ * actually want keeps the demo usable.
+ */
+
+import type { LanguageModel } from 'ai';
+
+export type Provider = 'anthropic' | 'google' | 'openai';
+
+export interface ResolvedProvider {
+  name: Provider;
+  model: (id: string) => LanguageModel;
+  defaults: { master: string; worker: string };
+}
+
+const DEFAULTS: Record<Provider, { master: string; worker: string }> = {
+  anthropic: { master: 'claude-sonnet-4-6', worker: 'claude-haiku-4-5' },
+  google: { master: 'gemini-2.5-pro', worker: 'gemini-2.5-flash' },
+  openai: { master: 'gpt-5', worker: 'gpt-5-mini' },
+};
+
+function envHas(name: Provider): boolean {
+  if (name === 'anthropic') return Boolean(process.env.ANTHROPIC_API_KEY);
+  if (name === 'google') return Boolean(process.env.GOOGLE_API_KEY || process.env.GEMINI_API_KEY);
+  return Boolean(process.env.OPENAI_API_KEY);
+}
+
+export async function resolveProvider(): Promise<ResolvedProvider> {
+  const requested = (process.env.DEMO_PROVIDER ?? '').toLowerCase();
+  let chosen: Provider | null = null;
+
+  if (requested === 'anthropic' || requested === 'google' || requested === 'openai') {
+    if (!envHas(requested)) {
+      console.error(
+        `Error: DEMO_PROVIDER=${requested} but the corresponding API key is not set.`,
+      );
+      console.error(missingKeyHint(requested));
+      process.exit(1);
+    }
+    chosen = requested;
+  } else if (requested !== '') {
+    console.error(`Error: DEMO_PROVIDER="${requested}" is not recognised. Use one of: anthropic, google, openai.`);
+    process.exit(1);
+  } else {
+    for (const candidate of ['anthropic', 'google', 'openai'] as Provider[]) {
+      if (envHas(candidate)) {
+        chosen = candidate;
+        break;
+      }
+    }
+  }
+
+  if (!chosen) {
+    console.error('Error: No provider API key found.');
+    console.error('  Set one of: ANTHROPIC_API_KEY, GOOGLE_API_KEY (or GEMINI_API_KEY), OPENAI_API_KEY.');
+    console.error('  Optionally set DEMO_PROVIDER=anthropic|google|openai to force a choice.');
+    process.exit(1);
+  }
+
+  const defaults = {
+    master: process.env.DEMO_MASTER_MODEL || DEFAULTS[chosen].master,
+    worker: process.env.DEMO_WORKER_MODEL || DEFAULTS[chosen].worker,
+  };
+
+  switch (chosen) {
+    case 'anthropic': {
+      const { createAnthropic } = await import('@ai-sdk/anthropic');
+      const provider = createAnthropic({ apiKey: process.env.ANTHROPIC_API_KEY! });
+      return {
+        name: 'anthropic',
+        // Cast through unknown because each provider's model type is
+        // branded separately; LanguageModel is the unified interface
+        // agent-do takes.
+        model: (id) => provider(id) as unknown as LanguageModel,
+        defaults,
+      };
+    }
+    case 'google': {
+      const { createGoogleGenerativeAI } = await import('@ai-sdk/google');
+      const apiKey = process.env.GOOGLE_API_KEY || process.env.GEMINI_API_KEY!;
+      const provider = createGoogleGenerativeAI({ apiKey });
+      return {
+        name: 'google',
+        model: (id) => provider(id) as unknown as LanguageModel,
+        defaults,
+      };
+    }
+    case 'openai': {
+      const { createOpenAI } = await import('@ai-sdk/openai');
+      const provider = createOpenAI({ apiKey: process.env.OPENAI_API_KEY! });
+      return {
+        name: 'openai',
+        model: (id) => provider(id) as unknown as LanguageModel,
+        defaults,
+      };
+    }
+  }
+}
+
+function missingKeyHint(provider: Provider): string {
+  if (provider === 'anthropic') return '  Set ANTHROPIC_API_KEY=sk-ant-...';
+  if (provider === 'google') return '  Set GOOGLE_API_KEY (or GEMINI_API_KEY).';
+  return '  Set OPENAI_API_KEY=sk-...';
+}
+
+export function announce(resolved: ResolvedProvider): void {
+  // eslint-disable-next-line no-console
+  console.log(
+    `  Provider: ${resolved.name} (master=${resolved.defaults.master}, worker=${resolved.defaults.worker})`,
+  );
+}

--- a/demos/chief-of-staff/provider.ts
+++ b/demos/chief-of-staff/provider.ts
@@ -9,17 +9,21 @@
  * key is available, in order anthropic → google → openai. Fails with a
  * readable error if nothing is set.
  *
- * Per-provider env vars:
+ * Per-provider env vars (matches the main CLI's convention — see
+ * src/cli/resolve-model.ts):
  *   ANTHROPIC_API_KEY
- *   GOOGLE_API_KEY  (or GEMINI_API_KEY — both accepted)
+ *   GOOGLE_GENERATIVE_AI_API_KEY   (canonical)
+ *     GOOGLE_API_KEY               (alias, also accepted)
+ *     GEMINI_API_KEY               (alias, also accepted)
  *   OPENAI_API_KEY
  *
  * Per-demo model overrides (optional):
  *   DEMO_MASTER_MODEL
  *   DEMO_WORKER_MODEL
  *
- * The SDKs are imported dynamically so installing only the provider you
- * actually want keeps the demo usable.
+ * The SDKs are imported dynamically so only the selected provider is
+ * imported and initialised at runtime — the unused providers stay out
+ * of the process even though they're present in node_modules.
  */
 
 import type { LanguageModel } from 'ai';
@@ -38,10 +42,32 @@ const DEFAULTS: Record<Provider, { master: string; worker: string }> = {
   openai: { master: 'gpt-5', worker: 'gpt-5-mini' },
 };
 
+/**
+ * Minimum plausible API-key length. The main CLI uses the same floor
+ * (src/cli/resolve-model.ts `value.length < 4`) so an obviously empty
+ * or placeholder value ("x", "123") produces a clean error instead of
+ * a confusing 4xx from the provider.
+ */
+const MIN_KEY_LENGTH = 4;
+
+function keyFor(name: Provider): string | undefined {
+  if (name === 'anthropic') {
+    return process.env.ANTHROPIC_API_KEY;
+  }
+  if (name === 'google') {
+    // Accept the canonical name first, then the two common aliases.
+    return (
+      process.env.GOOGLE_GENERATIVE_AI_API_KEY ||
+      process.env.GOOGLE_API_KEY ||
+      process.env.GEMINI_API_KEY
+    );
+  }
+  return process.env.OPENAI_API_KEY;
+}
+
 function envHas(name: Provider): boolean {
-  if (name === 'anthropic') return Boolean(process.env.ANTHROPIC_API_KEY);
-  if (name === 'google') return Boolean(process.env.GOOGLE_API_KEY || process.env.GEMINI_API_KEY);
-  return Boolean(process.env.OPENAI_API_KEY);
+  const key = keyFor(name);
+  return Boolean(key && key.length >= MIN_KEY_LENGTH);
 }
 
 export async function resolveProvider(): Promise<ResolvedProvider> {
@@ -51,7 +77,7 @@ export async function resolveProvider(): Promise<ResolvedProvider> {
   if (requested === 'anthropic' || requested === 'google' || requested === 'openai') {
     if (!envHas(requested)) {
       console.error(
-        `Error: DEMO_PROVIDER=${requested} but the corresponding API key is not set.`,
+        `Error: DEMO_PROVIDER=${requested} but the corresponding API key is not set (or shorter than ${MIN_KEY_LENGTH} chars).`,
       );
       console.error(missingKeyHint(requested));
       process.exit(1);
@@ -71,7 +97,10 @@ export async function resolveProvider(): Promise<ResolvedProvider> {
 
   if (!chosen) {
     console.error('Error: No provider API key found.');
-    console.error('  Set one of: ANTHROPIC_API_KEY, GOOGLE_API_KEY (or GEMINI_API_KEY), OPENAI_API_KEY.');
+    console.error('  Set one of:');
+    console.error('    ANTHROPIC_API_KEY');
+    console.error('    GOOGLE_GENERATIVE_AI_API_KEY (or GOOGLE_API_KEY / GEMINI_API_KEY)');
+    console.error('    OPENAI_API_KEY');
     console.error('  Optionally set DEMO_PROVIDER=anthropic|google|openai to force a choice.');
     process.exit(1);
   }
@@ -84,7 +113,7 @@ export async function resolveProvider(): Promise<ResolvedProvider> {
   switch (chosen) {
     case 'anthropic': {
       const { createAnthropic } = await import('@ai-sdk/anthropic');
-      const provider = createAnthropic({ apiKey: process.env.ANTHROPIC_API_KEY! });
+      const provider = createAnthropic({ apiKey: keyFor('anthropic')! });
       return {
         name: 'anthropic',
         // Cast through unknown because each provider's model type is
@@ -96,8 +125,7 @@ export async function resolveProvider(): Promise<ResolvedProvider> {
     }
     case 'google': {
       const { createGoogleGenerativeAI } = await import('@ai-sdk/google');
-      const apiKey = process.env.GOOGLE_API_KEY || process.env.GEMINI_API_KEY!;
-      const provider = createGoogleGenerativeAI({ apiKey });
+      const provider = createGoogleGenerativeAI({ apiKey: keyFor('google')! });
       return {
         name: 'google',
         model: (id) => provider(id) as unknown as LanguageModel,
@@ -106,7 +134,7 @@ export async function resolveProvider(): Promise<ResolvedProvider> {
     }
     case 'openai': {
       const { createOpenAI } = await import('@ai-sdk/openai');
-      const provider = createOpenAI({ apiKey: process.env.OPENAI_API_KEY! });
+      const provider = createOpenAI({ apiKey: keyFor('openai')! });
       return {
         name: 'openai',
         model: (id) => provider(id) as unknown as LanguageModel,
@@ -118,7 +146,9 @@ export async function resolveProvider(): Promise<ResolvedProvider> {
 
 function missingKeyHint(provider: Provider): string {
   if (provider === 'anthropic') return '  Set ANTHROPIC_API_KEY=sk-ant-...';
-  if (provider === 'google') return '  Set GOOGLE_API_KEY (or GEMINI_API_KEY).';
+  if (provider === 'google') {
+    return '  Set GOOGLE_GENERATIVE_AI_API_KEY=... (or GOOGLE_API_KEY / GEMINI_API_KEY).';
+  }
   return '  Set OPENAI_API_KEY=sk-...';
 }
 

--- a/demos/code-reviewer/README.md
+++ b/demos/code-reviewer/README.md
@@ -19,8 +19,10 @@ An agent that reads source files from a directory and produces a structured code
 # Install demo dependencies
 npm install
 
-# Set your API key
-export ANTHROPIC_API_KEY=sk-ant-...
+# Set an API key for any supported provider:
+export ANTHROPIC_API_KEY=sk-ant-...            # Anthropic (default)
+# export GOOGLE_GENERATIVE_AI_API_KEY=...      # Google / Gemini
+# export OPENAI_API_KEY=sk-...                 # OpenAI
 
 # Review a specific directory
 npm start /path/to/your/project
@@ -28,6 +30,8 @@ npm start /path/to/your/project
 # Review the current directory (default)
 npm start
 ```
+
+This demo auto-detects the provider from whichever API key is set. To force a specific provider when multiple keys are present, set `DEMO_PROVIDER=anthropic|google|openai`. See [demos/README.md](../README.md#choose-a-model-provider) for the full env surface.
 
 ## What to expect
 

--- a/demos/code-reviewer/index.ts
+++ b/demos/code-reviewer/index.ts
@@ -20,13 +20,12 @@ import {
   type AgentHooks,
 } from 'agent-do';
 import { FilesystemMemoryStore } from 'agent-do/stores/filesystem';
-import { createAnthropic } from '@ai-sdk/anthropic';
+import { resolveProvider } from './provider.js';
 
 // ═══════════════════════════════════════════════
 //  Configuration
 // ═══════════════════════════════════════════════
 
-const MODEL_ID = 'claude-sonnet-4-6';
 const AGENT_ID = 'reviewer';
 const OUTPUT_DIR = '.data/reviews';
 
@@ -34,12 +33,9 @@ const OUTPUT_DIR = '.data/reviews';
 //  Setup
 // ═══════════════════════════════════════════════
 
-const apiKey = process.env.ANTHROPIC_API_KEY;
-if (!apiKey) {
-  console.error('Error: ANTHROPIC_API_KEY environment variable is required.');
-  console.error('  export ANTHROPIC_API_KEY=sk-ant-...');
-  process.exit(1);
-}
+// Resolve provider from env — Anthropic / Google / OpenAI. See
+// ./provider.ts for DEMO_PROVIDER + per-provider key vars.
+const resolved = await resolveProvider();
 
 // Target directory from args or cwd
 const targetDir = path.resolve(process.argv[2] || process.cwd());
@@ -59,9 +55,9 @@ console.log('='.repeat(55));
 console.log('  Automated Code Reviewer');
 console.log('='.repeat(55));
 console.log('');
-console.log(`  Target:  ${targetDir}`);
-console.log(`  Model:   ${MODEL_ID}`);
-console.log(`  Mode:    READ-ONLY`);
+console.log(`  Target:   ${targetDir}`);
+console.log(`  Provider: ${resolved.name} (${resolved.defaults.master})`);
+console.log(`  Mode:     READ-ONLY`);
 console.log('');
 
 // ═══════════════════════════════════════════════
@@ -161,7 +157,7 @@ const hooks: AgentHooks = {
 const agent = createAgent({
   id: AGENT_ID,
   name: 'Code Reviewer',
-  model: createAnthropic({ apiKey })(MODEL_ID) as any,
+  model: resolved.model(resolved.defaults.master),
   systemPrompt: `You are an expert code reviewer. You analyze source code for issues across several categories.
 
 Your review process:

--- a/demos/code-reviewer/package-lock.json
+++ b/demos/code-reviewer/package-lock.json
@@ -10,27 +10,90 @@
       },
       "devDependencies": {
         "@ai-sdk/anthropic": "^3.0.0",
+        "@ai-sdk/google": "^3.0.0",
+        "@ai-sdk/openai": "^3.0.0",
         "tsx": "^4.0.0"
       }
     },
     "../..": {
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
-        "ai": "^6.0.0",
-        "zod": "^3.23.0"
+        "@ai-sdk/anthropic": "^3.0.0",
+        "@ai-sdk/google": "^3.0.0",
+        "@ai-sdk/openai": "^3.0.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "ai": "^6.0.168",
+        "ignore": "^7.0.5",
+        "yaml": "^2.8.3",
+        "zod": "^4.3.6"
+      },
+      "bin": {
+        "agent-do": "dist/src/cli.js"
       },
       "devDependencies": {
+        "@changesets/changelog-github": "^0.6.0",
+        "@changesets/cli": "^2.31.0",
         "@types/node": "^25.6.0",
         "typedoc": "^0.28.0",
         "typedoc-plugin-markdown": "^4.4.0",
-        "typescript": "^5.5.0",
-        "vitest": "^3.0.0"
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.4"
+      },
+      "peerDependencies": {
+        "@ai-sdk/anthropic": "^3.0.0",
+        "@ai-sdk/google": "^3.0.0",
+        "@ai-sdk/openai": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@ai-sdk/anthropic": {
+          "optional": true
+        },
+        "@ai-sdk/google": {
+          "optional": true
+        },
+        "@ai-sdk/openai": {
+          "optional": true
+        }
       }
     },
     "node_modules/@ai-sdk/anthropic": {
       "version": "3.0.69",
       "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.69.tgz",
       "integrity": "sha512-LshR7X3pFugY0o41G2VKTmg1XoGpSl7uoYWfzk6zjVZLhCfeFiwgpOga+eTV4XY1VVpZwKVqRnkDbIL7K2eH5g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/google": {
+      "version": "3.0.64",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-3.0.64.tgz",
+      "integrity": "sha512-CbR82EgGPNrj/6q0HtclwuCqe0/pDShyv3nWDP/A9DroujzWXnLMlUJVrgPOsg4b40zQCwwVs2XSKCxvt/4QaA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/openai": {
+      "version": "3.0.53",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.53.tgz",
+      "integrity": "sha512-Wld+Rbc05KaUn08uBt06eEuwcgalcIFtIl32Yp+GxuZXUQwOb6YeAuq+C6da4ch6BurFoqEaLemJVwjBb7x+PQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/demos/code-reviewer/package.json
+++ b/demos/code-reviewer/package.json
@@ -10,6 +10,8 @@
   },
   "devDependencies": {
     "@ai-sdk/anthropic": "^3.0.0",
+    "@ai-sdk/google": "^3.0.0",
+    "@ai-sdk/openai": "^3.0.0",
     "tsx": "^4.0.0"
   }
 }

--- a/demos/code-reviewer/provider.ts
+++ b/demos/code-reviewer/provider.ts
@@ -1,0 +1,130 @@
+/**
+ * Provider resolution for demos.
+ *
+ * Picks a model provider (Anthropic / Google / OpenAI) based on env:
+ *
+ *   DEMO_PROVIDER=anthropic | google | openai  (explicit choice)
+ *
+ * If `DEMO_PROVIDER` is unset, auto-picks the first provider whose API
+ * key is available, in order anthropic → google → openai. Fails with a
+ * readable error if nothing is set.
+ *
+ * Per-provider env vars:
+ *   ANTHROPIC_API_KEY
+ *   GOOGLE_API_KEY  (or GEMINI_API_KEY — both accepted)
+ *   OPENAI_API_KEY
+ *
+ * Per-demo model overrides (optional):
+ *   DEMO_MASTER_MODEL
+ *   DEMO_WORKER_MODEL
+ *
+ * The SDKs are imported dynamically so installing only the provider you
+ * actually want keeps the demo usable.
+ */
+
+import type { LanguageModel } from 'ai';
+
+export type Provider = 'anthropic' | 'google' | 'openai';
+
+export interface ResolvedProvider {
+  name: Provider;
+  model: (id: string) => LanguageModel;
+  defaults: { master: string; worker: string };
+}
+
+const DEFAULTS: Record<Provider, { master: string; worker: string }> = {
+  anthropic: { master: 'claude-sonnet-4-6', worker: 'claude-haiku-4-5' },
+  google: { master: 'gemini-2.5-pro', worker: 'gemini-2.5-flash' },
+  openai: { master: 'gpt-5', worker: 'gpt-5-mini' },
+};
+
+function envHas(name: Provider): boolean {
+  if (name === 'anthropic') return Boolean(process.env.ANTHROPIC_API_KEY);
+  if (name === 'google') return Boolean(process.env.GOOGLE_API_KEY || process.env.GEMINI_API_KEY);
+  return Boolean(process.env.OPENAI_API_KEY);
+}
+
+export async function resolveProvider(): Promise<ResolvedProvider> {
+  const requested = (process.env.DEMO_PROVIDER ?? '').toLowerCase();
+  let chosen: Provider | null = null;
+
+  if (requested === 'anthropic' || requested === 'google' || requested === 'openai') {
+    if (!envHas(requested)) {
+      console.error(
+        `Error: DEMO_PROVIDER=${requested} but the corresponding API key is not set.`,
+      );
+      console.error(missingKeyHint(requested));
+      process.exit(1);
+    }
+    chosen = requested;
+  } else if (requested !== '') {
+    console.error(`Error: DEMO_PROVIDER="${requested}" is not recognised. Use one of: anthropic, google, openai.`);
+    process.exit(1);
+  } else {
+    for (const candidate of ['anthropic', 'google', 'openai'] as Provider[]) {
+      if (envHas(candidate)) {
+        chosen = candidate;
+        break;
+      }
+    }
+  }
+
+  if (!chosen) {
+    console.error('Error: No provider API key found.');
+    console.error('  Set one of: ANTHROPIC_API_KEY, GOOGLE_API_KEY (or GEMINI_API_KEY), OPENAI_API_KEY.');
+    console.error('  Optionally set DEMO_PROVIDER=anthropic|google|openai to force a choice.');
+    process.exit(1);
+  }
+
+  const defaults = {
+    master: process.env.DEMO_MASTER_MODEL || DEFAULTS[chosen].master,
+    worker: process.env.DEMO_WORKER_MODEL || DEFAULTS[chosen].worker,
+  };
+
+  switch (chosen) {
+    case 'anthropic': {
+      const { createAnthropic } = await import('@ai-sdk/anthropic');
+      const provider = createAnthropic({ apiKey: process.env.ANTHROPIC_API_KEY! });
+      return {
+        name: 'anthropic',
+        // Cast through unknown because each provider's model type is
+        // branded separately; LanguageModel is the unified interface
+        // agent-do takes.
+        model: (id) => provider(id) as unknown as LanguageModel,
+        defaults,
+      };
+    }
+    case 'google': {
+      const { createGoogleGenerativeAI } = await import('@ai-sdk/google');
+      const apiKey = process.env.GOOGLE_API_KEY || process.env.GEMINI_API_KEY!;
+      const provider = createGoogleGenerativeAI({ apiKey });
+      return {
+        name: 'google',
+        model: (id) => provider(id) as unknown as LanguageModel,
+        defaults,
+      };
+    }
+    case 'openai': {
+      const { createOpenAI } = await import('@ai-sdk/openai');
+      const provider = createOpenAI({ apiKey: process.env.OPENAI_API_KEY! });
+      return {
+        name: 'openai',
+        model: (id) => provider(id) as unknown as LanguageModel,
+        defaults,
+      };
+    }
+  }
+}
+
+function missingKeyHint(provider: Provider): string {
+  if (provider === 'anthropic') return '  Set ANTHROPIC_API_KEY=sk-ant-...';
+  if (provider === 'google') return '  Set GOOGLE_API_KEY (or GEMINI_API_KEY).';
+  return '  Set OPENAI_API_KEY=sk-...';
+}
+
+export function announce(resolved: ResolvedProvider): void {
+  // eslint-disable-next-line no-console
+  console.log(
+    `  Provider: ${resolved.name} (master=${resolved.defaults.master}, worker=${resolved.defaults.worker})`,
+  );
+}

--- a/demos/code-reviewer/provider.ts
+++ b/demos/code-reviewer/provider.ts
@@ -9,17 +9,21 @@
  * key is available, in order anthropic → google → openai. Fails with a
  * readable error if nothing is set.
  *
- * Per-provider env vars:
+ * Per-provider env vars (matches the main CLI's convention — see
+ * src/cli/resolve-model.ts):
  *   ANTHROPIC_API_KEY
- *   GOOGLE_API_KEY  (or GEMINI_API_KEY — both accepted)
+ *   GOOGLE_GENERATIVE_AI_API_KEY   (canonical)
+ *     GOOGLE_API_KEY               (alias, also accepted)
+ *     GEMINI_API_KEY               (alias, also accepted)
  *   OPENAI_API_KEY
  *
  * Per-demo model overrides (optional):
  *   DEMO_MASTER_MODEL
  *   DEMO_WORKER_MODEL
  *
- * The SDKs are imported dynamically so installing only the provider you
- * actually want keeps the demo usable.
+ * The SDKs are imported dynamically so only the selected provider is
+ * imported and initialised at runtime — the unused providers stay out
+ * of the process even though they're present in node_modules.
  */
 
 import type { LanguageModel } from 'ai';
@@ -38,10 +42,32 @@ const DEFAULTS: Record<Provider, { master: string; worker: string }> = {
   openai: { master: 'gpt-5', worker: 'gpt-5-mini' },
 };
 
+/**
+ * Minimum plausible API-key length. The main CLI uses the same floor
+ * (src/cli/resolve-model.ts `value.length < 4`) so an obviously empty
+ * or placeholder value ("x", "123") produces a clean error instead of
+ * a confusing 4xx from the provider.
+ */
+const MIN_KEY_LENGTH = 4;
+
+function keyFor(name: Provider): string | undefined {
+  if (name === 'anthropic') {
+    return process.env.ANTHROPIC_API_KEY;
+  }
+  if (name === 'google') {
+    // Accept the canonical name first, then the two common aliases.
+    return (
+      process.env.GOOGLE_GENERATIVE_AI_API_KEY ||
+      process.env.GOOGLE_API_KEY ||
+      process.env.GEMINI_API_KEY
+    );
+  }
+  return process.env.OPENAI_API_KEY;
+}
+
 function envHas(name: Provider): boolean {
-  if (name === 'anthropic') return Boolean(process.env.ANTHROPIC_API_KEY);
-  if (name === 'google') return Boolean(process.env.GOOGLE_API_KEY || process.env.GEMINI_API_KEY);
-  return Boolean(process.env.OPENAI_API_KEY);
+  const key = keyFor(name);
+  return Boolean(key && key.length >= MIN_KEY_LENGTH);
 }
 
 export async function resolveProvider(): Promise<ResolvedProvider> {
@@ -51,7 +77,7 @@ export async function resolveProvider(): Promise<ResolvedProvider> {
   if (requested === 'anthropic' || requested === 'google' || requested === 'openai') {
     if (!envHas(requested)) {
       console.error(
-        `Error: DEMO_PROVIDER=${requested} but the corresponding API key is not set.`,
+        `Error: DEMO_PROVIDER=${requested} but the corresponding API key is not set (or shorter than ${MIN_KEY_LENGTH} chars).`,
       );
       console.error(missingKeyHint(requested));
       process.exit(1);
@@ -71,7 +97,10 @@ export async function resolveProvider(): Promise<ResolvedProvider> {
 
   if (!chosen) {
     console.error('Error: No provider API key found.');
-    console.error('  Set one of: ANTHROPIC_API_KEY, GOOGLE_API_KEY (or GEMINI_API_KEY), OPENAI_API_KEY.');
+    console.error('  Set one of:');
+    console.error('    ANTHROPIC_API_KEY');
+    console.error('    GOOGLE_GENERATIVE_AI_API_KEY (or GOOGLE_API_KEY / GEMINI_API_KEY)');
+    console.error('    OPENAI_API_KEY');
     console.error('  Optionally set DEMO_PROVIDER=anthropic|google|openai to force a choice.');
     process.exit(1);
   }
@@ -84,7 +113,7 @@ export async function resolveProvider(): Promise<ResolvedProvider> {
   switch (chosen) {
     case 'anthropic': {
       const { createAnthropic } = await import('@ai-sdk/anthropic');
-      const provider = createAnthropic({ apiKey: process.env.ANTHROPIC_API_KEY! });
+      const provider = createAnthropic({ apiKey: keyFor('anthropic')! });
       return {
         name: 'anthropic',
         // Cast through unknown because each provider's model type is
@@ -96,8 +125,7 @@ export async function resolveProvider(): Promise<ResolvedProvider> {
     }
     case 'google': {
       const { createGoogleGenerativeAI } = await import('@ai-sdk/google');
-      const apiKey = process.env.GOOGLE_API_KEY || process.env.GEMINI_API_KEY!;
-      const provider = createGoogleGenerativeAI({ apiKey });
+      const provider = createGoogleGenerativeAI({ apiKey: keyFor('google')! });
       return {
         name: 'google',
         model: (id) => provider(id) as unknown as LanguageModel,
@@ -106,7 +134,7 @@ export async function resolveProvider(): Promise<ResolvedProvider> {
     }
     case 'openai': {
       const { createOpenAI } = await import('@ai-sdk/openai');
-      const provider = createOpenAI({ apiKey: process.env.OPENAI_API_KEY! });
+      const provider = createOpenAI({ apiKey: keyFor('openai')! });
       return {
         name: 'openai',
         model: (id) => provider(id) as unknown as LanguageModel,
@@ -118,7 +146,9 @@ export async function resolveProvider(): Promise<ResolvedProvider> {
 
 function missingKeyHint(provider: Provider): string {
   if (provider === 'anthropic') return '  Set ANTHROPIC_API_KEY=sk-ant-...';
-  if (provider === 'google') return '  Set GOOGLE_API_KEY (or GEMINI_API_KEY).';
+  if (provider === 'google') {
+    return '  Set GOOGLE_GENERATIVE_AI_API_KEY=... (or GOOGLE_API_KEY / GEMINI_API_KEY).';
+  }
   return '  Set OPENAI_API_KEY=sk-...';
 }
 

--- a/demos/engineering-team/README.md
+++ b/demos/engineering-team/README.md
@@ -22,12 +22,18 @@ Ship    → release-engineer    → 05-rollout.md        (stages, metrics, rollb
 ## Setup
 
 ```sh
-export ANTHROPIC_API_KEY=sk-ant-...
+# Set an API key for any supported provider:
+export ANTHROPIC_API_KEY=sk-ant-...            # Anthropic (default)
+# export GOOGLE_GENERATIVE_AI_API_KEY=...      # Google / Gemini
+# export OPENAI_API_KEY=sk-...                 # OpenAI
+
 npm install
 npm start "Add an audit log for write operations"
 # Or run interactively:
 npm start
 ```
+
+This demo auto-detects the provider from whichever API key is set. To force a specific provider when multiple keys are present, set `DEMO_PROVIDER=anthropic|google|openai`. See [demos/README.md](../README.md#choose-a-model-provider) for the full env surface.
 
 ## Structure
 

--- a/demos/engineering-team/index.ts
+++ b/demos/engineering-team/index.ts
@@ -27,23 +27,17 @@ import { mkdirSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { createOrchestrator, createFileTools } from 'agent-do';
 import { FilesystemMemoryStore } from 'agent-do/stores/filesystem';
-import { createAnthropic } from '@ai-sdk/anthropic';
+import { resolveProvider, announce } from './provider.js';
 
 // ═══════════════════════════════════════════════
 //  Configuration
 // ═══════════════════════════════════════════════
 
 const SPRINT_DIR = resolve('sprint');
-const MASTER_MODEL = 'claude-sonnet-4-6';
-const WORKER_MODEL = 'claude-haiku-4-5';
 
-const apiKey = process.env.ANTHROPIC_API_KEY;
-if (!apiKey) {
-  console.error('Error: ANTHROPIC_API_KEY environment variable is required.');
-  process.exit(1);
-}
-
-const provider = createAnthropic({ apiKey });
+// Resolve provider from env — Anthropic / Google / OpenAI. See
+// ./provider.ts for DEMO_PROVIDER + per-provider key vars.
+const resolved = await resolveProvider();
 
 mkdirSync(SPRINT_DIR, { recursive: true });
 
@@ -64,7 +58,7 @@ const orchestrator = createOrchestrator({
   master: {
     id: 'master',
     name: 'Tech Lead',
-    model: provider(MASTER_MODEL) as any,
+    model: resolved.model(resolved.defaults.master),
     systemPrompt: `You are the tech lead running a 5-phase engineering sprint on a single feature request.
 
 Phases must happen in order. Each phase hands off a written artifact to the next via the shared workspace.
@@ -108,7 +102,7 @@ Do NOT skip phases. Do NOT write the artifacts yourself — each specialist writ
     {
       id: 'office-hours',
       name: 'Office Hours (Think)',
-      model: provider(WORKER_MODEL) as any,
+      model: resolved.model(resolved.defaults.worker),
       systemPrompt: `You run "office hours" for the tech lead. You answer six forcing questions about a feature request before any design work starts.
 
 Write 01-design-doc.md with exactly these sections:
@@ -126,7 +120,7 @@ Be concrete. Cite specifics, not generalities.`,
     {
       id: 'plan-eng-review',
       name: 'Engineering Plan Review',
-      model: provider(WORKER_MODEL) as any,
+      model: resolved.model(resolved.defaults.worker),
       systemPrompt: `You are a senior engineer doing a plan review BEFORE any code gets written.
 
 Read 01-design-doc.md. Write 02-plan.md with:
@@ -143,7 +137,7 @@ Be specific. No hand-waving.`,
     {
       id: 'investigate',
       name: 'Investigator',
-      model: provider(WORKER_MODEL) as any,
+      model: resolved.model(resolved.defaults.worker),
       systemPrompt: `You are the debugger/investigator. You do not propose fixes until you understand what's there.
 
 **Iron Law:** no recommendations without first investigating.
@@ -162,7 +156,7 @@ If you can't investigate something properly, say so explicitly ("Unable to verif
     {
       id: 'qa',
       name: 'QA',
-      model: provider(WORKER_MODEL) as any,
+      model: resolved.model(resolved.defaults.worker),
       systemPrompt: `You are QA. Your job is to find the holes — red-team the plan, don't bless it.
 
 Read 02-plan.md and 03-investigation.md. Write 04-test-plan.md with:
@@ -178,7 +172,7 @@ Lean pessimistic. If something can't be tested cheaply, flag it.`,
     {
       id: 'release-engineer',
       name: 'Release Engineer',
-      model: provider(WORKER_MODEL) as any,
+      model: resolved.model(resolved.defaults.worker),
       systemPrompt: `You are the release engineer. You design the rollout plan and the rollback.
 
 Read all prior artifacts (01-05 up to this point). Write 05-rollout.md with:
@@ -224,6 +218,7 @@ if (!feature) {
 console.log('=======================================================');
 console.log('  Engineering team sprint');
 console.log('=======================================================');
+announce(resolved);
 console.log(`  Feature: ${feature}`);
 console.log(`  Workspace: ${SPRINT_DIR}\n`);
 

--- a/demos/engineering-team/package-lock.json
+++ b/demos/engineering-team/package-lock.json
@@ -10,6 +10,8 @@
       },
       "devDependencies": {
         "@ai-sdk/anthropic": "^3.0.0",
+        "@ai-sdk/google": "^3.0.0",
+        "@ai-sdk/openai": "^3.0.0",
         "tsx": "^4.0.0"
       }
     },
@@ -58,6 +60,40 @@
       "version": "3.0.71",
       "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.71.tgz",
       "integrity": "sha512-bUWOzrzR0gJKJO/PLGMR4uH2dqEgqGhrsCV+sSpk4KtOEnUQlfjZI/F7BFlqSvVpFbjdgYRRLysAeEZpJ6S1lg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/google": {
+      "version": "3.0.64",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-3.0.64.tgz",
+      "integrity": "sha512-CbR82EgGPNrj/6q0HtclwuCqe0/pDShyv3nWDP/A9DroujzWXnLMlUJVrgPOsg4b40zQCwwVs2XSKCxvt/4QaA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/openai": {
+      "version": "3.0.53",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.53.tgz",
+      "integrity": "sha512-Wld+Rbc05KaUn08uBt06eEuwcgalcIFtIl32Yp+GxuZXUQwOb6YeAuq+C6da4ch6BurFoqEaLemJVwjBb7x+PQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/demos/engineering-team/package.json
+++ b/demos/engineering-team/package.json
@@ -10,6 +10,8 @@
   },
   "devDependencies": {
     "@ai-sdk/anthropic": "^3.0.0",
+    "@ai-sdk/google": "^3.0.0",
+    "@ai-sdk/openai": "^3.0.0",
     "tsx": "^4.0.0"
   }
 }

--- a/demos/engineering-team/provider.ts
+++ b/demos/engineering-team/provider.ts
@@ -1,0 +1,130 @@
+/**
+ * Provider resolution for demos.
+ *
+ * Picks a model provider (Anthropic / Google / OpenAI) based on env:
+ *
+ *   DEMO_PROVIDER=anthropic | google | openai  (explicit choice)
+ *
+ * If `DEMO_PROVIDER` is unset, auto-picks the first provider whose API
+ * key is available, in order anthropic → google → openai. Fails with a
+ * readable error if nothing is set.
+ *
+ * Per-provider env vars:
+ *   ANTHROPIC_API_KEY
+ *   GOOGLE_API_KEY  (or GEMINI_API_KEY — both accepted)
+ *   OPENAI_API_KEY
+ *
+ * Per-demo model overrides (optional):
+ *   DEMO_MASTER_MODEL
+ *   DEMO_WORKER_MODEL
+ *
+ * The SDKs are imported dynamically so installing only the provider you
+ * actually want keeps the demo usable.
+ */
+
+import type { LanguageModel } from 'ai';
+
+export type Provider = 'anthropic' | 'google' | 'openai';
+
+export interface ResolvedProvider {
+  name: Provider;
+  model: (id: string) => LanguageModel;
+  defaults: { master: string; worker: string };
+}
+
+const DEFAULTS: Record<Provider, { master: string; worker: string }> = {
+  anthropic: { master: 'claude-sonnet-4-6', worker: 'claude-haiku-4-5' },
+  google: { master: 'gemini-2.5-pro', worker: 'gemini-2.5-flash' },
+  openai: { master: 'gpt-5', worker: 'gpt-5-mini' },
+};
+
+function envHas(name: Provider): boolean {
+  if (name === 'anthropic') return Boolean(process.env.ANTHROPIC_API_KEY);
+  if (name === 'google') return Boolean(process.env.GOOGLE_API_KEY || process.env.GEMINI_API_KEY);
+  return Boolean(process.env.OPENAI_API_KEY);
+}
+
+export async function resolveProvider(): Promise<ResolvedProvider> {
+  const requested = (process.env.DEMO_PROVIDER ?? '').toLowerCase();
+  let chosen: Provider | null = null;
+
+  if (requested === 'anthropic' || requested === 'google' || requested === 'openai') {
+    if (!envHas(requested)) {
+      console.error(
+        `Error: DEMO_PROVIDER=${requested} but the corresponding API key is not set.`,
+      );
+      console.error(missingKeyHint(requested));
+      process.exit(1);
+    }
+    chosen = requested;
+  } else if (requested !== '') {
+    console.error(`Error: DEMO_PROVIDER="${requested}" is not recognised. Use one of: anthropic, google, openai.`);
+    process.exit(1);
+  } else {
+    for (const candidate of ['anthropic', 'google', 'openai'] as Provider[]) {
+      if (envHas(candidate)) {
+        chosen = candidate;
+        break;
+      }
+    }
+  }
+
+  if (!chosen) {
+    console.error('Error: No provider API key found.');
+    console.error('  Set one of: ANTHROPIC_API_KEY, GOOGLE_API_KEY (or GEMINI_API_KEY), OPENAI_API_KEY.');
+    console.error('  Optionally set DEMO_PROVIDER=anthropic|google|openai to force a choice.');
+    process.exit(1);
+  }
+
+  const defaults = {
+    master: process.env.DEMO_MASTER_MODEL || DEFAULTS[chosen].master,
+    worker: process.env.DEMO_WORKER_MODEL || DEFAULTS[chosen].worker,
+  };
+
+  switch (chosen) {
+    case 'anthropic': {
+      const { createAnthropic } = await import('@ai-sdk/anthropic');
+      const provider = createAnthropic({ apiKey: process.env.ANTHROPIC_API_KEY! });
+      return {
+        name: 'anthropic',
+        // Cast through unknown because each provider's model type is
+        // branded separately; LanguageModel is the unified interface
+        // agent-do takes.
+        model: (id) => provider(id) as unknown as LanguageModel,
+        defaults,
+      };
+    }
+    case 'google': {
+      const { createGoogleGenerativeAI } = await import('@ai-sdk/google');
+      const apiKey = process.env.GOOGLE_API_KEY || process.env.GEMINI_API_KEY!;
+      const provider = createGoogleGenerativeAI({ apiKey });
+      return {
+        name: 'google',
+        model: (id) => provider(id) as unknown as LanguageModel,
+        defaults,
+      };
+    }
+    case 'openai': {
+      const { createOpenAI } = await import('@ai-sdk/openai');
+      const provider = createOpenAI({ apiKey: process.env.OPENAI_API_KEY! });
+      return {
+        name: 'openai',
+        model: (id) => provider(id) as unknown as LanguageModel,
+        defaults,
+      };
+    }
+  }
+}
+
+function missingKeyHint(provider: Provider): string {
+  if (provider === 'anthropic') return '  Set ANTHROPIC_API_KEY=sk-ant-...';
+  if (provider === 'google') return '  Set GOOGLE_API_KEY (or GEMINI_API_KEY).';
+  return '  Set OPENAI_API_KEY=sk-...';
+}
+
+export function announce(resolved: ResolvedProvider): void {
+  // eslint-disable-next-line no-console
+  console.log(
+    `  Provider: ${resolved.name} (master=${resolved.defaults.master}, worker=${resolved.defaults.worker})`,
+  );
+}

--- a/demos/engineering-team/provider.ts
+++ b/demos/engineering-team/provider.ts
@@ -9,17 +9,21 @@
  * key is available, in order anthropic → google → openai. Fails with a
  * readable error if nothing is set.
  *
- * Per-provider env vars:
+ * Per-provider env vars (matches the main CLI's convention — see
+ * src/cli/resolve-model.ts):
  *   ANTHROPIC_API_KEY
- *   GOOGLE_API_KEY  (or GEMINI_API_KEY — both accepted)
+ *   GOOGLE_GENERATIVE_AI_API_KEY   (canonical)
+ *     GOOGLE_API_KEY               (alias, also accepted)
+ *     GEMINI_API_KEY               (alias, also accepted)
  *   OPENAI_API_KEY
  *
  * Per-demo model overrides (optional):
  *   DEMO_MASTER_MODEL
  *   DEMO_WORKER_MODEL
  *
- * The SDKs are imported dynamically so installing only the provider you
- * actually want keeps the demo usable.
+ * The SDKs are imported dynamically so only the selected provider is
+ * imported and initialised at runtime — the unused providers stay out
+ * of the process even though they're present in node_modules.
  */
 
 import type { LanguageModel } from 'ai';
@@ -38,10 +42,32 @@ const DEFAULTS: Record<Provider, { master: string; worker: string }> = {
   openai: { master: 'gpt-5', worker: 'gpt-5-mini' },
 };
 
+/**
+ * Minimum plausible API-key length. The main CLI uses the same floor
+ * (src/cli/resolve-model.ts `value.length < 4`) so an obviously empty
+ * or placeholder value ("x", "123") produces a clean error instead of
+ * a confusing 4xx from the provider.
+ */
+const MIN_KEY_LENGTH = 4;
+
+function keyFor(name: Provider): string | undefined {
+  if (name === 'anthropic') {
+    return process.env.ANTHROPIC_API_KEY;
+  }
+  if (name === 'google') {
+    // Accept the canonical name first, then the two common aliases.
+    return (
+      process.env.GOOGLE_GENERATIVE_AI_API_KEY ||
+      process.env.GOOGLE_API_KEY ||
+      process.env.GEMINI_API_KEY
+    );
+  }
+  return process.env.OPENAI_API_KEY;
+}
+
 function envHas(name: Provider): boolean {
-  if (name === 'anthropic') return Boolean(process.env.ANTHROPIC_API_KEY);
-  if (name === 'google') return Boolean(process.env.GOOGLE_API_KEY || process.env.GEMINI_API_KEY);
-  return Boolean(process.env.OPENAI_API_KEY);
+  const key = keyFor(name);
+  return Boolean(key && key.length >= MIN_KEY_LENGTH);
 }
 
 export async function resolveProvider(): Promise<ResolvedProvider> {
@@ -51,7 +77,7 @@ export async function resolveProvider(): Promise<ResolvedProvider> {
   if (requested === 'anthropic' || requested === 'google' || requested === 'openai') {
     if (!envHas(requested)) {
       console.error(
-        `Error: DEMO_PROVIDER=${requested} but the corresponding API key is not set.`,
+        `Error: DEMO_PROVIDER=${requested} but the corresponding API key is not set (or shorter than ${MIN_KEY_LENGTH} chars).`,
       );
       console.error(missingKeyHint(requested));
       process.exit(1);
@@ -71,7 +97,10 @@ export async function resolveProvider(): Promise<ResolvedProvider> {
 
   if (!chosen) {
     console.error('Error: No provider API key found.');
-    console.error('  Set one of: ANTHROPIC_API_KEY, GOOGLE_API_KEY (or GEMINI_API_KEY), OPENAI_API_KEY.');
+    console.error('  Set one of:');
+    console.error('    ANTHROPIC_API_KEY');
+    console.error('    GOOGLE_GENERATIVE_AI_API_KEY (or GOOGLE_API_KEY / GEMINI_API_KEY)');
+    console.error('    OPENAI_API_KEY');
     console.error('  Optionally set DEMO_PROVIDER=anthropic|google|openai to force a choice.');
     process.exit(1);
   }
@@ -84,7 +113,7 @@ export async function resolveProvider(): Promise<ResolvedProvider> {
   switch (chosen) {
     case 'anthropic': {
       const { createAnthropic } = await import('@ai-sdk/anthropic');
-      const provider = createAnthropic({ apiKey: process.env.ANTHROPIC_API_KEY! });
+      const provider = createAnthropic({ apiKey: keyFor('anthropic')! });
       return {
         name: 'anthropic',
         // Cast through unknown because each provider's model type is
@@ -96,8 +125,7 @@ export async function resolveProvider(): Promise<ResolvedProvider> {
     }
     case 'google': {
       const { createGoogleGenerativeAI } = await import('@ai-sdk/google');
-      const apiKey = process.env.GOOGLE_API_KEY || process.env.GEMINI_API_KEY!;
-      const provider = createGoogleGenerativeAI({ apiKey });
+      const provider = createGoogleGenerativeAI({ apiKey: keyFor('google')! });
       return {
         name: 'google',
         model: (id) => provider(id) as unknown as LanguageModel,
@@ -106,7 +134,7 @@ export async function resolveProvider(): Promise<ResolvedProvider> {
     }
     case 'openai': {
       const { createOpenAI } = await import('@ai-sdk/openai');
-      const provider = createOpenAI({ apiKey: process.env.OPENAI_API_KEY! });
+      const provider = createOpenAI({ apiKey: keyFor('openai')! });
       return {
         name: 'openai',
         model: (id) => provider(id) as unknown as LanguageModel,
@@ -118,7 +146,9 @@ export async function resolveProvider(): Promise<ResolvedProvider> {
 
 function missingKeyHint(provider: Provider): string {
   if (provider === 'anthropic') return '  Set ANTHROPIC_API_KEY=sk-ant-...';
-  if (provider === 'google') return '  Set GOOGLE_API_KEY (or GEMINI_API_KEY).';
+  if (provider === 'google') {
+    return '  Set GOOGLE_GENERATIVE_AI_API_KEY=... (or GOOGLE_API_KEY / GEMINI_API_KEY).';
+  }
   return '  Set OPENAI_API_KEY=sk-...';
 }
 

--- a/demos/research-team/README.md
+++ b/demos/research-team/README.md
@@ -19,14 +19,18 @@ A multi-agent orchestrator where a Master agent coordinates a Researcher and Wri
 # Install demo dependencies
 npm install
 
-# Set your API key
-export ANTHROPIC_API_KEY=sk-ant-...
+# Set an API key for any supported provider:
+export ANTHROPIC_API_KEY=sk-ant-...            # Anthropic (default)
+# export GOOGLE_GENERATIVE_AI_API_KEY=...      # Google / Gemini
+# export OPENAI_API_KEY=sk-...                 # OpenAI
 
 # Run with a topic (passed as argument or prompted)
 npm start "Rust programming language"
 npm start "the history of the internet"
 npm start  # prompts for a topic interactively
 ```
+
+This demo auto-detects the provider from whichever API key is set. To force a specific provider when multiple keys are present, set `DEMO_PROVIDER=anthropic|google|openai`. Default model IDs differ per provider — see [demos/README.md](../README.md#choose-a-model-provider) for the full env surface.
 
 ## What to expect
 
@@ -44,17 +48,17 @@ npm start  # prompts for a topic interactively
 User (topic)
   |
   v
-Master Agent (claude-sonnet-4-6)
+Master Agent (master model — e.g. claude-sonnet-4-6 / gemini-2.5-pro / gpt-5)
   |--- delegate_task("researcher", "Research X...")
   |      |
   |      v
-  |    Researcher Agent (claude-haiku-4-5)
+  |    Researcher Agent (worker model — e.g. claude-haiku-4-5)
   |      returns findings
   |
   |--- delegate_task("writer", "Write a report using...")
   |      |
   |      v
-  |    Writer Agent (claude-haiku-4-5)
+  |    Writer Agent (worker model)
   |      returns polished report
   |
   v

--- a/demos/research-team/index.ts
+++ b/demos/research-team/index.ts
@@ -17,28 +17,21 @@ import {
   createFileTools,
 } from 'agent-do';
 import { FilesystemMemoryStore } from 'agent-do/stores/filesystem';
-import { createAnthropic } from '@ai-sdk/anthropic';
+import { resolveProvider, announce } from './provider.js';
 
 // ═══════════════════════════════════════════════
 //  Configuration
 // ═══════════════════════════════════════════════
 
 const DATA_DIR = '.data';
-const MASTER_MODEL = 'claude-sonnet-4-6';
-const WORKER_MODEL = 'claude-haiku-4-5';
 
 // ═══════════════════════════════════════════════
 //  Setup
 // ═══════════════════════════════════════════════
 
-const apiKey = process.env.ANTHROPIC_API_KEY;
-if (!apiKey) {
-  console.error('Error: ANTHROPIC_API_KEY environment variable is required.');
-  console.error('  export ANTHROPIC_API_KEY=sk-ant-...');
-  process.exit(1);
-}
-
-const provider = createAnthropic({ apiKey });
+// Resolve provider from env — Anthropic / Google / OpenAI. See
+// ./provider.ts for DEMO_PROVIDER + per-provider key vars.
+const resolved = await resolveProvider();
 
 // Persistent filesystem store for the master (to save reports)
 const store = new FilesystemMemoryStore(DATA_DIR);
@@ -53,17 +46,19 @@ console.log('='.repeat(55));
 console.log('  Multi-Agent Research Pipeline');
 console.log('='.repeat(55));
 console.log('');
+announce(resolved);
+console.log('');
 console.log('  Agents:');
-console.log(`    Master:     ${MASTER_MODEL} (coordinates work)`);
-console.log(`    Researcher: ${WORKER_MODEL} (gathers information)`);
-console.log(`    Writer:     ${WORKER_MODEL} (drafts the report)`);
+console.log(`    Master:     ${resolved.defaults.master} (coordinates work)`);
+console.log(`    Researcher: ${resolved.defaults.worker} (gathers information)`);
+console.log(`    Writer:     ${resolved.defaults.worker} (drafts the report)`);
 console.log('');
 
 const orchestrator = createOrchestrator({
   master: {
     id: 'master',
     name: 'Master',
-    model: provider(MASTER_MODEL) as any,
+    model: resolved.model(resolved.defaults.master),
     systemPrompt: `You are a master agent coordinating a research pipeline.
 
 Your workflow:
@@ -128,7 +123,7 @@ Save the final report to a file before responding.`,
     {
       id: 'researcher',
       name: 'Researcher',
-      model: provider(WORKER_MODEL) as any,
+      model: resolved.model(resolved.defaults.worker),
       systemPrompt: `You are a research specialist. When given a topic, provide comprehensive research including:
 
 - Overview and definition
@@ -145,7 +140,7 @@ Cite specific facts, dates, and numbers where possible.`,
     {
       id: 'writer',
       name: 'Writer',
-      model: provider(WORKER_MODEL) as any,
+      model: resolved.model(resolved.defaults.worker),
       systemPrompt: `You are a writing specialist. When given research notes, produce a polished markdown report with:
 
 - A clear title (# heading)

--- a/demos/research-team/package-lock.json
+++ b/demos/research-team/package-lock.json
@@ -10,27 +10,90 @@
       },
       "devDependencies": {
         "@ai-sdk/anthropic": "^3.0.0",
+        "@ai-sdk/google": "^3.0.0",
+        "@ai-sdk/openai": "^3.0.0",
         "tsx": "^4.0.0"
       }
     },
     "../..": {
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
-        "ai": "^6.0.0",
-        "zod": "^3.23.0"
+        "@ai-sdk/anthropic": "^3.0.0",
+        "@ai-sdk/google": "^3.0.0",
+        "@ai-sdk/openai": "^3.0.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "ai": "^6.0.168",
+        "ignore": "^7.0.5",
+        "yaml": "^2.8.3",
+        "zod": "^4.3.6"
+      },
+      "bin": {
+        "agent-do": "dist/src/cli.js"
       },
       "devDependencies": {
+        "@changesets/changelog-github": "^0.6.0",
+        "@changesets/cli": "^2.31.0",
         "@types/node": "^25.6.0",
         "typedoc": "^0.28.0",
         "typedoc-plugin-markdown": "^4.4.0",
-        "typescript": "^5.5.0",
-        "vitest": "^3.0.0"
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.4"
+      },
+      "peerDependencies": {
+        "@ai-sdk/anthropic": "^3.0.0",
+        "@ai-sdk/google": "^3.0.0",
+        "@ai-sdk/openai": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@ai-sdk/anthropic": {
+          "optional": true
+        },
+        "@ai-sdk/google": {
+          "optional": true
+        },
+        "@ai-sdk/openai": {
+          "optional": true
+        }
       }
     },
     "node_modules/@ai-sdk/anthropic": {
       "version": "3.0.69",
       "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.69.tgz",
       "integrity": "sha512-LshR7X3pFugY0o41G2VKTmg1XoGpSl7uoYWfzk6zjVZLhCfeFiwgpOga+eTV4XY1VVpZwKVqRnkDbIL7K2eH5g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/google": {
+      "version": "3.0.64",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-3.0.64.tgz",
+      "integrity": "sha512-CbR82EgGPNrj/6q0HtclwuCqe0/pDShyv3nWDP/A9DroujzWXnLMlUJVrgPOsg4b40zQCwwVs2XSKCxvt/4QaA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/openai": {
+      "version": "3.0.53",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.53.tgz",
+      "integrity": "sha512-Wld+Rbc05KaUn08uBt06eEuwcgalcIFtIl32Yp+GxuZXUQwOb6YeAuq+C6da4ch6BurFoqEaLemJVwjBb7x+PQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/demos/research-team/package.json
+++ b/demos/research-team/package.json
@@ -10,6 +10,8 @@
   },
   "devDependencies": {
     "@ai-sdk/anthropic": "^3.0.0",
+    "@ai-sdk/google": "^3.0.0",
+    "@ai-sdk/openai": "^3.0.0",
     "tsx": "^4.0.0"
   }
 }

--- a/demos/research-team/provider.ts
+++ b/demos/research-team/provider.ts
@@ -1,0 +1,130 @@
+/**
+ * Provider resolution for demos.
+ *
+ * Picks a model provider (Anthropic / Google / OpenAI) based on env:
+ *
+ *   DEMO_PROVIDER=anthropic | google | openai  (explicit choice)
+ *
+ * If `DEMO_PROVIDER` is unset, auto-picks the first provider whose API
+ * key is available, in order anthropic → google → openai. Fails with a
+ * readable error if nothing is set.
+ *
+ * Per-provider env vars:
+ *   ANTHROPIC_API_KEY
+ *   GOOGLE_API_KEY  (or GEMINI_API_KEY — both accepted)
+ *   OPENAI_API_KEY
+ *
+ * Per-demo model overrides (optional):
+ *   DEMO_MASTER_MODEL
+ *   DEMO_WORKER_MODEL
+ *
+ * The SDKs are imported dynamically so installing only the provider you
+ * actually want keeps the demo usable.
+ */
+
+import type { LanguageModel } from 'ai';
+
+export type Provider = 'anthropic' | 'google' | 'openai';
+
+export interface ResolvedProvider {
+  name: Provider;
+  model: (id: string) => LanguageModel;
+  defaults: { master: string; worker: string };
+}
+
+const DEFAULTS: Record<Provider, { master: string; worker: string }> = {
+  anthropic: { master: 'claude-sonnet-4-6', worker: 'claude-haiku-4-5' },
+  google: { master: 'gemini-2.5-pro', worker: 'gemini-2.5-flash' },
+  openai: { master: 'gpt-5', worker: 'gpt-5-mini' },
+};
+
+function envHas(name: Provider): boolean {
+  if (name === 'anthropic') return Boolean(process.env.ANTHROPIC_API_KEY);
+  if (name === 'google') return Boolean(process.env.GOOGLE_API_KEY || process.env.GEMINI_API_KEY);
+  return Boolean(process.env.OPENAI_API_KEY);
+}
+
+export async function resolveProvider(): Promise<ResolvedProvider> {
+  const requested = (process.env.DEMO_PROVIDER ?? '').toLowerCase();
+  let chosen: Provider | null = null;
+
+  if (requested === 'anthropic' || requested === 'google' || requested === 'openai') {
+    if (!envHas(requested)) {
+      console.error(
+        `Error: DEMO_PROVIDER=${requested} but the corresponding API key is not set.`,
+      );
+      console.error(missingKeyHint(requested));
+      process.exit(1);
+    }
+    chosen = requested;
+  } else if (requested !== '') {
+    console.error(`Error: DEMO_PROVIDER="${requested}" is not recognised. Use one of: anthropic, google, openai.`);
+    process.exit(1);
+  } else {
+    for (const candidate of ['anthropic', 'google', 'openai'] as Provider[]) {
+      if (envHas(candidate)) {
+        chosen = candidate;
+        break;
+      }
+    }
+  }
+
+  if (!chosen) {
+    console.error('Error: No provider API key found.');
+    console.error('  Set one of: ANTHROPIC_API_KEY, GOOGLE_API_KEY (or GEMINI_API_KEY), OPENAI_API_KEY.');
+    console.error('  Optionally set DEMO_PROVIDER=anthropic|google|openai to force a choice.');
+    process.exit(1);
+  }
+
+  const defaults = {
+    master: process.env.DEMO_MASTER_MODEL || DEFAULTS[chosen].master,
+    worker: process.env.DEMO_WORKER_MODEL || DEFAULTS[chosen].worker,
+  };
+
+  switch (chosen) {
+    case 'anthropic': {
+      const { createAnthropic } = await import('@ai-sdk/anthropic');
+      const provider = createAnthropic({ apiKey: process.env.ANTHROPIC_API_KEY! });
+      return {
+        name: 'anthropic',
+        // Cast through unknown because each provider's model type is
+        // branded separately; LanguageModel is the unified interface
+        // agent-do takes.
+        model: (id) => provider(id) as unknown as LanguageModel,
+        defaults,
+      };
+    }
+    case 'google': {
+      const { createGoogleGenerativeAI } = await import('@ai-sdk/google');
+      const apiKey = process.env.GOOGLE_API_KEY || process.env.GEMINI_API_KEY!;
+      const provider = createGoogleGenerativeAI({ apiKey });
+      return {
+        name: 'google',
+        model: (id) => provider(id) as unknown as LanguageModel,
+        defaults,
+      };
+    }
+    case 'openai': {
+      const { createOpenAI } = await import('@ai-sdk/openai');
+      const provider = createOpenAI({ apiKey: process.env.OPENAI_API_KEY! });
+      return {
+        name: 'openai',
+        model: (id) => provider(id) as unknown as LanguageModel,
+        defaults,
+      };
+    }
+  }
+}
+
+function missingKeyHint(provider: Provider): string {
+  if (provider === 'anthropic') return '  Set ANTHROPIC_API_KEY=sk-ant-...';
+  if (provider === 'google') return '  Set GOOGLE_API_KEY (or GEMINI_API_KEY).';
+  return '  Set OPENAI_API_KEY=sk-...';
+}
+
+export function announce(resolved: ResolvedProvider): void {
+  // eslint-disable-next-line no-console
+  console.log(
+    `  Provider: ${resolved.name} (master=${resolved.defaults.master}, worker=${resolved.defaults.worker})`,
+  );
+}

--- a/demos/research-team/provider.ts
+++ b/demos/research-team/provider.ts
@@ -9,17 +9,21 @@
  * key is available, in order anthropic → google → openai. Fails with a
  * readable error if nothing is set.
  *
- * Per-provider env vars:
+ * Per-provider env vars (matches the main CLI's convention — see
+ * src/cli/resolve-model.ts):
  *   ANTHROPIC_API_KEY
- *   GOOGLE_API_KEY  (or GEMINI_API_KEY — both accepted)
+ *   GOOGLE_GENERATIVE_AI_API_KEY   (canonical)
+ *     GOOGLE_API_KEY               (alias, also accepted)
+ *     GEMINI_API_KEY               (alias, also accepted)
  *   OPENAI_API_KEY
  *
  * Per-demo model overrides (optional):
  *   DEMO_MASTER_MODEL
  *   DEMO_WORKER_MODEL
  *
- * The SDKs are imported dynamically so installing only the provider you
- * actually want keeps the demo usable.
+ * The SDKs are imported dynamically so only the selected provider is
+ * imported and initialised at runtime — the unused providers stay out
+ * of the process even though they're present in node_modules.
  */
 
 import type { LanguageModel } from 'ai';
@@ -38,10 +42,32 @@ const DEFAULTS: Record<Provider, { master: string; worker: string }> = {
   openai: { master: 'gpt-5', worker: 'gpt-5-mini' },
 };
 
+/**
+ * Minimum plausible API-key length. The main CLI uses the same floor
+ * (src/cli/resolve-model.ts `value.length < 4`) so an obviously empty
+ * or placeholder value ("x", "123") produces a clean error instead of
+ * a confusing 4xx from the provider.
+ */
+const MIN_KEY_LENGTH = 4;
+
+function keyFor(name: Provider): string | undefined {
+  if (name === 'anthropic') {
+    return process.env.ANTHROPIC_API_KEY;
+  }
+  if (name === 'google') {
+    // Accept the canonical name first, then the two common aliases.
+    return (
+      process.env.GOOGLE_GENERATIVE_AI_API_KEY ||
+      process.env.GOOGLE_API_KEY ||
+      process.env.GEMINI_API_KEY
+    );
+  }
+  return process.env.OPENAI_API_KEY;
+}
+
 function envHas(name: Provider): boolean {
-  if (name === 'anthropic') return Boolean(process.env.ANTHROPIC_API_KEY);
-  if (name === 'google') return Boolean(process.env.GOOGLE_API_KEY || process.env.GEMINI_API_KEY);
-  return Boolean(process.env.OPENAI_API_KEY);
+  const key = keyFor(name);
+  return Boolean(key && key.length >= MIN_KEY_LENGTH);
 }
 
 export async function resolveProvider(): Promise<ResolvedProvider> {
@@ -51,7 +77,7 @@ export async function resolveProvider(): Promise<ResolvedProvider> {
   if (requested === 'anthropic' || requested === 'google' || requested === 'openai') {
     if (!envHas(requested)) {
       console.error(
-        `Error: DEMO_PROVIDER=${requested} but the corresponding API key is not set.`,
+        `Error: DEMO_PROVIDER=${requested} but the corresponding API key is not set (or shorter than ${MIN_KEY_LENGTH} chars).`,
       );
       console.error(missingKeyHint(requested));
       process.exit(1);
@@ -71,7 +97,10 @@ export async function resolveProvider(): Promise<ResolvedProvider> {
 
   if (!chosen) {
     console.error('Error: No provider API key found.');
-    console.error('  Set one of: ANTHROPIC_API_KEY, GOOGLE_API_KEY (or GEMINI_API_KEY), OPENAI_API_KEY.');
+    console.error('  Set one of:');
+    console.error('    ANTHROPIC_API_KEY');
+    console.error('    GOOGLE_GENERATIVE_AI_API_KEY (or GOOGLE_API_KEY / GEMINI_API_KEY)');
+    console.error('    OPENAI_API_KEY');
     console.error('  Optionally set DEMO_PROVIDER=anthropic|google|openai to force a choice.');
     process.exit(1);
   }
@@ -84,7 +113,7 @@ export async function resolveProvider(): Promise<ResolvedProvider> {
   switch (chosen) {
     case 'anthropic': {
       const { createAnthropic } = await import('@ai-sdk/anthropic');
-      const provider = createAnthropic({ apiKey: process.env.ANTHROPIC_API_KEY! });
+      const provider = createAnthropic({ apiKey: keyFor('anthropic')! });
       return {
         name: 'anthropic',
         // Cast through unknown because each provider's model type is
@@ -96,8 +125,7 @@ export async function resolveProvider(): Promise<ResolvedProvider> {
     }
     case 'google': {
       const { createGoogleGenerativeAI } = await import('@ai-sdk/google');
-      const apiKey = process.env.GOOGLE_API_KEY || process.env.GEMINI_API_KEY!;
-      const provider = createGoogleGenerativeAI({ apiKey });
+      const provider = createGoogleGenerativeAI({ apiKey: keyFor('google')! });
       return {
         name: 'google',
         model: (id) => provider(id) as unknown as LanguageModel,
@@ -106,7 +134,7 @@ export async function resolveProvider(): Promise<ResolvedProvider> {
     }
     case 'openai': {
       const { createOpenAI } = await import('@ai-sdk/openai');
-      const provider = createOpenAI({ apiKey: process.env.OPENAI_API_KEY! });
+      const provider = createOpenAI({ apiKey: keyFor('openai')! });
       return {
         name: 'openai',
         model: (id) => provider(id) as unknown as LanguageModel,
@@ -118,7 +146,9 @@ export async function resolveProvider(): Promise<ResolvedProvider> {
 
 function missingKeyHint(provider: Provider): string {
   if (provider === 'anthropic') return '  Set ANTHROPIC_API_KEY=sk-ant-...';
-  if (provider === 'google') return '  Set GOOGLE_API_KEY (or GEMINI_API_KEY).';
+  if (provider === 'google') {
+    return '  Set GOOGLE_GENERATIVE_AI_API_KEY=... (or GOOGLE_API_KEY / GEMINI_API_KEY).';
+  }
   return '  Set OPENAI_API_KEY=sk-...';
 }
 


### PR DESCRIPTION
## Summary

Each demo now auto-picks Anthropic / Google / OpenAI from the environment, so you can actually *use* these as starters — not just as shape demonstrations.

### Env surface

```bash
export ANTHROPIC_API_KEY=sk-ant-...    # → claude-sonnet-4-6 / claude-haiku-4-5
export GOOGLE_API_KEY=...              # → gemini-2.5-pro / gemini-2.5-flash
#  …or GEMINI_API_KEY, accepted as an alias
export OPENAI_API_KEY=sk-...           # → gpt-5 / gpt-5-mini
```

Auto-resolution order: **anthropic → google → openai** (first key found wins).

Force a specific provider:
```bash
DEMO_PROVIDER=google npm start
```

Override model IDs for a run:
```bash
DEMO_MASTER_MODEL=claude-opus-4-6 DEMO_WORKER_MODEL=claude-sonnet-4-6 npm start
```

### Applied to

- `demos/assistant`
- `demos/research-team`
- `demos/code-reviewer`
- `demos/chief-of-staff`
- `demos/engineering-team`

### Implementation notes

- Each demo gets a local `provider.ts` helper (duplicated — demos are standalone npm packages, so a shared import would couple them artificially). Single file, ~100 lines, clearly commented.
- `resolveProvider()` dynamically imports only the AI SDK corresponding to the chosen provider, so installing one demo doesn't force all three SDKs to be present at runtime.
- `package.json` devDependencies list all three `@ai-sdk/*` packages so any of them works out of the box.
- Lockfiles regenerated (all five).
- `demos/README.md` updated with the full env surface.
- Removes the `as any` casts on model passing — `resolveProvider()` returns a `LanguageModel`-typed value directly.

Default stays Anthropic for consistency with what the demos were originally written against, but switching providers is now one env var.

## Test plan

- [x] `npm run typecheck` clean on main package
- [x] `npx tsc --noEmit` clean in each of the 5 demos after `npm install`
- [ ] Manual: `DEMO_PROVIDER=google GOOGLE_API_KEY=... (cd demos/research-team && npm start "Rust")` — should announce google + model names + run successfully
- [ ] Manual: `DEMO_PROVIDER=openai OPENAI_API_KEY=... (cd demos/engineering-team && npm start "Audit log")` — should run 5 phases against gpt-5
- [ ] Manual: unset all keys + run a demo → readable error listing the three env options

🤖 Generated with [Claude Code](https://claude.com/claude-code)