### PR TITLE
Fix release flow: null-author changelog crash + local-publish provenance

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.4/schema.json",
   "changelog": [
-    "@changesets/changelog-github",
+    "./scripts/changelog-formatter.cjs",
     { "repo": "PaulKinlan/agent-do" }
   ],
   "commit": false,

--- a/scripts/changelog-formatter.cjs
+++ b/scripts/changelog-formatter.cjs
@@ -1,0 +1,66 @@
+/**
+ * Changelog formatter for `@changesets/cli`.
+ *
+ * Wraps `@changesets/changelog-github` with a fallback: when the GitHub
+ * GraphQL lookup fails (missing token, commit not yet indexed, PR not
+ * discoverable, etc.), we emit the changeset's summary line as a plain
+ * bullet instead of crashing the whole release.
+ *
+ * Why: the upstream plugin throws `Cannot read properties of null
+ * (reading 'author')` if `object(expression: <sha>)` returns null,
+ * which is common for commits that were pushed seconds ago (GitHub
+ * GraphQL indexes slower than REST). The failure mode of a locally-
+ * driven release shouldn't be "changelog generation explodes"; it
+ * should be "slightly less rich changelog line."
+ *
+ * See: `scripts/release.sh`, `.changeset/config.json`.
+ */
+
+const githubChangelog = require('@changesets/changelog-github').default;
+
+/**
+ * Render a plain summary line when the GitHub-aware formatter errors.
+ * Matches the shape the upstream plugin emits on the happy path
+ * (`- summary`), just without the PR / commit / author links.
+ */
+function plainSummary(changeset) {
+  const firstLine = (changeset.summary || '').split('\n')[0].trimEnd();
+  return `\n\n- ${firstLine}`;
+}
+
+module.exports = {
+  async getReleaseLine(changeset, type, options) {
+    try {
+      return await githubChangelog.getReleaseLine(changeset, type, options);
+    } catch (err) {
+      // Emit a warning so operators notice something's off, but don't
+      // fail the release. Common triggers: fresh commit not yet indexed
+      // by GH GraphQL, missing GITHUB_TOKEN scope, rate limit.
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(
+        `[changelog] GitHub enrichment failed for changeset "${changeset.id ?? '<unknown>'}" — falling back to plain summary. (${msg})`,
+      );
+      return plainSummary(changeset);
+    }
+  },
+
+  async getDependencyReleaseLine(changesets, dependenciesUpdated, options) {
+    try {
+      return await githubChangelog.getDependencyReleaseLine(
+        changesets,
+        dependenciesUpdated,
+        options,
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(
+        `[changelog] GitHub enrichment failed for dependency update — falling back to plain line. (${msg})`,
+      );
+      if (dependenciesUpdated.length === 0) return '';
+      const updates = dependenciesUpdated
+        .map((d) => `  - ${d.name}@${d.newVersion}`)
+        .join('\n');
+      return `\n\n- Updated dependencies:\n${updates}`;
+    }
+  },
+};

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -81,8 +81,18 @@ git commit -m "chore: release v$new_version"
 
 # ── 4. Publish to npm + create git tag ───────────────────────────────
 
-log "Publishing to npm (provenance enabled)…"
-NPM_CONFIG_PROVENANCE=true "$CHANGESET_BIN" publish
+# npm provenance is a CI-only feature: npm needs to detect a supported
+# provider (GitHub Actions, GitLab CI, CircleCI) + an OIDC token. In a
+# local shell there's no provider, so setting NPM_CONFIG_PROVENANCE=true
+# aborts publish with "Automatic provenance generation not supported
+# for provider: null". Only enable it when we're actually in a CI run.
+if [ -n "${CI:-}" ] && [ -n "${GITHUB_ACTIONS:-${ACTIONS_ID_TOKEN_REQUEST_URL:-}}" ]; then
+  log "Publishing to npm (provenance enabled — CI detected)…"
+  NPM_CONFIG_PROVENANCE=true "$CHANGESET_BIN" publish
+else
+  log "Publishing to npm (local run — provenance disabled)…"
+  "$CHANGESET_BIN" publish
+fi
 
 # ── 5. Push commit + tags ────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Two release-flow blockers. Both reproduced against the pending release of \`sparkly-goats-allow.md\`.

### 1. Changelog generation crash on null author

\`@changesets/changelog-github\` calls the GitHub GraphQL API for each changeset's commit. \`object(expression: <sha>)\` returns \`null\` when:
- the commit isn't indexed yet (GH GraphQL lags REST by a minute or two after a push), or
- the \`GITHUB_TOKEN\` can't resolve it.

The upstream plugin then accesses \`data.author\` without a null check and wedges the whole release.

Fix: \`scripts/changelog-formatter.cjs\` wraps the upstream plugin. On any error it logs a warning and emits \`- <first line of summary>\` as a graceful fallback. Wired in via \`.changeset/config.json\`'s \`changelog\` field. Same interface as the upstream plugin, so the happy-path output is unchanged — PR links + commit links + author mentions still appear when the lookup succeeds.

### 2. npm provenance fails locally

\`scripts/release.sh\` unconditionally set \`NPM_CONFIG_PROVENANCE=true\`, but npm provenance needs a supported CI provider (GitHub Actions / GitLab CI / CircleCI) and an OIDC token. Running locally → npm errors with \`Automatic provenance generation not supported for provider: null\`.

The release script's own header says:

> Intentionally manual — no automated CI workflow publishes for us

So provenance belongs behind a CI check. Now:
- \`CI\` + GitHub Actions markers set → provenance on
- Otherwise → provenance off, message says "local run — provenance disabled"

## Test plan

- [x] Smoke-tested the fallback formatter: unset \`GITHUB_TOKEN\`, called \`getReleaseLine\` with a synthetic commit sha. Warning logged, plain bullet returned.
- [x] \`npm run typecheck\` clean
- [x] \`npm test\` clean (623 tests, 34 files)
- [ ] Paul reruns \`npm run release\` locally — should succeed end-to-end even if the fresh commit isn't yet indexed by GH GraphQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)