### PR TITLE
Template packs — installable compositions of roles, skills, routines, policies, tools, MCP bindings (#78)

### DIFF
--- a/.changeset/template-packs.md
+++ b/.changeset/template-packs.md
@@ -1,0 +1,11 @@
+---
+"agent-do": minor
+---
+
+Template packs — installable compositions of skills, routines, policies, tool groups, and MCP server bindings.
+
+- New `createTemplatePack(name, options)` API composes a ready-to-run agent from a bundled or user-installed pack. It interpolates `{{variable}}` placeholders in the system prompt, policies, skills, and routines; installs skills into a `SkillStore`; saves routines into a `RoutineStore`; wires the declared tool groups and MCP servers; and returns the composed `Agent` plus metadata.
+- New CLI subcommands: `npx agent-do install <pack>`, `npx agent-do uninstall <pack>`, `npx agent-do list-packs`. Install copies the pack into `.agent-do/packs/<name>/` and records it in `.agent-do/packs/config.json`; `--force` overwrites; `--from <dir>` installs a local pack directory (useful while authoring).
+- New programmatic APIs: `installPack`, `uninstallPack`, `listPacks`, `readInstallRegistry`, `loadPack`, `loadPackFromDir`, `resolvePackDir`, `parsePackManifest`, `PackManifestSchema`, plus the corresponding types (`PackManifest`, `PackVariable`, `LoadedPack`, `CreateTemplatePackOptions`, `TemplatePack`, `PackListEntry`, `InstalledPackEntry`, `InstallRegistry`).
+- Three packs ship bundled: `chief-of-staff` (full — policies, skills, routines, docs), `engineering-team` (sprint-ordered pipeline skills), `research-team` (scout / analyst / synthesiser / fact-checker).
+- `packs/` is added to the npm `files` allowlist so bundled packs ship with the published tarball.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ There is no undo. Proceed with caution.
 - **Usage tracking** -- built-in cost estimation for 50+ models with per-run and per-day spending limits
 - **Testable** -- `createMockModel()` returns a mock `LanguageModel` with predetermined responses
 - **Eval framework** -- `defineEval()` + `runEvals()` to measure agent quality with 13 assertion types, LLM-as-judge, and multi-provider comparison
+- **Template packs** -- `createTemplatePack(name, options)` composes skills, routines, policies, tools, and MCP bindings into a ready-to-run agent; `npx agent-do install <pack>` copies a pack into your project
 
 ## Install
 
@@ -116,6 +117,12 @@ npx agent-do run code-reviewer "Review this function"
 
 # List saved agents
 npx agent-do list
+
+# Install a template pack — a ready-to-run composition of skills +
+# routines + policies. See "Template packs" below.
+npx agent-do install chief-of-staff
+npx agent-do list-packs
+npx agent-do uninstall chief-of-staff
 
 # Run a custom agent script (.js/.mjs/.cjs/.ts files).
 # --script is required to import local JavaScript/TypeScript; see
@@ -1020,6 +1027,98 @@ const result = await agent.run('Weather in London?');
 | `inputTokensPerCall` | `10` | Simulated input tokens per call |
 | `outputTokensPerCall` | `20` | Simulated output tokens per call |
 
+## Template Packs
+
+Template packs are opinionated compositions that turn a pile of primitives
+(skills, routines, policy modules, tool groups, MCP bindings) into a
+turn-key agent. Think of them as the "plugins" layer on top of agent-do:
+you install a pack with one command and get a working chief of staff,
+research team, or engineering reviewer.
+
+### Bundled packs
+
+| Pack | Description |
+|------|-------------|
+| `chief-of-staff` | Inbox triage + BD tracker + daily task manager, with `priority-map` and `auto-resolver` policy modules |
+| `engineering-team` | Sprint-ordered Think → Plan → Build → Review → Ship → Reflect pipeline |
+| `research-team` | Daily digest pipeline — scout, analyst, synthesiser, fact-checker |
+
+### Using a pack
+
+```ts
+import { createTemplatePack } from 'agent-do';
+import { createAnthropic } from '@ai-sdk/anthropic';
+
+const { agent } = await createTemplatePack('chief-of-staff', {
+  model: createAnthropic()('claude-sonnet-4-6'),
+  variables: { owner: 'Paul Kinlan' },
+  workingDir: './workspace',
+  // mcpServers: { gmail: {...}, calendar: {...} },  // when the pack declares them
+});
+
+await agent.run('Do the morning pass: triage inbox, update tasks.md.');
+```
+
+`createTemplatePack` resolves the pack (bundled or user-installed),
+interpolates `{{variable}}` placeholders in the system prompt / policies
+/ skills / routines, installs the skills into a `SkillStore`, saves the
+routines into a `RoutineStore`, wires declared tool groups
+(`workspace`, `memory`) and MCP servers, and returns the ready-to-run
+agent. Required variables must be supplied (`options.variables`); required
+MCP servers must be supplied (`options.mcpServers`) or the call fails fast.
+
+### Installing and customising
+
+```bash
+npx agent-do install chief-of-staff    # copies to .agent-do/packs/chief-of-staff/
+npx agent-do list-packs                # shows bundled and installed packs
+npx agent-do uninstall chief-of-staff  # removes the local copy
+```
+
+Once installed, the pack lives in `.agent-do/packs/<name>/` — edit the
+policies, skills, and routines in place to customise. User-installed
+packs shadow bundled ones.
+
+### Authoring a pack
+
+A pack is a directory with this layout:
+
+```
+my-pack/
+  pack.json        # manifest — see below
+  policies/*.md    # concatenated into the system prompt
+  skills/*.md      # SKILL.md-style with YAML frontmatter
+  routines/*.md    # routine prompt-as-macros (#77)
+  README.md        # shown by list-packs
+```
+
+`pack.json` is JSON:
+
+```json
+{
+  "name": "my-pack",
+  "version": "0.1.0",
+  "description": "One-line summary",
+  "skills": ["skill-one", "skill-two"],
+  "routines": ["routine-one"],
+  "policies": ["policy-one"],
+  "tools": ["workspace"],
+  "mcpServers": ["gmail"],
+  "variables": [
+    { "name": "owner", "required": true }
+  ],
+  "systemPrompt": "You are {{owner}}'s assistant."
+}
+```
+
+File references can be bare (`priority-triage`) — the loader adds `.md`
+— or explicit (`subdir/priority-triage.md`). Absolute paths and `..`
+segments are rejected. To test an in-development pack locally:
+
+```bash
+npx agent-do install my-pack --from ./path/to/my-pack
+```
+
 ## Eval Framework
 
 Define eval cases to measure agent quality, compare providers, and catch regressions.
@@ -1145,6 +1244,12 @@ const result = await runEvals(suite, { output: 'silent' });
 | `UsageTracker` | class | Track usage and costs within a run |
 | `estimateCost` | `(model, input, output, pricing?) => number` | Estimate cost in USD |
 | `DEFAULT_PRICING` | `PricingTable` | Built-in pricing for 50+ models |
+| `createTemplatePack` | `(name, options) => Promise<TemplatePack>` | Compose a ready-to-run agent from a bundled or installed pack |
+| `installPack` | `(name, options?) => Promise<PackManifest>` | Install a template pack into `.agent-do/packs/` |
+| `uninstallPack` | `(name, options?) => Promise<boolean>` | Remove an installed template pack |
+| `listPacks` | `(options?) => Promise<PackListEntry[]>` | List bundled + installed packs |
+| `loadPack` | `(name, options?) => Promise<LoadedPack>` | Parse pack files without composing an agent |
+| `parsePackManifest` | `(json, sourcePath?) => PackManifest` | Validate a raw `pack.json` body |
 
 ### Test exports (`agent-do/testing`)
 
@@ -1230,6 +1335,9 @@ The [`examples/`](examples/) directory contains runnable examples:
 | 11 | [`11-filesystem-store.ts`](examples/11-filesystem-store.ts) | Persistent filesystem storage — explore the created files |
 | 12 | [`12-prompt-builder.ts`](examples/12-prompt-builder.ts) | Composable system prompts from templates + sections + variables |
 | 13 | [`13-eval-framework.ts`](examples/13-eval-framework.ts) | Eval framework — define cases, assert quality, compare providers |
+| 14 | [`14-mcp.ts`](examples/14-mcp.ts) | MCP — mount external tool servers alongside local tools |
+| 15 | [`15-routines.ts`](examples/15-routines.ts) | Routines — named prompt-as-macro procedures |
+| 16 | [`16-template-packs.ts`](examples/16-template-packs.ts) | Template packs — `createTemplatePack('chief-of-staff', ...)` |
 
 Run any example: `npx tsx examples/01-basic-agent.ts`
 

--- a/examples/16-template-packs.ts
+++ b/examples/16-template-packs.ts
@@ -1,0 +1,48 @@
+/**
+ * Example: Template Packs (#78)
+ *
+ * Compose a ready-to-run agent from a bundled pack. Packs bundle
+ * skills + routines + policy modules + tool groups + MCP bindings
+ * into a single install.
+ *
+ * Run:
+ *   export ANTHROPIC_API_KEY=sk-ant-...
+ *   npx tsx examples/16-template-packs.ts
+ *
+ * See also:
+ *   - `npx agent-do list-packs` — shows bundled and installed packs
+ *   - `npx agent-do install <pack>` — copies a pack into
+ *     `.agent-do/packs/` so you can customise it in place.
+ *   - `npx agent-do uninstall <pack>` — removes a user-installed copy.
+ */
+
+import { createTemplatePack } from 'agent-do';
+import { createAnthropic } from '@ai-sdk/anthropic';
+
+const { agent, manifest, systemPrompt, skills, routines } = await createTemplatePack(
+  'chief-of-staff',
+  {
+    model: createAnthropic()('claude-sonnet-4-6'),
+    variables: {
+      owner: 'Ada Lovelace',
+      timezone: 'Europe/London',
+    },
+    workingDir: './workspace',
+  },
+);
+
+console.log(`Pack: ${manifest.name} v${manifest.version}`);
+console.log(`Description: ${manifest.description}`);
+console.log(`System prompt (${systemPrompt.length} bytes):`);
+console.log(systemPrompt.slice(0, 400) + (systemPrompt.length > 400 ? '…' : ''));
+console.log();
+console.log(`Installed skills: ${skills.map((s) => s.id).join(', ')}`);
+console.log(`Installed routines: ${routines.map((r) => r.id).join(', ')}`);
+console.log();
+
+const report = await agent.run(
+  'Imagine the standard morning pass. Walk through what you would do step-by-step, citing the priority-map and auto-resolver policies.',
+);
+
+console.log('--- Agent report ---');
+console.log(report);

--- a/llms.txt
+++ b/llms.txt
@@ -45,6 +45,18 @@
 - `buildSkillsPrompt(skills: Skill[]): string` — build system prompt section
 - `createSkillTools(store: SkillStore): ToolSet` — search/install/list/remove skills
 
+## Template Packs (#78)
+
+- `createTemplatePack(name, options): Promise<TemplatePack>` — compose a ready-to-run agent from a pack. Options take `model` (required), `variables`, `mcpServers` (keyed by name), `workingDir`, `packsDir`, `hooks`, `permissions`, etc.
+- `installPack(name, { cwd?, from?, force? }): Promise<PackManifest>` — copy a pack into `.agent-do/packs/<name>/`
+- `uninstallPack(name, { cwd? }): Promise<boolean>` — remove an installed pack
+- `listPacks({ cwd? }): Promise<PackListEntry[]>` — list bundled + user-installed packs
+- `loadPack(name, options?): Promise<LoadedPack>` — parse pack files without composing an agent
+- `parsePackManifest(json, sourcePath?): PackManifest` — validate a raw `pack.json` body
+- Bundled packs: `chief-of-staff`, `engineering-team`, `research-team`
+- Manifest shape: `name`, `version`, `description`, `roles?`, `skills?`, `routines?`, `policies?`, `mcpServers?`, `tools?` (`'workspace'|'memory'`), `heartbeat?`, `systemPrompt?`, `variables?`
+- Pack layout on disk: `pack.json`, `policies/*.md` (concatenated into system prompt), `skills/*.md` (SKILL.md format), `routines/*.md`, `README.md`
+
 ## Orchestration
 
 - `createOrchestrator(config: OrchestratorConfig): Orchestrator` — master + workers
@@ -118,6 +130,9 @@
 - `npx agent-do list` — list saved agents
 - `npx agent-do run <name|file>` — run a saved agent by name, or a script file
 - `npx agent-do eval <file|dir>` — run eval cases from file or directory
+- `npx agent-do install <pack> [--force] [--from <dir>]` — install a template pack into `.agent-do/packs/`
+- `npx agent-do uninstall <pack>` — remove an installed template pack
+- `npx agent-do list-packs` — list bundled and installed packs
 - `--provider <name>` — anthropic | google | openai | ollama (default: anthropic)
 - `--model <id>` — model ID (default: provider-specific)
 - `--system <prompt>` — system prompt

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-do",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-do",
-      "version": "0.2.0",
+      "version": "0.4.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.0",
         "@ai-sdk/google": "^3.0.0",
@@ -422,7 +422,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -435,7 +434,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1065,7 +1063,6 @@
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -1760,7 +1757,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2107,7 +2103,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3655,7 +3650,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3730,7 +3724,6 @@
       "integrity": "sha512-wKh+lhdmMFivMlc6vRRcMGXeGEHGU2g8a2CkPTJjJlwRf1iXbimWIPcFolCqe4E0d/FRtGszpIrsp3WLpDB8Pw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@gerrit0/mini-shiki": "^3.23.0",
         "lunr": "^2.3.9",
@@ -3768,7 +3761,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3825,7 +3817,6 @@
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -4090,7 +4081,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "files": [
     "dist/src/",
+    "packs/",
     "README.md",
     "LICENSE"
   ],

--- a/packs/chief-of-staff/README.md
+++ b/packs/chief-of-staff/README.md
@@ -1,0 +1,87 @@
+# Chief of Staff pack
+
+An opinionated composition of agent-do primitives that gives a principal
+(founder, exec, solo operator) a working chief of staff: inbox triage, BD
+follow-up, and daily task management against a shared markdown workspace.
+
+Shaped after the clawchief pattern — policy modules injected into the system
+prompt, deterministic handoffs, and a single source-of-truth workspace each
+role reads before acting.
+
+## What's inside
+
+| Component   | Files |
+|-------------|-------|
+| Policies    | `priority-map.md`, `auto-resolver.md` (concatenated into the system prompt) |
+| Skills      | `priority-triage`, `meeting-notes`, `follow-up-cadence` |
+| Routines    | `daily-task-prep`, `nightly-backup` |
+| Tools       | Workspace tools (`read_file`, `write_file`, …) rooted at the working directory |
+| Variables   | `owner` (required), `timezone` (default `UTC`) |
+
+## Install
+
+```
+npx agent-do install chief-of-staff
+```
+
+This copies the pack to `.agent-do/packs/chief-of-staff/` in your project so
+you can edit the policies, skills, and routines in place — they're meant to
+be customised.
+
+## Use
+
+```ts
+import { createTemplatePack } from 'agent-do';
+import { createAnthropic } from '@ai-sdk/anthropic';
+
+const { agent } = await createTemplatePack('chief-of-staff', {
+  model: createAnthropic()('claude-sonnet-4-6'),
+  variables: { owner: 'Paul Kinlan', timezone: 'Europe/London' },
+  workingDir: './workspace',
+});
+
+const report = await agent.run(
+  'Do the morning pass: triage the inbox, update the BD tracker, refresh tasks.md.',
+);
+console.log(report);
+```
+
+The agent expects a workspace directory with these files (see
+`demos/chief-of-staff` for a seeded example):
+
+- `inbox.md` — mock inbox or whatever feeds it at runtime
+- `tracker.md` — BD / CRM state
+- `tasks.md` — the live TODO list
+- `meetings/` — meeting note output (created as needed)
+- `backups/` — nightly snapshots (created by the `nightly-backup` routine)
+
+## MCP bindings
+
+This pack does **not** require any MCP servers by default — everything runs
+against the local filesystem. In production you'd usually mount Gmail and
+Calendar servers and have the `priority-triage` / `meeting-notes` skills
+read from them directly. To add them:
+
+```ts
+const { agent } = await createTemplatePack('chief-of-staff', {
+  model,
+  variables: { owner: 'Paul Kinlan' },
+  mcpServers: {
+    gmail: { name: 'gmail', transport: { type: 'stdio', command: 'gmail-mcp' } },
+    calendar: { name: 'calendar', transport: { type: 'stdio', command: 'gcal-mcp' } },
+  },
+});
+```
+
+You can also add `mcpServers: ['gmail', 'calendar']` to `pack.json` to make
+them required — users who forget to pass them at create time get a clear
+error.
+
+## Uninstall
+
+```
+npx agent-do uninstall chief-of-staff
+```
+
+This removes the copy under `.agent-do/packs/chief-of-staff/` and updates the
+install registry. The bundled version is still available for reinstall.

--- a/packs/chief-of-staff/pack.json
+++ b/packs/chief-of-staff/pack.json
@@ -1,0 +1,30 @@
+{
+  "name": "chief-of-staff",
+  "version": "0.1.0",
+  "description": "Inbox triage + BD tracker + daily task manager, following the clawchief composition pattern.",
+  "roles": [
+    "executive-assistant",
+    "business-development",
+    "daily-task-manager"
+  ],
+  "skills": [
+    "priority-triage",
+    "meeting-notes",
+    "follow-up-cadence"
+  ],
+  "routines": [
+    "daily-task-prep",
+    "nightly-backup"
+  ],
+  "policies": [
+    "priority-map",
+    "auto-resolver"
+  ],
+  "tools": ["workspace"],
+  "heartbeat": "schedules/default.json",
+  "variables": [
+    { "name": "owner", "description": "The principal the chief of staff reports to", "required": true },
+    { "name": "timezone", "description": "Principal's local timezone", "default": "UTC" }
+  ],
+  "systemPrompt": "You are {{owner}}'s chief of staff. Coordinate triage, BD follow-ups, and daily task management against a shared workspace of markdown files (inbox.md, tracker.md, tasks.md). Always re-read priority-map and auto-resolver before acting. Never auto-resolve anything at P0 or anything involving money without {{owner}}'s sign-off. Operate in {{timezone}} unless the user specifies otherwise."
+}

--- a/packs/chief-of-staff/policies/auto-resolver.md
+++ b/packs/chief-of-staff/policies/auto-resolver.md
@@ -1,0 +1,29 @@
+# Auto-resolver
+
+How the chief of staff decides to act on each signal. Four modes:
+
+- **auto-resolve:** act without asking. OK for P2/P3 informational replies,
+  out-of-office confirmations, calendar confirmations matching a standing
+  preference, and meeting reschedules that don't break a commitment.
+- **draft-and-ask:** write the reply / action but wait for {{owner}}'s
+  approval. Default for P1 customer replies, new commitments, anything
+  touching money, and any first-time outreach to a new contact.
+- **escalate:** surface directly to {{owner}}, do not draft. P0 items,
+  conflicts in priority-map, legal/compliance signals, security incidents.
+- **ignore:** filter spam, confirmed duplicates, no-reply newsletters,
+  cold pitches that don't match {{owner}}'s interests.
+
+## Source-of-truth rule
+
+Never auto-resolve from memory alone. Always re-read the current state of
+`inbox.md`, `tracker.md`, and `tasks.md` before acting. If a file disagrees
+with what you remember, trust the file.
+
+## Hand-off contract
+
+When delegating to a specialist, include in the hand-off:
+
+1. The raw signal (email body / event / task).
+2. Your priority classification + resolution mode.
+3. Which file(s) the specialist should read before responding.
+4. A one-line summary of why this matters to {{owner}}.

--- a/packs/chief-of-staff/policies/priority-map.md
+++ b/packs/chief-of-staff/policies/priority-map.md
@@ -1,0 +1,22 @@
+# Priority Map
+
+Ordering rules for what gets {{owner}}'s attention first. Refresh this file any
+time a new VIP or customer deserves a standing priority boost.
+
+## Levels
+
+- **P0 — drop everything:** CEO, board, regulators, security incidents, legal
+  notices. Surface immediately, never auto-resolve.
+- **P1 — same day:** direct reports, active customers, active deals > $50K,
+  anyone {{owner}} has personally committed to reply to today.
+- **P2 — this week:** prospects, vendors, partner check-ins, newsletter
+  signups, routine scheduling.
+- **P3 — when time permits:** cold outreach, PR pitches, generic recruiter
+  mail, newsletters, FYI cc's.
+
+## Routing rules (signal → handoff)
+
+- New lead or outreach → **business-development**
+- Calendar / scheduling request → **executive-assistant**
+- New TODO or status update → **task-manager**
+- Any P0 → surface to {{owner}} immediately; do not auto-resolve.

--- a/packs/chief-of-staff/routines/daily-task-prep.md
+++ b/packs/chief-of-staff/routines/daily-task-prep.md
@@ -1,0 +1,28 @@
+---
+name: daily-task-prep
+description: Prepare {{owner}}'s day — triage overnight inbox, check today's calendar, surface the top 3 priorities
+version: 0.1.0
+inputs:
+  - name: date
+    description: ISO date for the prep (YYYY-MM-DD). Defaults to today.
+    optional: true
+---
+
+Run the standard morning prep for {{owner}}, scoped to {{date}} (or today if
+omitted).
+
+1. **Triage** the overnight signals in `inbox.md` by applying the
+   priority-triage skill. Keep the decisions in-file; produce a rollup at the
+   top of `inbox.md` under a `## Overnight` heading.
+2. **Calendar sweep** — list today's meetings from `calendar.md` (or the
+   calendar MCP server if mounted). For every meeting flag whether prep work
+   is outstanding (does `tasks.md` have an open `[ ] prep for <meeting>` item?
+   does the meeting have notes linked?).
+3. **Top 3** — choose the three highest-priority items across inbox + tasks +
+   calendar. Use priority-map. Write them to the top of `tasks.md` under
+   `## Today`. Bump yesterday's un-done items below.
+4. **Report** — summarise in <10 bullets what {{owner}} should look at first
+   when they start their day.
+
+Do not send anything. Every action item stays in a draft state until
+{{owner}} signs off.

--- a/packs/chief-of-staff/routines/nightly-backup.md
+++ b/packs/chief-of-staff/routines/nightly-backup.md
@@ -1,0 +1,24 @@
+---
+name: nightly-backup
+description: Snapshot the chief-of-staff workspace into backups/YYYY-MM-DD/ and archive resolved items
+version: 0.1.0
+inputs:
+  - name: date
+    description: ISO date for the backup folder (YYYY-MM-DD). Defaults to today.
+    optional: true
+---
+
+Nightly maintenance — run once at end of day.
+
+1. Make a `backups/{{date}}/` directory.
+2. Copy `inbox.md`, `tracker.md`, `tasks.md` into it verbatim.
+3. In `inbox.md`: move every entry tagged `[auto-resolved]` or `[ignore]` to
+   an `## Archive` section at the bottom.
+4. In `tasks.md`: move every checked-off task to a `## Completed — {{date}}`
+   section at the bottom.
+5. In `tracker.md`: verify that every row's `Next touch` date is still in the
+   future; if it's past, bump the row's touch counter (see the
+   follow-up-cadence skill) or move to `## Closed`.
+6. Report the counts: how many archived / completed / moved to closed.
+
+Do not contact anyone during backup. This is maintenance only.

--- a/packs/chief-of-staff/skills/follow-up-cadence.md
+++ b/packs/chief-of-staff/skills/follow-up-cadence.md
@@ -1,0 +1,40 @@
+---
+name: Follow-up Cadence
+description: Standard BD follow-up schedule — when to nudge, when to drop a lead
+author: agent-do
+version: 0.1.0
+triggers:
+  - follow up with leads
+  - nudge this prospect
+  - when should we reach out
+  - bd follow-up
+---
+
+# Follow-up Cadence
+
+The standing cadence for outbound BD — read `tracker.md` first, never
+nudge from memory.
+
+## Schedule
+
+| Touch | Delay since previous | Channel | Template tone |
+|-------|---------------------|---------|---------------|
+| 1 | Day 0 (initial contact) | Email | Warm intro, 3 sentences, one clear ask |
+| 2 | +2 business days | Email reply | Short bump, reference the first message |
+| 3 | +5 business days | Email reply | One-liner + alternative path (call / async) |
+| 4 | +7 business days | Closing note | "I'll stop bumping — open to reconnect any time" |
+
+## Stop conditions
+
+- Stop after touch #4. Do not continue.
+- Stop immediately if the lead says "not now" or "please remove me".
+- Stop immediately if the lead replies — switch to the normal conversation.
+
+## Tracker hygiene
+
+After every touch:
+
+1. Update the `Next touch` column in `tracker.md` to the scheduled date.
+2. Increment the touch count in the `Status` column: `Touch 2 sent 2026-04-21`.
+3. When you hit stop conditions, move the row to a `## Closed` section with
+   the outcome recorded.

--- a/packs/chief-of-staff/skills/meeting-notes.md
+++ b/packs/chief-of-staff/skills/meeting-notes.md
@@ -1,0 +1,51 @@
+---
+name: Meeting Notes
+description: Capture structured meeting notes and propagate action items into tasks.md
+author: agent-do
+version: 0.1.0
+triggers:
+  - take meeting notes
+  - capture meeting outcomes
+  - write up this meeting
+  - post-meeting follow-up
+---
+
+# Meeting Notes
+
+Capture every meeting in a consistent structure so {{owner}} can scan the
+weekly rollup in one pass.
+
+## Output file
+
+Write the note to `meetings/YYYY-MM-DD-<slug>.md` where `slug` is the meeting
+title kebab-cased.
+
+## Required sections
+
+```
+# <Meeting Title> — <Date>
+
+**Attendees:** ...
+**Topic:** one line summary
+
+## Decisions
+- ...
+
+## Action items
+- [ ] <owner>: <action> (due <date>)
+
+## Open threads
+- ...
+
+## Notes
+Free-form context.
+```
+
+## After writing
+
+- For every unchecked action item under `## Action items`, append a matching
+  entry to `tasks.md` under the owner section — or under `## Principal` if the
+  owner is {{owner}}. Include a back-link to the meeting file so the task
+  carries its context.
+- Flag any **decision** involving money, hiring, or a customer commitment for
+  `draft-and-ask` review (per auto-resolver).

--- a/packs/chief-of-staff/skills/priority-triage.md
+++ b/packs/chief-of-staff/skills/priority-triage.md
@@ -1,0 +1,39 @@
+---
+name: Priority Triage
+description: Classify an inbox item into P0/P1/P2/P3 and choose auto-resolve / draft-and-ask / escalate / ignore per the auto-resolver policy
+author: agent-do
+version: 0.1.0
+triggers:
+  - triage the inbox
+  - process my inbox
+  - classify this email
+  - what's urgent today
+---
+
+# Priority Triage
+
+Apply this skill every time a new signal enters `inbox.md` — whether it's an
+email, a Slack DM pasted in, or a calendar invite.
+
+## Steps
+
+1. **Read the two policy files first:** `priority-map.md` and `auto-resolver.md`.
+   These override anything in your memory. If the map promotes or demotes a
+   sender since the last time you saw them, apply the new rule.
+2. **Classify priority (P0–P3)** using the levels from priority-map. When two
+   levels could apply, take the higher one.
+3. **Choose a resolution mode** from auto-resolver:
+   auto-resolve / draft-and-ask / escalate / ignore.
+4. **Write the decision** into `inbox.md` next to the item, in the form:
+   `[P1 | draft-and-ask] reason`.
+5. **Produce a report** with three sections:
+   - **Escalate now** — P0s and anything else that needs the principal today.
+   - **Draft reply (needs approval)** — drafts written but not sent.
+   - **Auto-resolved** — the ones you already handled.
+
+## Never
+
+- Never send a reply directly. Drafts go to {{owner}} for approval.
+- Never skip reading the policy files, even on your tenth run of the day.
+- Never classify from the sender alone — the message body may elevate
+  priority (e.g. a P3 vendor sending a P0 security disclosure).

--- a/packs/engineering-team/README.md
+++ b/packs/engineering-team/README.md
@@ -1,0 +1,39 @@
+# Engineering Team pack
+
+A sprint-ordered engineering pipeline: **Think → Plan → Build → Review →
+Ship → Reflect**. Each phase pairs a plan-time twin with an audit-time twin
+that scores the output against the original plan.
+
+This pack ships an initial set of reusable skills (`plan-review`,
+`ship-checklist`, `retro`). Build out the role-specific twins (office hours,
+CEO review, design review, QA, CSO, canary) by adding more skills under
+`skills/` — the composition pattern is documented in the issue tracker.
+
+## Install
+
+```
+npx agent-do install engineering-team
+```
+
+## Use
+
+```ts
+import { createTemplatePack } from 'agent-do';
+import { createAnthropic } from '@ai-sdk/anthropic';
+
+const { agent } = await createTemplatePack('engineering-team', {
+  model: createAnthropic()('claude-sonnet-4-6'),
+  variables: { team: 'platform' },
+  workingDir: './repo',
+});
+
+const review = await agent.run(
+  'Review plan.md against the CEO / engineering / design rubrics and flag anything blocking Build.',
+);
+```
+
+## Customising
+
+After install, edit the files under `.agent-do/packs/engineering-team/` to
+fit your process. Add team-specific review rubrics, local ship checklist
+items (e.g. "SOC-2 approval", "data-migration signoff"), and retro templates.

--- a/packs/engineering-team/pack.json
+++ b/packs/engineering-team/pack.json
@@ -1,0 +1,28 @@
+{
+  "name": "engineering-team",
+  "version": "0.1.0",
+  "description": "Sprint-ordered engineering pipeline — Think, Plan, Build, Review, Ship, Reflect.",
+  "roles": [
+    "office-hours",
+    "plan-ceo-review",
+    "plan-eng-review",
+    "plan-design-review",
+    "review",
+    "investigate",
+    "qa",
+    "cso",
+    "ship",
+    "canary",
+    "retro"
+  ],
+  "skills": [
+    "plan-review",
+    "ship-checklist",
+    "retro"
+  ],
+  "tools": ["workspace"],
+  "variables": [
+    { "name": "team", "description": "Team or codebase name", "default": "engineering" }
+  ],
+  "systemPrompt": "You are the lead agent for the {{team}} engineering team. Work sprint-ordered — Think → Plan → Build → Review → Ship → Reflect. Pair every plan-time role with an audit-time twin that scores the output against the original plan. Always cite the file and line you're referencing when reviewing code."
+}

--- a/packs/engineering-team/skills/plan-review.md
+++ b/packs/engineering-team/skills/plan-review.md
@@ -1,0 +1,42 @@
+---
+name: Plan Review
+description: Score a proposed implementation plan against CEO, engineering, and design rubrics
+author: agent-do
+version: 0.1.0
+triggers:
+  - review this plan
+  - plan review
+  - score the proposal
+  - what are the risks in this plan
+---
+
+# Plan Review
+
+Apply this three-axis rubric before any build work starts.
+
+## CEO axis (user / business outcome)
+
+- Does the plan state the user-visible outcome in one sentence?
+- Is the outcome the *simplest* one that unblocks the goal, or is it
+  gold-plated? Call out scope creep explicitly.
+- Are success metrics named and measurable?
+
+## Engineering axis
+
+- Does the plan identify the smallest unit that can ship safely?
+- What's the rollback story? (Feature flag, migration, revert.)
+- Where does it break backward compatibility, if anywhere?
+- What tests prove the change works *and* prove the regression doesn't
+  come back?
+
+## Design / UX axis
+
+- Is the user's first-run experience described step-by-step?
+- Are the failure modes designed for (not just handled)?
+- Does the change need copy review, accessibility check, or localisation?
+
+## Output
+
+A single numbered list of concerns, ordered most-blocking first. Each item
+names the axis it came from. If the plan passes all three axes, say so
+explicitly and recommend moving to Build.

--- a/packs/engineering-team/skills/retro.md
+++ b/packs/engineering-team/skills/retro.md
@@ -1,0 +1,42 @@
+---
+name: Retrospective
+description: Structured post-mortem / retrospective on a completed piece of work
+author: agent-do
+version: 0.1.0
+triggers:
+  - retro
+  - retrospective
+  - post-mortem
+  - what went wrong
+  - what did we learn
+---
+
+# Retrospective
+
+For a completed sprint, feature, or incident. Keep it short and specific.
+
+## What we set out to do
+
+One paragraph. State the original goal and the success criteria.
+
+## What actually happened
+
+- Timeline of key events with dates.
+- What shipped, what didn't.
+
+## What went well
+
+- Bullet list. Be specific — `cache invalidation worked first time` not
+  `things went smoothly`.
+
+## What went wrong
+
+- Bullet list. Focus on systems and process, not individuals. Each bullet
+  should name the underlying cause, not the symptom.
+
+## Action items
+
+- [ ] <owner>: <action> by <date>
+
+Keep action items to a maximum of five. More than five means nothing will
+happen — prioritise.

--- a/packs/engineering-team/skills/ship-checklist.md
+++ b/packs/engineering-team/skills/ship-checklist.md
@@ -1,0 +1,27 @@
+---
+name: Ship Checklist
+description: Pre-flight checks before merging / deploying a change
+author: agent-do
+version: 0.1.0
+triggers:
+  - ready to ship
+  - pre-deploy check
+  - pre-merge checklist
+  - ship checklist
+---
+
+# Ship Checklist
+
+Run through every item. Any unchecked item blocks the ship.
+
+- [ ] Tests pass locally and in CI.
+- [ ] Lint / typecheck clean.
+- [ ] Changelog / changeset entry added (user-facing prose, not "refactored
+      loop.ts").
+- [ ] Feature flag wired up OR rollback path documented in the PR body.
+- [ ] Monitoring / alerting updated for any new failure mode.
+- [ ] Docs updated for any API surface change.
+- [ ] A canary / staged rollout plan exists if the blast radius is large.
+
+Output the checklist with each box either checked or marked `FAIL: <why>`.
+Never mark a box checked you haven't actually verified.

--- a/packs/research-team/README.md
+++ b/packs/research-team/README.md
@@ -1,0 +1,57 @@
+# Research Team pack
+
+A four-agent research pipeline: **scout → analyst → synthesiser →
+fact-checker**. Ships the rubrics as skills and the end-to-end flow as a
+`daily-digest` routine — extends the shape of `demos/research-team` into a
+reusable composition.
+
+## What's inside
+
+| Component | Files |
+|-----------|-------|
+| Skills    | `scout-brief`, `synthesis-rubric`, `fact-check` |
+| Routines  | `daily-digest` |
+| Tools     | Workspace tools rooted at the working directory |
+| Variables | `topic` (required) |
+
+## Install
+
+```
+npx agent-do install research-team
+```
+
+## Use
+
+```ts
+import { createTemplatePack } from 'agent-do';
+import { createAnthropic } from '@ai-sdk/anthropic';
+
+const { agent } = await createTemplatePack('research-team', {
+  model: createAnthropic()('claude-sonnet-4-6'),
+  variables: { topic: 'AI agents' },
+  workingDir: './research',
+});
+
+// Trigger the full pipeline for today's digest:
+const report = await agent.run('Run the daily-digest routine for today.');
+```
+
+## MCP bindings
+
+For a real research team you'd mount a web-search MCP and (optionally) a
+Drive / Notion MCP for publishing. Wire them at create time:
+
+```ts
+const { agent } = await createTemplatePack('research-team', {
+  model,
+  variables: { topic: 'AI agents' },
+  mcpServers: {
+    search: { name: 'search', transport: { type: 'stdio', command: 'web-search-mcp' } },
+  },
+});
+```
+
+## Customising
+
+Edit the rubrics in `skills/` after install to add domain-specific
+verification rules (e.g. "always cite primary sources for medical claims").

--- a/packs/research-team/pack.json
+++ b/packs/research-team/pack.json
@@ -1,0 +1,24 @@
+{
+  "name": "research-team",
+  "version": "0.1.0",
+  "description": "Daily research digest pipeline — scout, analyst, synthesiser, fact-checker.",
+  "roles": [
+    "scout",
+    "analyst",
+    "synthesiser",
+    "fact-checker"
+  ],
+  "skills": [
+    "scout-brief",
+    "synthesis-rubric",
+    "fact-check"
+  ],
+  "routines": [
+    "daily-digest"
+  ],
+  "tools": ["workspace"],
+  "variables": [
+    { "name": "topic", "description": "Focus area for the research team", "required": true }
+  ],
+  "systemPrompt": "You lead a 4-agent research team focused on {{topic}}: scout gathers, analyst extracts signal, synthesiser composes the digest, fact-checker verifies every claim against a cited source. Never publish anything that hasn't passed fact-check. Keep the daily digest to 500 words max."
+}

--- a/packs/research-team/routines/daily-digest.md
+++ b/packs/research-team/routines/daily-digest.md
@@ -1,0 +1,25 @@
+---
+name: daily-digest
+description: Run the full scout → analyst → synthesiser → fact-checker pipeline for today's digest on {{topic}}
+version: 0.1.0
+inputs:
+  - name: date
+    description: ISO date for the digest (YYYY-MM-DD). Defaults to today.
+    optional: true
+---
+
+Produce today's digest on {{topic}} for {{date}}.
+
+1. **Scout** — apply the Scout Brief skill to produce `briefs/{{date}}.md`
+   with 3–5 candidate sources from the last 24 hours.
+2. **Analyse** — extract the signal from the scout brief. Note which claims
+   are factual (must pass fact-check) vs interpretive.
+3. **Synthesise** — apply the Synthesis Rubric skill to compose
+   `digests/{{date}}.md`. Mark as `[DRAFT — pending fact-check]`.
+4. **Fact-check** — apply the Fact Check skill. Output a fact-check report
+   at `digests/{{date}}.fact-check.md`.
+5. **Publish or rework** — if the fact-check recommends publishing, remove
+   the draft marker. Otherwise loop back to step 3 with the corrections.
+
+Hand back the final published digest. Never publish a digest with
+unresolved WRONG / UNSUPPORTED items.

--- a/packs/research-team/skills/fact-check.md
+++ b/packs/research-team/skills/fact-check.md
@@ -1,0 +1,39 @@
+---
+name: Fact Check
+description: Verify every factual claim in a digest against a cited source
+author: agent-do
+version: 0.1.0
+triggers:
+  - fact check this
+  - verify the claims
+  - check the sources
+  - fact-check the digest
+---
+
+# Fact Check
+
+Run this before publishing any digest. You are the last line before the
+reader sees a wrong claim.
+
+## For every bracketed citation
+
+1. Open the source.
+2. Verify that the claim in the digest matches what the source actually says.
+3. If the claim is paraphrased — confirm the paraphrase preserves the
+   original meaning, including any quantifiers ("most", "some", "all") and
+   any dates.
+
+## Flag
+
+- **WRONG** — source contradicts the claim. Must be removed or corrected.
+- **UNSUPPORTED** — source doesn't say what the digest claims. Must be
+  removed or re-cited.
+- **WEAK** — source says it but only implicitly / second-hand. Add a
+  qualifier or find a stronger source.
+- **OK** — claim matches source exactly.
+
+## Output
+
+For each citation, report `[Source N] CLAIM — STATUS`. Then give a
+single recommendation: "Publish", "Publish with corrections (listed)", or
+"Do not publish — rework needed".

--- a/packs/research-team/skills/scout-brief.md
+++ b/packs/research-team/skills/scout-brief.md
@@ -1,0 +1,46 @@
+---
+name: Scout Brief
+description: Produce a structured scouting brief on a topic with 3–5 candidate sources
+author: agent-do
+version: 0.1.0
+triggers:
+  - scout this topic
+  - find sources on
+  - gather research on
+  - what's new in
+---
+
+# Scout Brief
+
+Produce a one-page brief on {{topic}} that the analyst can feed into
+synthesis. **Do not synthesise yet** — the scout's job is recall, not opinion.
+
+## Output format
+
+```
+# Scout Brief — {{topic}}
+
+## Time window
+<e.g. last 7 days>
+
+## Candidate sources (3–5)
+1. **<title>** — <outlet / author> — <date>
+   URL: <canonical URL>
+   Relevance: one sentence on why this matters.
+2. ...
+
+## Signals to flag for the analyst
+- <short bullet for each recurring theme or surprising claim>
+
+## Gaps
+- <what you looked for but couldn't find>
+```
+
+## Rules
+
+- 3–5 sources, no more. Force prioritisation.
+- URLs must be canonical (no tracking parameters).
+- Quote exact claim text in the "Signals" section when a source says
+  something that will drive synthesis — the fact-checker will need it.
+- If you have fewer than 3 sources, report that in "Gaps" rather than
+  padding with weak sources.

--- a/packs/research-team/skills/synthesis-rubric.md
+++ b/packs/research-team/skills/synthesis-rubric.md
@@ -1,0 +1,40 @@
+---
+name: Synthesis Rubric
+description: Rules for composing the daily digest from the analyst's extracted signals
+author: agent-do
+version: 0.1.0
+triggers:
+  - write the daily digest
+  - synthesise the research
+  - compose the digest
+---
+
+# Synthesis Rubric
+
+Given an analyst report on {{topic}}, compose the daily digest.
+
+## Structure
+
+```
+# {{topic}} — <Date>
+
+## TL;DR
+<3 sentences, maximum. The one thing a busy reader should know.>
+
+## What happened
+- 2–4 bullets of the most important developments. Each bullet names a source
+  with a bracketed citation: `[Source 3]`.
+
+## What to watch
+- 1–2 forward-looking items: trends, upcoming events, open questions.
+```
+
+## Rules
+
+- 500 words absolute max. If it doesn't fit, cut — don't abbreviate.
+- Every factual claim must carry a citation pointing at an entry from the
+  scout brief.
+- No hedging — if the sources disagree, say so explicitly and attribute.
+- No editorialising — the rubric is about selection, not opinion.
+- Hand off to the fact-checker before publishing. Mark the digest
+  `[DRAFT — pending fact-check]` until then.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,11 @@ import { runPromptMode } from './cli/prompt.js';
 import { runScriptMode } from './cli/script.js';
 import { runEvalMode } from './cli/eval-cmd.js';
 import { createSavedAgent, listSavedAgents } from './cli/agents.js';
+import {
+  runInstallCommand,
+  runUninstallCommand,
+  runListPacksCommand,
+} from './cli/pack-cmd.js';
 
 async function main(): Promise<void> {
   let args: ParsedArgs;
@@ -51,6 +56,15 @@ async function main(): Promise<void> {
       case 'list':
         await listSavedAgents();
         break;
+      case 'install':
+        await runInstallCommand(args);
+        break;
+      case 'uninstall':
+        await runUninstallCommand(args);
+        break;
+      case 'list-packs':
+        await runListPacksCommand(args);
+        break;
     }
   } catch (err) {
     console.error(err instanceof Error ? err.message : String(err));
@@ -72,6 +86,9 @@ Usage:
   npx agent-do list                        List saved agents
   npx agent-do run <name|file> [task]      Run a saved agent or script file
   npx agent-do eval <file|dir> [options]   Run eval cases
+  npx agent-do install <pack> [--force]    Install a template pack
+  npx agent-do uninstall <pack>            Remove an installed template pack
+  npx agent-do list-packs                  List bundled and installed packs
 
 Piping:
   echo "context" | npx agent-do "prompt"   Merge piped input with prompt
@@ -129,6 +146,11 @@ Eval options:
   --output <format>      console | json | csv (default: console)
   --compare <providers>  Compare across providers (comma-separated)
   --concurrency <n>      Parallel case execution (default: 1)
+
+Pack options:
+  --from <dir>           Install a pack from a local directory (for
+                         authoring / testing) instead of the bundled set
+  --force                Overwrite an existing installation of the same pack
 
 Environment:
   ANTHROPIC_API_KEY      Required for Anthropic models

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -6,10 +6,25 @@
  */
 
 export interface ParsedArgs {
-  command: 'prompt' | 'run' | 'eval' | 'create' | 'list';
+  command: 'prompt' | 'run' | 'eval' | 'create' | 'list' | 'install' | 'uninstall' | 'list-packs';
   prompt?: string;
   file?: string;
   agentName?: string;
+  /**
+   * Pack name positional, for `install <pack>` / `uninstall <pack>` (#78).
+   */
+  packName?: string;
+  /**
+   * Explicit source directory for `install --from <dir>`. When set,
+   * installation copies from this directory instead of the bundled
+   * packs. Useful during pack development.
+   */
+  fromPath?: string;
+  /**
+   * Overwrite an existing installation of the same pack. Required by
+   * `install` when the target already exists.
+   */
+  force?: boolean;
   provider: string;
   model?: string;
   systemPrompt: string;
@@ -152,6 +167,15 @@ export function parseArgs(argv: string[]): ParsedArgs {
     } else if (first === 'list') {
       args.command = 'list';
       i = 1;
+    } else if (first === 'install') {
+      args.command = 'install';
+      i = 1;
+    } else if (first === 'uninstall') {
+      args.command = 'uninstall';
+      i = 1;
+    } else if (first === 'list-packs') {
+      args.command = 'list-packs';
+      i = 1;
     }
   }
 
@@ -244,6 +268,10 @@ export function parseArgs(argv: string[]): ParsedArgs {
     } else if (arg === '--allow') {
       const val = requireValue(argv, ++i, '--allow');
       args.allow.push(...val.split(',').map((s) => s.trim()).filter(Boolean));
+    } else if (arg === '--from') {
+      args.fromPath = requireValue(argv, ++i, '--from');
+    } else if (arg === '--force') {
+      args.force = true;
     } else if (arg.startsWith('-')) {
       throw new Error(`Unknown option: ${arg}. Use --help for usage.`);
     } else {
@@ -271,6 +299,13 @@ export function parseArgs(argv: string[]): ParsedArgs {
     }
     args.agentName = positional[0];
   } else if (args.command === 'list') {
+    // no positional args needed
+  } else if (args.command === 'install' || args.command === 'uninstall') {
+    if (positional.length === 0 && !args.help) {
+      throw new Error(`Usage: npx agent-do ${args.command} <pack>`);
+    }
+    args.packName = positional[0];
+  } else if (args.command === 'list-packs') {
     // no positional args needed
   } else {
     // prompt mode — all positional args become the prompt

--- a/src/cli/pack-cmd.ts
+++ b/src/cli/pack-cmd.ts
@@ -1,0 +1,87 @@
+/**
+ * CLI handlers for pack management (#78).
+ *
+ *   agent-do install <pack> [--force] [--from <dir>]
+ *   agent-do uninstall <pack>
+ *   agent-do list-packs
+ *
+ * Each handler is a thin wrapper over the programmatic API in
+ * `src/packs/install.ts`. Errors propagate up to `cli.ts` which
+ * prints them and exits non-zero.
+ */
+
+import { installPack, uninstallPack, listPacks } from '../packs/install.js';
+import type { ParsedArgs } from './args.js';
+
+export async function runInstallCommand(args: ParsedArgs): Promise<void> {
+  if (!args.packName) {
+    throw new Error('Usage: npx agent-do install <pack> [--force] [--from <dir>]');
+  }
+  const manifest = await installPack(args.packName, {
+    cwd: args.workingDir,
+    from: args.fromPath,
+    force: args.force,
+  });
+  console.log(`Installed pack "${manifest.name}" v${manifest.version}`);
+  console.log(`  ${manifest.description}`);
+  console.log();
+  console.log(`  Location: ${args.workingDir}/.agent-do/packs/${manifest.name}/`);
+  const parts: string[] = [];
+  if (manifest.skills?.length) parts.push(`${manifest.skills.length} skill${manifest.skills.length === 1 ? '' : 's'}`);
+  if (manifest.routines?.length) parts.push(`${manifest.routines.length} routine${manifest.routines.length === 1 ? '' : 's'}`);
+  if (manifest.policies?.length) parts.push(`${manifest.policies.length} polic${manifest.policies.length === 1 ? 'y' : 'ies'}`);
+  if (manifest.mcpServers?.length) parts.push(`${manifest.mcpServers.length} MCP server binding${manifest.mcpServers.length === 1 ? '' : 's'}`);
+  if (parts.length) console.log(`  Includes: ${parts.join(', ')}`);
+  if (manifest.mcpServers?.length) {
+    console.log();
+    console.log(`  This pack expects the following MCP servers at runtime:`);
+    for (const name of manifest.mcpServers) console.log(`    - ${name}`);
+    console.log(`  Configure them via \`createTemplatePack('${manifest.name}', { mcpServers: { ... } })\`.`);
+  }
+}
+
+export async function runUninstallCommand(args: ParsedArgs): Promise<void> {
+  if (!args.packName) {
+    throw new Error('Usage: npx agent-do uninstall <pack>');
+  }
+  const removed = await uninstallPack(args.packName, { cwd: args.workingDir });
+  if (removed) {
+    console.log(`Uninstalled pack "${args.packName}".`);
+  } else {
+    console.log(`Pack "${args.packName}" is not installed.`);
+  }
+}
+
+export async function runListPacksCommand(args: ParsedArgs): Promise<void> {
+  const entries = await listPacks({ cwd: args.workingDir });
+  if (entries.length === 0) {
+    console.log('No packs available.');
+    return;
+  }
+  const bundled = entries.filter((e) => e.source === 'bundled');
+  const user = entries.filter((e) => e.source === 'user');
+
+  if (user.length > 0) {
+    console.log('Installed packs:\n');
+    for (const e of user) {
+      console.log(`  ${padName(e.manifest.name)} v${e.manifest.version}  ${truncate(e.manifest.description, 60)}`);
+    }
+    console.log();
+  }
+  if (bundled.length > 0) {
+    console.log('Available bundled packs:\n');
+    for (const e of bundled) {
+      const marker = e.shadowed ? ' (shadowed by installed version)' : '';
+      console.log(`  ${padName(e.manifest.name)} v${e.manifest.version}  ${truncate(e.manifest.description, 60)}${marker}`);
+    }
+    console.log();
+    console.log('Install with:  npx agent-do install <pack>');
+  }
+}
+
+function padName(name: string): string {
+  return name.padEnd(24);
+}
+function truncate(s: string, n: number): string {
+  return s.length > n ? s.slice(0, n - 1) + '…' : s;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,6 +104,36 @@ export { InMemoryMemoryStore } from './stores/in-memory.js';
 export { FilesystemMemoryStore } from './stores/filesystem.js';
 export type { FilesystemMemoryStoreOptions } from './types.js';
 
+// Template Packs (#78) — installable compositions of skills, routines,
+// policies, tools, and MCP server bindings.
+export {
+  createTemplatePack,
+  installPack,
+  uninstallPack,
+  listPacks,
+  readInstallRegistry,
+  loadPack,
+  loadPackFromDir,
+  resolvePackDir,
+  findBundledPacksDir,
+  listPacksInDir,
+  parsePackManifest,
+  PackManifestSchema,
+} from './packs/index.js';
+export type {
+  PackManifest,
+  PackVariable,
+  LoadedPack,
+  CreateTemplatePackOptions,
+  TemplatePack,
+  InstallPackOptions,
+  UninstallPackOptions,
+  ListPacksOptions,
+  PackListEntry,
+  InstalledPackEntry,
+  InstallRegistry,
+} from './packs/index.js';
+
 // Prompt builder
 export { buildSystemPrompt, interpolate } from './prompts/builder.js';
 export { builtinSections } from './prompts/sections.js';

--- a/src/packs/create.ts
+++ b/src/packs/create.ts
@@ -1,0 +1,242 @@
+/**
+ * createTemplatePack() — compose a ready-to-run agent from a pack (#78).
+ *
+ * The pack loader (see `loader.ts`) gives us manifest + parsed skills,
+ * routines, and raw policy bodies. This module turns that into an
+ * Agent by:
+ *
+ *   1. Interpolating `{{var}}` placeholders in systemPrompt, policies,
+ *      and skill/routine bodies with the caller-supplied variables.
+ *   2. Installing skills into an in-memory skill store so the agent
+ *      can list/load them at runtime.
+ *   3. Installing routines into an in-memory routine store.
+ *   4. Validating that every `manifest.mcpServers` entry is matched in
+ *      `options.mcpServers`.
+ *   5. Composing the system prompt: manifest.systemPrompt + all
+ *      policy bodies, concatenated with headers.
+ *   6. Wiring workspace / memory tools if the manifest asked for them.
+ *
+ * The returned {@link TemplatePack} exposes the agent plus the
+ * composed artefacts (system prompt, skills, routines) so callers can
+ * inspect what the pack baked in — useful for debugging and for
+ * building richer UIs around installed packs.
+ */
+
+import { createAgent } from '../agent.js';
+import { interpolate } from '../prompts/builder.js';
+import { InMemorySkillStore } from '../skills.js';
+import { InMemoryRoutineStore } from '../routines.js';
+import { createWorkspaceTools } from '../tools/workspace-tools.js';
+import { createMemoryTools } from '../tools/memory-tools.js';
+import { InMemoryMemoryStore } from '../stores/in-memory.js';
+import { loadPack } from './loader.js';
+import type {
+  CreateTemplatePackOptions,
+  LoadedPack,
+  TemplatePack,
+} from './types.js';
+import type { Skill, Routine } from '../types.js';
+import type { ToolSet } from 'ai';
+
+/**
+ * Apply `{{name}}` substitution to a string with the provided vars.
+ * Thin wrapper over `interpolate` so this module has a single call
+ * site — keeps the substitution semantics consistent across the
+ * systemPrompt / policies / skills / routines surfaces.
+ */
+function apply(value: string, vars: Record<string, string> | undefined): string {
+  if (!vars || Object.keys(vars).length === 0) return value;
+  return interpolate(value, vars);
+}
+
+function resolveVariables(
+  loaded: LoadedPack,
+  provided: Record<string, string> | undefined,
+): Record<string, string> {
+  const vars: Record<string, string> = Object.create(null);
+  // Seed defaults from the manifest.
+  for (const decl of loaded.manifest.variables ?? []) {
+    if (decl.default !== undefined) vars[decl.name] = decl.default;
+  }
+  // Caller overrides defaults.
+  if (provided) {
+    for (const [k, v] of Object.entries(provided)) {
+      if (k === '__proto__' || k === 'constructor' || k === 'prototype') continue;
+      vars[k] = v;
+    }
+  }
+  // Enforce required variables.
+  const missing: string[] = [];
+  for (const decl of loaded.manifest.variables ?? []) {
+    if (decl.required && (vars[decl.name] === undefined || vars[decl.name] === '')) {
+      missing.push(decl.name);
+    }
+  }
+  if (missing.length > 0) {
+    throw new Error(
+      `Pack "${loaded.manifest.name}" requires variables: ${missing.join(', ')}. ` +
+      `Pass them via \`variables\` on createTemplatePack().`,
+    );
+  }
+  return vars;
+}
+
+function validateMcpServers(
+  loaded: LoadedPack,
+  provided: CreateTemplatePackOptions['mcpServers'],
+): void {
+  const required = loaded.manifest.mcpServers ?? [];
+  if (required.length === 0) return;
+  const providedKeys = new Set(Object.keys(provided ?? {}));
+  const missing = required.filter((name) => !providedKeys.has(name));
+  if (missing.length > 0) {
+    throw new Error(
+      `Pack "${loaded.manifest.name}" requires MCP servers: ${missing.join(', ')}. ` +
+      `Pass them via \`mcpServers\` on createTemplatePack() ` +
+      `(keys must match the manifest names).`,
+    );
+  }
+}
+
+/**
+ * Convert the pack name to a human-readable default agent name
+ * (`chief-of-staff` → `Chief Of Staff`). Callers can override via
+ * `options.name`.
+ */
+function humanName(packName: string): string {
+  return packName
+    .split(/[-_]/)
+    .map((part) => (part.length > 0 ? part[0]!.toUpperCase() + part.slice(1) : part))
+    .join(' ');
+}
+
+function composeSystemPrompt(
+  loaded: LoadedPack,
+  vars: Record<string, string>,
+): string {
+  const parts: string[] = [];
+  if (loaded.manifest.systemPrompt) {
+    parts.push(apply(loaded.manifest.systemPrompt, vars).trim());
+  }
+  for (const policy of loaded.policies) {
+    const body = apply(policy.body, vars).trim();
+    if (!body) continue;
+    parts.push(`## Policy: ${policy.name}\n\n${body}`);
+  }
+  return parts.join('\n\n').trim();
+}
+
+function interpolateSkills(skills: Skill[], vars: Record<string, string>): Skill[] {
+  return skills.map((skill) => ({
+    ...skill,
+    description: apply(skill.description, vars),
+    content: apply(skill.content, vars),
+  }));
+}
+
+function interpolateRoutines(routines: Routine[], vars: Record<string, string>): Routine[] {
+  return routines.map((routine) => ({
+    ...routine,
+    description: apply(routine.description, vars),
+    body: apply(routine.body, vars),
+  }));
+}
+
+/**
+ * Create a ready-to-run agent from a template pack.
+ *
+ * @example
+ * ```ts
+ * import { createTemplatePack } from 'agent-do';
+ * import { createAnthropic } from '@ai-sdk/anthropic';
+ *
+ * const { agent } = await createTemplatePack('chief-of-staff', {
+ *   model: createAnthropic()('claude-sonnet-4-6'),
+ *   variables: { owner: 'Paul Kinlan' },
+ *   // mcpServers: { gmail: {...}, calendar: {...} },  // when the pack declares them
+ * });
+ *
+ * const answer = await agent.run('Triage the inbox');
+ * ```
+ */
+export async function createTemplatePack(
+  name: string,
+  options: CreateTemplatePackOptions,
+): Promise<TemplatePack> {
+  if (!options || !options.model) {
+    throw new Error(
+      'createTemplatePack requires `options.model`. agent-do is provider-agnostic; ' +
+      'pass any Vercel AI SDK LanguageModel.',
+    );
+  }
+  const loaded = await loadPack(name, {
+    packsDir: options.packsDir,
+  });
+  const vars = resolveVariables(loaded, options.variables);
+  validateMcpServers(loaded, options.mcpServers);
+
+  const skills = interpolateSkills(loaded.skills, vars);
+  const routines = interpolateRoutines(loaded.routines, vars);
+
+  // Install skills into an in-memory store so the agent loop can list
+  // / load them.
+  const skillStore = new InMemorySkillStore();
+  for (const skill of skills) await skillStore.install(skill);
+
+  const routineStore = new InMemoryRoutineStore();
+  for (const routine of routines) await routineStore.save(routine);
+
+  // Compose tools from the pack's declared groups plus caller overrides.
+  let tools: ToolSet = {};
+  const toolGroups = loaded.manifest.tools ?? [];
+  for (const group of toolGroups) {
+    if (group === 'workspace') {
+      const workspaceTools = createWorkspaceTools(
+        options.workingDir ?? process.cwd(),
+      );
+      tools = { ...tools, ...workspaceTools };
+    } else if (group === 'memory') {
+      const memStore = new InMemoryMemoryStore();
+      const memoryTools = createMemoryTools(memStore, options.id ?? loaded.manifest.name);
+      tools = { ...tools, ...memoryTools };
+    }
+  }
+  if (options.tools) tools = { ...tools, ...options.tools };
+
+  // Compose the MCP server list. The manifest only *names* required
+  // servers; the caller provides the configs. If the caller passes
+  // extra servers not declared in the manifest we forward them — a
+  // pack saying "I need gmail" doesn't prevent a user from also wiring
+  // a workspace-wide tool server.
+  const mcpServers = options.mcpServers
+    ? Object.entries(options.mcpServers).map(([serverName, cfg]) => ({
+        ...cfg,
+        name: cfg.name ?? serverName,
+      }))
+    : undefined;
+
+  const systemPrompt = composeSystemPrompt(loaded, vars);
+
+  const agent = createAgent({
+    id: options.id ?? loaded.manifest.name,
+    name: options.name ?? humanName(loaded.manifest.name),
+    model: options.model,
+    systemPrompt,
+    tools: Object.keys(tools).length > 0 ? tools : undefined,
+    skills: skillStore,
+    routines: routineStore,
+    mcpServers,
+    hooks: options.hooks,
+    permissions: options.permissions,
+    maxIterations: options.maxIterations,
+    ...(options.agentConfigOverrides ?? {}),
+  });
+
+  return {
+    agent,
+    manifest: loaded.manifest,
+    skills,
+    routines,
+    systemPrompt,
+  };
+}

--- a/src/packs/index.ts
+++ b/src/packs/index.ts
@@ -1,0 +1,55 @@
+/**
+ * Template Packs (#78) — installable compositions of roles, skills,
+ * routines, policies, tools, and MCP server bindings.
+ *
+ * Public surface:
+ *
+ *   - `createTemplatePack(name, options)` — build a ready-to-run
+ *     agent from a pack.
+ *   - `installPack(name, options)` / `uninstallPack(name, options)`
+ *     / `listPacks(options)` — manage user-installed packs.
+ *   - `loadPack(name, options)` — lower-level: parse the pack files
+ *     without composing an agent.
+ *   - `parsePackManifest` / `PackManifestSchema` — validate a raw
+ *     `pack.json` body against the manifest schema.
+ *
+ * Pack directory layout (on disk):
+ *
+ *   my-pack/
+ *     pack.json
+ *     policies/*.md     (concatenated into system prompt)
+ *     skills/*.md       (SKILL.md-style, installed into a SkillStore)
+ *     routines/*.md     (installed into a RoutineStore)
+ *     README.md         (shown by `list-packs`)
+ */
+
+export { createTemplatePack } from './create.js';
+export {
+  installPack,
+  uninstallPack,
+  listPacks,
+  readInstallRegistry,
+} from './install.js';
+export {
+  loadPack,
+  loadPackFromDir,
+  resolvePackDir,
+  findBundledPacksDir,
+  listPacksInDir,
+} from './loader.js';
+export { parsePackManifest, PackManifestSchema } from './manifest.js';
+export type {
+  PackManifest,
+  PackVariable,
+  LoadedPack,
+  CreateTemplatePackOptions,
+  TemplatePack,
+} from './types.js';
+export type {
+  InstallPackOptions,
+  UninstallPackOptions,
+  ListPacksOptions,
+  PackListEntry,
+  InstalledPackEntry,
+  InstallRegistry,
+} from './install.js';

--- a/src/packs/install.ts
+++ b/src/packs/install.ts
@@ -1,0 +1,332 @@
+/**
+ * Pack install / uninstall / listing (#78).
+ *
+ * Install target: `.agent-do/packs/<name>/` in the caller's project.
+ * A sibling `.agent-do/packs/config.json` records what's installed so
+ * upgrades and uninstalls are traceable:
+ *
+ *   {
+ *     "installedPacks": {
+ *       "chief-of-staff": {
+ *         "version": "1.0.0",
+ *         "installedAt": "2026-04-21T12:00:00.000Z",
+ *         "source": "bundled"
+ *       }
+ *     }
+ *   }
+ *
+ * Pack installation is a straight copy of the pack directory. We don't
+ * execute anything from the pack at install time — packs are data,
+ * not code. The copy is bounded in size + entry count, skips symlinks
+ * and dotfiles, and validates the manifest first.
+ */
+
+import { promises as fs, existsSync } from 'node:fs';
+import { dirname, join, relative, resolve, sep } from 'node:path';
+import {
+  findBundledPacksDir,
+  listPacksInDir,
+  loadPackFromDir,
+  resolvePackDir,
+} from './loader.js';
+import type { PackManifest } from './types.js';
+
+const USER_PACKS_SUBDIR = join('.agent-do', 'packs');
+const INSTALL_REGISTRY_FILE = 'config.json';
+
+/** Max total bytes we'll copy for a single pack. Generous for text-only packs. */
+const MAX_PACK_BYTES = 4 * 1024 * 1024;
+/** Max entries (files + dirs) per pack. */
+const MAX_PACK_ENTRIES = 512;
+/** Max depth inside a pack directory. */
+const MAX_PACK_DEPTH = 8;
+
+export interface InstalledPackEntry {
+  version: string;
+  installedAt: string;
+  /** Where the pack came from — `'bundled'` or `'<path>'` for a --from path. */
+  source: string;
+}
+
+export interface InstallRegistry {
+  installedPacks: Record<string, InstalledPackEntry>;
+}
+
+function registryPath(cwd: string): string {
+  return resolve(cwd, USER_PACKS_SUBDIR, INSTALL_REGISTRY_FILE);
+}
+
+function userPacksDir(cwd: string): string {
+  return resolve(cwd, USER_PACKS_SUBDIR);
+}
+
+/**
+ * Load the install registry. Missing file → empty registry. Malformed
+ * file → warn on stderr and start fresh; we don't want a corrupt
+ * registry to wedge installs.
+ */
+export async function readInstallRegistry(cwd: string = process.cwd()): Promise<InstallRegistry> {
+  const path = registryPath(cwd);
+  try {
+    const raw = await fs.readFile(path, 'utf8');
+    // JSON reviver drops prototype-pollution keys defensively.
+    const parsed = JSON.parse(raw, (key, value) => {
+      if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+        return undefined;
+      }
+      return value;
+    }) as unknown;
+    if (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      typeof (parsed as InstallRegistry).installedPacks === 'object' &&
+      (parsed as InstallRegistry).installedPacks !== null
+    ) {
+      return parsed as InstallRegistry;
+    }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+      process.stderr.write(
+        `[agent-do] Ignoring malformed pack registry at ${path}: ${
+          err instanceof Error ? err.message : String(err)
+        }\n`,
+      );
+    }
+  }
+  return { installedPacks: Object.create(null) };
+}
+
+async function writeInstallRegistry(
+  registry: InstallRegistry,
+  cwd: string,
+): Promise<void> {
+  const path = registryPath(cwd);
+  await fs.mkdir(dirname(path), { recursive: true });
+  await fs.writeFile(path, JSON.stringify(registry, null, 2) + '\n', 'utf8');
+}
+
+/**
+ * Copy a pack directory tree from `src` to `dest`. Refuses symlinks
+ * (we don't want an install to follow attacker-controlled links out
+ * of the pack dir) and caps total bytes / entries / depth to bound
+ * the blast radius of a hostile or malformed pack. Skips dotfiles —
+ * pack content is all visible-named markdown / JSON.
+ */
+async function copyPackTree(src: string, dest: string): Promise<void> {
+  let byteCount = 0;
+  let entryCount = 0;
+
+  async function walk(srcDir: string, destDir: string, depth: number): Promise<void> {
+    if (depth > MAX_PACK_DEPTH) {
+      throw new Error(`Pack directory tree deeper than ${MAX_PACK_DEPTH} levels — refusing to install.`);
+    }
+    await fs.mkdir(destDir, { recursive: true });
+    const entries = await fs.readdir(srcDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.name.startsWith('.')) continue; // skip hidden files / dot-dirs
+      entryCount++;
+      if (entryCount > MAX_PACK_ENTRIES) {
+        throw new Error(`Pack has more than ${MAX_PACK_ENTRIES} entries — refusing to install.`);
+      }
+      if (entry.isSymbolicLink()) {
+        throw new Error(
+          `Pack contains a symlink at ${join(srcDir, entry.name)} — refusing to install. Packs must not include symlinks.`,
+        );
+      }
+      const srcPath = join(srcDir, entry.name);
+      const destPath = join(destDir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(srcPath, destPath, depth + 1);
+      } else if (entry.isFile()) {
+        const stat = await fs.stat(srcPath);
+        byteCount += stat.size;
+        if (byteCount > MAX_PACK_BYTES) {
+          throw new Error(`Pack exceeds ${MAX_PACK_BYTES} bytes — refusing to install.`);
+        }
+        await fs.copyFile(srcPath, destPath);
+      }
+      // Other entry types (sockets, block devices, …) are silently skipped.
+    }
+  }
+
+  await walk(src, dest, 0);
+}
+
+/**
+ * Validate that `dest` is actually inside the user-packs root. Defence
+ * in depth: the pack name regex in the manifest schema already blocks
+ * `../` segments, but an explicit check here means a future bug can't
+ * let a crafted name escape the sandbox.
+ */
+function assertWithinPacksRoot(packsRoot: string, dest: string): void {
+  const relPath = relative(packsRoot, dest);
+  if (relPath.startsWith('..') || relPath.startsWith(`..${sep}`) || resolve(packsRoot, relPath) !== dest) {
+    throw new Error(`Install destination "${dest}" escapes packs root "${packsRoot}".`);
+  }
+}
+
+export interface InstallPackOptions {
+  /** Directory to install into. Defaults to `process.cwd()`. */
+  cwd?: string;
+  /**
+   * Source directory to copy from. When omitted, installs the bundled
+   * pack with matching name. When provided, copies from this directory
+   * (which must itself contain a `pack.json`).
+   */
+  from?: string;
+  /** Overwrite an existing installation of the same name. */
+  force?: boolean;
+}
+
+/**
+ * Install a pack into the caller's project.
+ *
+ * Returns the installed manifest. Throws if the pack can't be found,
+ * already exists (without `force`), or violates copy-safety rules.
+ */
+export async function installPack(
+  name: string,
+  options: InstallPackOptions = {},
+): Promise<PackManifest> {
+  const cwd = options.cwd ?? process.cwd();
+  let src: string | null;
+  let sourceLabel: string;
+  if (options.from) {
+    src = resolve(cwd, options.from);
+    sourceLabel = src;
+    if (!existsSync(src)) {
+      throw new Error(`--from source "${src}" does not exist.`);
+    }
+  } else {
+    const bundled = findBundledPacksDir();
+    if (!bundled) {
+      throw new Error('Bundled packs directory not found. Run `agent-do install <pack> --from <path>` to install from an explicit location.');
+    }
+    src = resolvePackDir(name, { packsDir: bundled, cwd });
+    sourceLabel = 'bundled';
+    if (!src) {
+      throw new Error(
+        `Bundled pack "${name}" not found. Run \`agent-do list-packs\` to see available packs.`,
+      );
+    }
+  }
+
+  // Validate the manifest at the source before copying anything.
+  const loaded = await loadPackFromDir(src);
+  if (loaded.manifest.name !== name) {
+    throw new Error(
+      `Pack name mismatch: install requested "${name}" but the manifest at ${src}/pack.json declares "${loaded.manifest.name}".`,
+    );
+  }
+
+  const packsRoot = userPacksDir(cwd);
+  const dest = join(packsRoot, name);
+  assertWithinPacksRoot(packsRoot, dest);
+
+  const alreadyExists = existsSync(dest);
+  if (alreadyExists && !options.force) {
+    throw new Error(
+      `Pack "${name}" is already installed at ${dest}. Pass --force to overwrite.`,
+    );
+  }
+  if (alreadyExists) {
+    await fs.rm(dest, { recursive: true, force: true });
+  }
+
+  await copyPackTree(src, dest);
+
+  const registry = await readInstallRegistry(cwd);
+  registry.installedPacks[name] = {
+    version: loaded.manifest.version,
+    installedAt: new Date().toISOString(),
+    source: sourceLabel,
+  };
+  await writeInstallRegistry(registry, cwd);
+
+  return loaded.manifest;
+}
+
+export interface UninstallPackOptions {
+  cwd?: string;
+}
+
+/**
+ * Remove an installed pack. Returns true if something was removed,
+ * false if the pack wasn't installed to begin with (so callers can
+ * print a useful message without errors).
+ */
+export async function uninstallPack(
+  name: string,
+  options: UninstallPackOptions = {},
+): Promise<boolean> {
+  const cwd = options.cwd ?? process.cwd();
+  const packsRoot = userPacksDir(cwd);
+  const dest = join(packsRoot, name);
+  assertWithinPacksRoot(packsRoot, dest);
+
+  const existsOnDisk = existsSync(dest);
+  const registry = await readInstallRegistry(cwd);
+  const inRegistry = Object.prototype.hasOwnProperty.call(registry.installedPacks, name);
+
+  if (existsOnDisk) {
+    await fs.rm(dest, { recursive: true, force: true });
+  }
+  if (inRegistry) {
+    delete registry.installedPacks[name];
+    await writeInstallRegistry(registry, cwd);
+  }
+  return existsOnDisk || inRegistry;
+}
+
+export interface ListPacksOptions {
+  cwd?: string;
+}
+
+export interface PackListEntry {
+  manifest: PackManifest;
+  /** Where this pack lives. */
+  source: 'bundled' | 'user';
+  /** Absolute directory the pack is in. */
+  dir: string;
+  /** True when the same name also exists in the other source. */
+  shadowed?: boolean;
+}
+
+/**
+ * List packs visible to the caller — both bundled (shipped with the
+ * library) and user-installed (in `.agent-do/packs/`). When a name
+ * appears in both, both entries are returned and the user-installed
+ * entry is marked as shadowing the bundled one.
+ */
+export async function listPacks(options: ListPacksOptions = {}): Promise<PackListEntry[]> {
+  const cwd = options.cwd ?? process.cwd();
+  const entries: PackListEntry[] = [];
+
+  const bundledDir = findBundledPacksDir();
+  const bundledManifests = bundledDir ? await listPacksInDir(bundledDir) : [];
+  for (const m of bundledManifests) {
+    entries.push({
+      manifest: m,
+      source: 'bundled',
+      dir: join(bundledDir!, m.name),
+    });
+  }
+
+  const userDir = userPacksDir(cwd);
+  const userManifests = await listPacksInDir(userDir);
+  const userNames = new Set(userManifests.map((m) => m.name));
+  for (const m of userManifests) {
+    entries.push({
+      manifest: m,
+      source: 'user',
+      dir: join(userDir, m.name),
+      shadowed: false,
+    });
+  }
+  for (const e of entries) {
+    if (e.source === 'bundled' && userNames.has(e.manifest.name)) {
+      e.shadowed = true;
+    }
+  }
+  return entries;
+}

--- a/src/packs/loader.ts
+++ b/src/packs/loader.ts
@@ -1,0 +1,231 @@
+/**
+ * Pack loader — discover pack directories and parse their contents (#78).
+ *
+ * Packs live in one of two places at runtime:
+ *
+ *   1. Bundled — the `packs/` directory inside the installed
+ *      `agent-do` package. Resolved by walking up from this module's
+ *      own location until we find a `package.json` with the
+ *      `agent-do` name.
+ *   2. User-installed — `.agent-do/packs/<name>/` in the caller's
+ *      project. Populated by `agent-do install <pack>`.
+ *
+ * The loader is provider-agnostic — it doesn't care about models,
+ * MCP, or tools. It returns a {@link LoadedPack} with parsed skills,
+ * routines, and raw policy bodies. Composition happens in `create.ts`.
+ */
+
+import { promises as fs, existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve, isAbsolute } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parsePackManifest } from './manifest.js';
+import { parseSkillMd } from '../skills.js';
+import { parseRoutineMd } from '../routines.js';
+import type { LoadedPack, PackManifest } from './types.js';
+
+/**
+ * Walk up from `startDir` to find the agent-do package root — the
+ * first directory with a `package.json` whose `name` is `agent-do`.
+ * Caches the result per-process since it never changes.
+ *
+ * Works from both the compiled `dist/src/packs/loader.js` path and
+ * from `src/packs/loader.ts` when the tests run directly off source.
+ */
+let cachedBundledDir: string | null | undefined;
+
+export function findBundledPacksDir(): string | null {
+  if (cachedBundledDir !== undefined) return cachedBundledDir;
+  let dir: string;
+  try {
+    dir = dirname(fileURLToPath(import.meta.url));
+  } catch {
+    cachedBundledDir = null;
+    return null;
+  }
+  for (let i = 0; i < 15; i++) {
+    const pkgJson = join(dir, 'package.json');
+    if (existsSync(pkgJson)) {
+      try {
+        const pkg = JSON.parse(readFileSync(pkgJson, 'utf8')) as { name?: string };
+        if (pkg.name === 'agent-do') {
+          const packsDir = join(dir, 'packs');
+          if (existsSync(packsDir)) {
+            cachedBundledDir = packsDir;
+            return packsDir;
+          }
+        }
+      } catch {
+        // keep walking
+      }
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  cachedBundledDir = null;
+  return null;
+}
+
+/**
+ * Resolve where a named pack lives on disk. Search order:
+ *
+ *   1. If `options.packsDir` is provided, use it verbatim — no
+ *      fallback. Used by tests and by the CLI's install path when it
+ *      already knows which root to read from.
+ *   2. `<cwd>/.agent-do/packs/<name>/` — user-installed packs.
+ *   3. Bundled `<agent-do-pkg>/packs/<name>/` — shipped with the
+ *      library.
+ *
+ * Returns the absolute pack directory or `null` if not found.
+ */
+export function resolvePackDir(
+  name: string,
+  options: { packsDir?: string; cwd?: string } = {},
+): string | null {
+  if (!/^[a-z0-9][a-z0-9_-]*$/.test(name)) return null;
+  if (options.packsDir) {
+    const dir = isAbsolute(options.packsDir)
+      ? options.packsDir
+      : resolve(options.cwd ?? process.cwd(), options.packsDir);
+    const candidate = join(dir, name);
+    return existsSync(candidate) ? candidate : null;
+  }
+  const cwd = options.cwd ?? process.cwd();
+  const userInstalled = resolve(cwd, '.agent-do', 'packs', name);
+  if (existsSync(userInstalled)) return userInstalled;
+  const bundled = findBundledPacksDir();
+  if (bundled) {
+    const bundledPack = join(bundled, name);
+    if (existsSync(bundledPack)) return bundledPack;
+  }
+  return null;
+}
+
+async function readFileIfExists(path: string): Promise<string | null> {
+  try {
+    return await fs.readFile(path, 'utf8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw err;
+  }
+}
+
+/**
+ * Candidate filesystem paths for a file reference in the manifest.
+ *
+ * `basename-without-extension` is the ergonomic form — manifest
+ * authors write `priority-triage` and we look for
+ * `skills/priority-triage.md`. Explicit relative paths (with or
+ * without extension) also work. We always resolve relative to the
+ * subfolder (`skills/`, `routines/`, `policies/`).
+ */
+function candidatePaths(subdir: string, ref: string): string[] {
+  const withExt = /\.(md|markdown)$/i.test(ref) ? [ref] : [`${ref}.md`, ref];
+  const paths: string[] = [];
+  for (const p of withExt) {
+    paths.push(join(subdir, p));
+  }
+  return paths;
+}
+
+async function loadFileByRef(
+  packDir: string,
+  subdir: string,
+  ref: string,
+): Promise<{ path: string; content: string } | null> {
+  for (const candidate of candidatePaths(subdir, ref)) {
+    const full = join(packDir, candidate);
+    const content = await readFileIfExists(full);
+    if (content !== null) return { path: full, content };
+  }
+  return null;
+}
+
+/**
+ * Load a pack from disk by name. Throws if the pack is missing, the
+ * manifest is malformed, or a file reference can't be resolved.
+ */
+export async function loadPack(
+  name: string,
+  options: { packsDir?: string; cwd?: string } = {},
+): Promise<LoadedPack> {
+  const packDir = resolvePackDir(name, options);
+  if (!packDir) {
+    throw new Error(
+      `Pack "${name}" not found. Looked in:\n` +
+      `  - ${resolve(options.cwd ?? process.cwd(), '.agent-do/packs', name)} (user-installed)\n` +
+      `  - bundled packs directory inside agent-do\n` +
+      `Run \`agent-do list-packs\` to see what's available.`,
+    );
+  }
+  return loadPackFromDir(packDir);
+}
+
+/**
+ * Load a pack from an explicit directory. Lower-level than
+ * {@link loadPack} — skips name resolution.
+ */
+export async function loadPackFromDir(packDir: string): Promise<LoadedPack> {
+  const manifestPath = join(packDir, 'pack.json');
+  const manifestRaw = await readFileIfExists(manifestPath);
+  if (manifestRaw === null) {
+    throw new Error(`Pack directory "${packDir}" is missing pack.json`);
+  }
+  const manifest = parsePackManifest(manifestRaw, manifestPath);
+
+  const skills = [];
+  for (const ref of manifest.skills ?? []) {
+    const loaded = await loadFileByRef(packDir, 'skills', ref);
+    if (!loaded) {
+      throw new Error(`Pack "${manifest.name}": skill file "${ref}" not found under ${packDir}/skills/`);
+    }
+    skills.push(parseSkillMd(loaded.content));
+  }
+
+  const routines = [];
+  for (const ref of manifest.routines ?? []) {
+    const loaded = await loadFileByRef(packDir, 'routines', ref);
+    if (!loaded) {
+      throw new Error(`Pack "${manifest.name}": routine file "${ref}" not found under ${packDir}/routines/`);
+    }
+    routines.push(parseRoutineMd(loaded.content));
+  }
+
+  const policies = [];
+  for (const ref of manifest.policies ?? []) {
+    const loaded = await loadFileByRef(packDir, 'policies', ref);
+    if (!loaded) {
+      throw new Error(`Pack "${manifest.name}": policy file "${ref}" not found under ${packDir}/policies/`);
+    }
+    // Basename without extension becomes the policy "name" for display.
+    const name = ref.replace(/\.(md|markdown)$/i, '').split(/[/\\]/).pop()!;
+    policies.push({ name, body: loaded.content.trim() });
+  }
+
+  return { manifest, dir: packDir, skills, routines, policies };
+}
+
+/**
+ * List pack names available in a given directory. Used by the CLI's
+ * `list-packs` command to surface both bundled and user-installed
+ * packs. Returns manifests so callers can display the description
+ * alongside the name.
+ */
+export async function listPacksInDir(dir: string): Promise<PackManifest[]> {
+  if (!existsSync(dir)) return [];
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const manifests: PackManifest[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const manifestPath = join(dir, entry.name, 'pack.json');
+    const raw = await readFileIfExists(manifestPath);
+    if (raw === null) continue;
+    try {
+      manifests.push(parsePackManifest(raw, manifestPath));
+    } catch {
+      // Skip invalid packs silently in list output — errors surface
+      // when the user tries to install / create them.
+    }
+  }
+  return manifests;
+}

--- a/src/packs/manifest.ts
+++ b/src/packs/manifest.ts
@@ -1,0 +1,99 @@
+/**
+ * Pack manifest parsing + schema validation (#78).
+ *
+ * The manifest lives at `<pack-dir>/pack.json` and is the single
+ * source of truth for what a pack contains. Validation here mirrors
+ * the same defensive pattern used for `SavedAgentSchema` in
+ * `src/cli/agents.ts` — prototype-pollution keys are stripped, path
+ * references are confined to the pack directory (no `..` / absolute
+ * paths), and unknown top-level keys are rejected so future footguns
+ * fail closed.
+ */
+
+import { z } from 'zod';
+import type { PackManifest } from './types.js';
+
+const PACK_NAME_RE = /^[a-z0-9][a-z0-9_-]*$/;
+const PACK_VERSION_MAX = 32;
+const PACK_DESCRIPTION_MAX = 512;
+const PACK_VARIABLE_NAME_RE = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+/**
+ * Zod schema for a single entry in `skills` / `routines` / `policies`.
+ * Entries must be relative paths confined to the pack directory. We
+ * also reject absolute paths and `..` segments — a planted `pack.json`
+ * could otherwise point at arbitrary filesystem locations and leak
+ * their contents into the system prompt.
+ */
+const PackFileRefSchema = z
+  .string()
+  .min(1)
+  .max(256)
+  .refine((v) => !v.startsWith('/') && !v.match(/^[a-zA-Z]:[\\/]/), {
+    message: 'must be a relative path (no absolute paths)',
+  })
+  .refine((v) => !v.split(/[/\\]/).includes('..'), {
+    message: 'must not contain `..` segments',
+  });
+
+const PackVariableSchema = z
+  .object({
+    name: z.string().regex(PACK_VARIABLE_NAME_RE).max(64),
+    description: z.string().max(256).optional(),
+    default: z.string().max(1024).optional(),
+    required: z.boolean().optional(),
+  })
+  .strict();
+
+export const PackManifestSchema = z
+  .object({
+    name: z.string().regex(PACK_NAME_RE).max(64),
+    version: z.string().min(1).max(PACK_VERSION_MAX),
+    description: z.string().min(1).max(PACK_DESCRIPTION_MAX),
+    roles: z.array(z.string().min(1).max(64)).max(64).optional(),
+    skills: z.array(PackFileRefSchema).max(128).optional(),
+    routines: z.array(PackFileRefSchema).max(128).optional(),
+    policies: z.array(PackFileRefSchema).max(128).optional(),
+    mcpServers: z.array(z.string().regex(/^[a-zA-Z0-9_-]+$/).max(64)).max(32).optional(),
+    tools: z.array(z.enum(['workspace', 'memory'])).max(8).optional(),
+    heartbeat: PackFileRefSchema.optional(),
+    systemPrompt: z.string().max(32 * 1024).optional(),
+    variables: z.array(PackVariableSchema).max(64).optional(),
+  })
+  .strict();
+
+/**
+ * Parse a raw JSON string into a validated {@link PackManifest}.
+ *
+ * Throws on parse or schema failure with a readable error describing
+ * every offending field. Prototype-pollution keys are filtered out of
+ * the parsed JSON before validation so a hostile manifest can't
+ * inject `__proto__` / `constructor` entries.
+ */
+export function parsePackManifest(json: string, sourcePath?: string): PackManifest {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(json, (key, value) => {
+      if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+        return undefined;
+      }
+      return value;
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `Pack manifest${sourcePath ? ` at ${sourcePath}` : ''} is not valid JSON: ${msg}`,
+    );
+  }
+
+  const parsed = PackManifestSchema.safeParse(raw);
+  if (!parsed.success) {
+    const issues = parsed.error.issues
+      .map((i) => `  ${i.path.join('.') || '(root)'}: ${i.message}`)
+      .join('\n');
+    throw new Error(
+      `Invalid pack manifest${sourcePath ? ` at ${sourcePath}` : ''}:\n${issues}`,
+    );
+  }
+  return parsed.data;
+}

--- a/src/packs/types.ts
+++ b/src/packs/types.ts
@@ -1,0 +1,183 @@
+/**
+ * Template Pack types (#78).
+ *
+ * A "pack" is an opinionated composition of skills, routines, policies,
+ * tools, and MCP server bindings that users can install with one
+ * command. See {@link PackManifest} for the on-disk shape and
+ * {@link CreateTemplatePackOptions} for the runtime surface consumed by
+ * `createTemplatePack`.
+ */
+
+import type { LanguageModel, ToolSet } from 'ai';
+import type { McpServerConfig } from '../mcp.js';
+import type { Agent, AgentConfig, AgentHooks, PermissionConfig } from '../types.js';
+import type { Skill, Routine } from '../types.js';
+
+/**
+ * The `pack.json` manifest shape. Every pack ships one.
+ *
+ * Field semantics:
+ *
+ *  - `name` — canonical pack id. Kebab-case; used as the directory name
+ *    under `.agent-do/packs/<name>/` when installed and as the argument
+ *    to `createTemplatePack(name, ...)`.
+ *  - `version` — pack version. Recorded in `.agent-do/config.json` on
+ *    install so pack upgrades are detectable.
+ *  - `description` — one-line summary shown by `list-packs`.
+ *  - `roles` — optional list of role names the pack composes. Purely
+ *    informational today; packs that need multi-agent orchestration
+ *    wire it up themselves in their `systemPrompt`.
+ *  - `skills` — relative paths (or basename-without-extension) of
+ *    SKILL.md files shipped under `skills/` inside the pack dir. The
+ *    loader resolves them; callers never list files directly.
+ *  - `routines` — relative paths (or basename-without-extension) of
+ *    routine markdown files shipped under `routines/`. Same loading
+ *    rules as skills.
+ *  - `policies` — relative paths (or basename-without-extension) of
+ *    markdown files shipped under `policies/`. Policy files are
+ *    concatenated verbatim into the agent's system prompt (after the
+ *    pack's own `systemPrompt`) — they're opinionated guidance the
+ *    pack author wants the model to always see.
+ *  - `mcpServers` — names of MCP servers the pack *expects* the caller
+ *    to provide at `createTemplatePack` time. Every entry listed here
+ *    must be matched by a key in `options.mcpServers`; missing ones
+ *    fail the create call with a readable error. agent-do deliberately
+ *    does not ship MCP server wiring in packs — servers have
+ *    credentials, spawn commands, and trust boundaries that are
+ *    host-specific.
+ *  - `tools` — advisory list of built-in tool groups the pack expects
+ *    (`workspace`, `memory`). The loader enables them; unknown entries
+ *    are ignored with a warning.
+ *  - `heartbeat` — optional path (relative to the pack dir) of a
+ *    schedule file. Advisory only — agent-do does not ship a cron
+ *    runner; callers that want scheduling wire it up with their own
+ *    infrastructure. Surfaced for parity with the issue spec so pack
+ *    authors can declare their intent.
+ *  - `systemPrompt` — the base system prompt for the pack's agent.
+ *    Policy files are appended after this.
+ *  - `variables` — declared variables the pack accepts (e.g. `owner`,
+ *    `timezone`). Used by `createTemplatePack` to populate defaults
+ *    and (in future) produce user-facing prompts for values the
+ *    caller didn't supply.
+ */
+export interface PackManifest {
+  name: string;
+  version: string;
+  description: string;
+  roles?: string[];
+  skills?: string[];
+  routines?: string[];
+  policies?: string[];
+  mcpServers?: string[];
+  tools?: Array<'workspace' | 'memory'>;
+  heartbeat?: string;
+  systemPrompt?: string;
+  variables?: Array<PackVariable>;
+}
+
+/**
+ * Declared variable in a pack manifest. A pack that references
+ * `{{owner}}` in its systemPrompt / policies / skill bodies declares
+ * the variable here so `createTemplatePack` can validate that the
+ * caller supplied it.
+ */
+export interface PackVariable {
+  name: string;
+  description?: string;
+  default?: string;
+  /** When true, `createTemplatePack` throws if the caller omits this variable. */
+  required?: boolean;
+}
+
+/**
+ * The loaded shape of a pack — manifest + the parsed content of its
+ * skills / routines / policies. Produced by `loadPack()`.
+ */
+export interface LoadedPack {
+  manifest: PackManifest;
+  /** Absolute directory the pack was loaded from. */
+  dir: string;
+  skills: Skill[];
+  routines: Routine[];
+  /** Policy files, in manifest order. Each entry is the raw markdown body. */
+  policies: Array<{ name: string; body: string }>;
+}
+
+/**
+ * Config passed to {@link createTemplatePack}.
+ *
+ * agent-do is provider-agnostic; the caller always supplies the model.
+ * MCP servers are also caller-supplied (they have credentials and
+ * trust boundaries). Variables declared by the pack are passed as a
+ * flat map — if the caller uses top-level keys that don't collide with
+ * reserved fields they're forwarded into `variables` as a convenience.
+ */
+export interface CreateTemplatePackOptions {
+  /** LanguageModel to run the pack's agent. Required. */
+  model: LanguageModel;
+  /**
+   * Variables declared in the pack manifest. Interpolated into the
+   * system prompt, policies, and skill/routine bodies via the same
+   * `{{name}}` substitution rule as the rest of agent-do.
+   */
+  variables?: Record<string, string>;
+  /**
+   * MCP servers keyed by the same names the pack manifest declares.
+   * Every name listed in `manifest.mcpServers` must have a match here.
+   */
+  mcpServers?: Record<string, McpServerConfig>;
+  /**
+   * Working directory for workspace tools if the pack declares
+   * `tools: ['workspace']`. Default: `process.cwd()`.
+   */
+  workingDir?: string;
+  /**
+   * Custom tools merged into the pack's toolset after pack-declared
+   * tool groups are resolved. Takes precedence on name collisions so
+   * callers can override pack defaults.
+   */
+  tools?: ToolSet;
+  /**
+   * Directory to resolve the pack from. Defaults to the bundled
+   * packs directory inside the installed `agent-do` package. Pass an
+   * explicit path to load from `.agent-do/packs/` (the CLI's install
+   * target) or to point tests at fixtures.
+   */
+  packsDir?: string;
+  /**
+   * Override the agent id. Defaults to the pack name.
+   */
+  id?: string;
+  /**
+   * Override the agent display name. Defaults to a title-cased version
+   * of the pack name.
+   */
+  name?: string;
+  /** Lifecycle hooks forwarded to the agent config. */
+  hooks?: AgentHooks;
+  /** Permission config forwarded to the agent config. */
+  permissions?: PermissionConfig;
+  /** Max iterations forwarded to the agent config. */
+  maxIterations?: number;
+  /**
+   * Additional AgentConfig fields forwarded verbatim. Use sparingly —
+   * the pack composition decides most behaviour; this is an escape
+   * hatch for fields we don't explicitly surface above.
+   */
+  agentConfigOverrides?: Partial<AgentConfig>;
+}
+
+/**
+ * Result of {@link createTemplatePack}: the ready-to-run agent plus
+ * enough metadata that callers can introspect the composition.
+ */
+export interface TemplatePack {
+  agent: Agent;
+  manifest: PackManifest;
+  /** Resolved skills loaded from the pack, after variable interpolation. */
+  skills: Skill[];
+  /** Resolved routines loaded from the pack, after variable interpolation. */
+  routines: Routine[];
+  /** Resolved system prompt the agent was configured with. */
+  systemPrompt: string;
+}

--- a/tests/packs.test.ts
+++ b/tests/packs.test.ts
@@ -1,0 +1,506 @@
+/**
+ * Tests for template packs (#78):
+ *   - manifest parsing + validation
+ *   - on-disk loader (bundled packs + fixture packs)
+ *   - createTemplatePack composition (system prompt, skills, routines,
+ *     variable interpolation, MCP validation)
+ *   - install / uninstall / list-packs
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import {
+  parsePackManifest,
+  loadPack,
+  loadPackFromDir,
+  resolvePackDir,
+  createTemplatePack,
+  installPack,
+  uninstallPack,
+  listPacks,
+  readInstallRegistry,
+  findBundledPacksDir,
+} from '../src/packs/index.js';
+import { createMockModel } from '../src/testing/index.js';
+
+// ── Fixture helpers ──────────────────────────────────────────────────
+
+function makeFixturePack(
+  root: string,
+  name: string,
+  opts: {
+    manifest: Record<string, unknown>;
+    skills?: Record<string, string>;
+    routines?: Record<string, string>;
+    policies?: Record<string, string>;
+  },
+): string {
+  const dir = join(root, name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'pack.json'), JSON.stringify(opts.manifest, null, 2));
+  if (opts.skills) {
+    mkdirSync(join(dir, 'skills'), { recursive: true });
+    for (const [file, body] of Object.entries(opts.skills)) {
+      writeFileSync(join(dir, 'skills', file), body);
+    }
+  }
+  if (opts.routines) {
+    mkdirSync(join(dir, 'routines'), { recursive: true });
+    for (const [file, body] of Object.entries(opts.routines)) {
+      writeFileSync(join(dir, 'routines', file), body);
+    }
+  }
+  if (opts.policies) {
+    mkdirSync(join(dir, 'policies'), { recursive: true });
+    for (const [file, body] of Object.entries(opts.policies)) {
+      writeFileSync(join(dir, 'policies', file), body);
+    }
+  }
+  return dir;
+}
+
+let scratchDir: string;
+let packsRoot: string;
+
+beforeEach(() => {
+  scratchDir = mkdtempSync(join(tmpdir(), 'agent-do-packs-test-'));
+  packsRoot = join(scratchDir, 'packs');
+  mkdirSync(packsRoot, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(scratchDir, { recursive: true, force: true });
+});
+
+// ── parsePackManifest ────────────────────────────────────────────────
+
+describe('parsePackManifest', () => {
+  it('parses a minimal valid manifest', () => {
+    const m = parsePackManifest(
+      JSON.stringify({
+        name: 'sample',
+        version: '1.0.0',
+        description: 'A sample pack',
+      }),
+    );
+    expect(m.name).toBe('sample');
+    expect(m.version).toBe('1.0.0');
+    expect(m.description).toBe('A sample pack');
+  });
+
+  it('rejects invalid names (uppercase, leading dash, spaces)', () => {
+    expect(() => parsePackManifest(JSON.stringify({ name: 'Bad Name', version: '1', description: 'x' }))).toThrow();
+    expect(() => parsePackManifest(JSON.stringify({ name: '-leading', version: '1', description: 'x' }))).toThrow();
+    expect(() => parsePackManifest(JSON.stringify({ name: 'spaces are bad', version: '1', description: 'x' }))).toThrow();
+  });
+
+  it('rejects unknown top-level keys', () => {
+    expect(() =>
+      parsePackManifest(
+        JSON.stringify({
+          name: 'sample',
+          version: '1.0.0',
+          description: 'x',
+          arbitraryField: true,
+        }),
+      ),
+    ).toThrow();
+  });
+
+  it('rejects absolute paths in file references', () => {
+    expect(() =>
+      parsePackManifest(
+        JSON.stringify({
+          name: 'sample',
+          version: '1',
+          description: 'x',
+          skills: ['/etc/passwd'],
+        }),
+      ),
+    ).toThrow(/absolute/);
+  });
+
+  it('rejects `..` segments in file references', () => {
+    expect(() =>
+      parsePackManifest(
+        JSON.stringify({
+          name: 'sample',
+          version: '1',
+          description: 'x',
+          policies: ['../../etc/passwd'],
+        }),
+      ),
+    ).toThrow(/`\.\.`/);
+  });
+
+  it('strips prototype-pollution keys at parse time', () => {
+    const json = `{
+      "name": "sample",
+      "version": "1.0.0",
+      "description": "x",
+      "__proto__": { "polluted": true }
+    }`;
+    const m = parsePackManifest(json);
+    expect(m.name).toBe('sample');
+    // Verify Object.prototype wasn't polluted.
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it('surfaces a clear error on malformed JSON', () => {
+    expect(() => parsePackManifest('not json {')).toThrow(/not valid JSON/);
+  });
+});
+
+// ── loadPack / loader behaviour ─────────────────────────────────────
+
+describe('loadPack', () => {
+  it('loads a pack with skills, routines, and policies', async () => {
+    makeFixturePack(packsRoot, 'example', {
+      manifest: {
+        name: 'example',
+        version: '1.0.0',
+        description: 'Example',
+        skills: ['greet'],
+        routines: ['hello'],
+        policies: ['manners'],
+      },
+      skills: {
+        'greet.md': `---\nname: Greet\ndescription: Say hello\n---\n\nSay hi back.`,
+      },
+      routines: {
+        'hello.md': `---\nname: hello\ndescription: Run a hello\n---\n\nStep 1: say hi.`,
+      },
+      policies: {
+        'manners.md': `Be polite.`,
+      },
+    });
+    const loaded = await loadPack('example', { packsDir: packsRoot });
+    expect(loaded.manifest.name).toBe('example');
+    expect(loaded.skills.length).toBe(1);
+    expect(loaded.skills[0]!.name).toBe('Greet');
+    expect(loaded.routines.length).toBe(1);
+    expect(loaded.routines[0]!.name).toBe('hello');
+    expect(loaded.policies.length).toBe(1);
+    expect(loaded.policies[0]!.name).toBe('manners');
+  });
+
+  it('throws when a referenced file is missing', async () => {
+    makeFixturePack(packsRoot, 'broken', {
+      manifest: {
+        name: 'broken',
+        version: '1.0.0',
+        description: 'Broken',
+        skills: ['missing'],
+      },
+    });
+    await expect(loadPack('broken', { packsDir: packsRoot })).rejects.toThrow(/skill file/);
+  });
+
+  it('throws when the pack directory is missing', async () => {
+    await expect(loadPack('nope', { packsDir: packsRoot })).rejects.toThrow(/not found/);
+  });
+
+  it('accepts file references with or without .md extension', async () => {
+    makeFixturePack(packsRoot, 'ext', {
+      manifest: {
+        name: 'ext',
+        version: '1',
+        description: 'Ext',
+        skills: ['one', 'two.md'],
+      },
+      skills: {
+        'one.md': '---\nname: One\n---\n\nOne body.',
+        'two.md': '---\nname: Two\n---\n\nTwo body.',
+      },
+    });
+    const loaded = await loadPack('ext', { packsDir: packsRoot });
+    expect(loaded.skills.map((s) => s.name)).toEqual(['One', 'Two']);
+  });
+
+  it('rejects pack names with traversal segments at resolvePackDir', () => {
+    expect(resolvePackDir('../escape', { packsDir: packsRoot })).toBeNull();
+  });
+});
+
+// ── createTemplatePack ───────────────────────────────────────────────
+
+describe('createTemplatePack', () => {
+  const mockModel = () => createMockModel({ responses: [{ text: 'ok' }] });
+
+  it('composes system prompt from manifest + policies with variable interpolation', async () => {
+    makeFixturePack(packsRoot, 'composed', {
+      manifest: {
+        name: 'composed',
+        version: '1',
+        description: 'Composed',
+        policies: ['base'],
+        variables: [{ name: 'owner', required: true }],
+        systemPrompt: "Act as {{owner}}'s assistant.",
+      },
+      policies: { 'base.md': 'Always serve {{owner}}.' },
+    });
+    const { systemPrompt, manifest } = await createTemplatePack('composed', {
+      model: mockModel(),
+      packsDir: packsRoot,
+      variables: { owner: 'Alice' },
+    });
+    expect(manifest.name).toBe('composed');
+    expect(systemPrompt).toContain("Act as Alice's assistant.");
+    expect(systemPrompt).toContain('Always serve Alice.');
+    expect(systemPrompt).toContain('## Policy: base');
+  });
+
+  it('interpolates variables into skills and routines', async () => {
+    makeFixturePack(packsRoot, 'interp', {
+      manifest: {
+        name: 'interp',
+        version: '1',
+        description: 'x',
+        skills: ['s'],
+        routines: ['r'],
+        variables: [{ name: 'topic', default: 'widgets' }],
+      },
+      skills: { 's.md': `---\nname: S\n---\n\nDescribe {{topic}}.` },
+      routines: { 'r.md': `---\nname: r\ndescription: desc\n---\n\nRun on {{topic}}.` },
+    });
+    const pack = await createTemplatePack('interp', {
+      model: mockModel(),
+      packsDir: packsRoot,
+    });
+    expect(pack.skills[0]!.content).toContain('Describe widgets.');
+    expect(pack.routines[0]!.body).toContain('Run on widgets.');
+  });
+
+  it('caller-supplied variables override manifest defaults', async () => {
+    makeFixturePack(packsRoot, 'override', {
+      manifest: {
+        name: 'override',
+        version: '1',
+        description: 'x',
+        variables: [{ name: 'topic', default: 'widgets' }],
+        systemPrompt: 'Focus: {{topic}}.',
+      },
+    });
+    const { systemPrompt } = await createTemplatePack('override', {
+      model: mockModel(),
+      packsDir: packsRoot,
+      variables: { topic: 'sprockets' },
+    });
+    expect(systemPrompt).toContain('Focus: sprockets.');
+  });
+
+  it('throws when a required variable is missing', async () => {
+    makeFixturePack(packsRoot, 'required', {
+      manifest: {
+        name: 'required',
+        version: '1',
+        description: 'x',
+        variables: [{ name: 'owner', required: true }],
+      },
+    });
+    await expect(
+      createTemplatePack('required', { model: mockModel(), packsDir: packsRoot }),
+    ).rejects.toThrow(/requires variables: owner/);
+  });
+
+  it('throws when a required MCP server name is missing from options.mcpServers', async () => {
+    makeFixturePack(packsRoot, 'needs-mcp', {
+      manifest: {
+        name: 'needs-mcp',
+        version: '1',
+        description: 'x',
+        mcpServers: ['gmail', 'calendar'],
+      },
+    });
+    await expect(
+      createTemplatePack('needs-mcp', {
+        model: mockModel(),
+        packsDir: packsRoot,
+        mcpServers: {
+          gmail: { name: 'gmail', transport: { type: 'stdio', command: 'x' } },
+        },
+      }),
+    ).rejects.toThrow(/requires MCP servers: calendar/);
+  });
+
+  it('throws without model', async () => {
+    makeFixturePack(packsRoot, 'needs-model', {
+      manifest: { name: 'needs-model', version: '1', description: 'x' },
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await expect(
+      createTemplatePack('needs-model', { packsDir: packsRoot } as any),
+    ).rejects.toThrow(/requires `options.model`/);
+  });
+
+  it('returns an agent with the expected id + name', async () => {
+    makeFixturePack(packsRoot, 'ident', {
+      manifest: { name: 'ident', version: '1', description: 'x' },
+    });
+    const { agent } = await createTemplatePack('ident', {
+      model: mockModel(),
+      packsDir: packsRoot,
+    });
+    expect(agent.id).toBe('ident');
+    expect(agent.name).toBe('Ident');
+  });
+
+  it('honours explicit id/name overrides', async () => {
+    makeFixturePack(packsRoot, 'ident2', {
+      manifest: { name: 'ident2', version: '1', description: 'x' },
+    });
+    const { agent } = await createTemplatePack('ident2', {
+      model: mockModel(),
+      packsDir: packsRoot,
+      id: 'custom',
+      name: 'Custom Agent',
+    });
+    expect(agent.id).toBe('custom');
+    expect(agent.name).toBe('Custom Agent');
+  });
+});
+
+// ── install / uninstall / list ──────────────────────────────────────
+
+describe('installPack / uninstallPack / listPacks', () => {
+  let projectCwd: string;
+  let sourceRoot: string;
+
+  beforeEach(() => {
+    projectCwd = join(scratchDir, 'project');
+    mkdirSync(projectCwd, { recursive: true });
+    sourceRoot = join(scratchDir, 'source-packs');
+    mkdirSync(sourceRoot, { recursive: true });
+  });
+
+  it('installs from --from, records in registry, and listPacks surfaces it', async () => {
+    makeFixturePack(sourceRoot, 'installable', {
+      manifest: {
+        name: 'installable',
+        version: '1.2.3',
+        description: 'Can be installed',
+      },
+    });
+    const manifest = await installPack('installable', {
+      cwd: projectCwd,
+      from: join(sourceRoot, 'installable'),
+    });
+    expect(manifest.name).toBe('installable');
+    const destPack = join(projectCwd, '.agent-do', 'packs', 'installable');
+    expect(existsSync(join(destPack, 'pack.json'))).toBe(true);
+
+    const registry = await readInstallRegistry(projectCwd);
+    expect(registry.installedPacks['installable']).toBeDefined();
+    expect(registry.installedPacks['installable']!.version).toBe('1.2.3');
+
+    const entries = await listPacks({ cwd: projectCwd });
+    const user = entries.find((e) => e.source === 'user' && e.manifest.name === 'installable');
+    expect(user).toBeDefined();
+  });
+
+  it('refuses to overwrite without --force', async () => {
+    makeFixturePack(sourceRoot, 'installable', {
+      manifest: { name: 'installable', version: '1', description: 'x' },
+    });
+    await installPack('installable', {
+      cwd: projectCwd,
+      from: join(sourceRoot, 'installable'),
+    });
+    await expect(
+      installPack('installable', { cwd: projectCwd, from: join(sourceRoot, 'installable') }),
+    ).rejects.toThrow(/already installed/);
+  });
+
+  it('overwrites with --force', async () => {
+    makeFixturePack(sourceRoot, 'installable', {
+      manifest: { name: 'installable', version: '1', description: 'v1' },
+    });
+    await installPack('installable', {
+      cwd: projectCwd,
+      from: join(sourceRoot, 'installable'),
+    });
+    // Bump the source version and reinstall.
+    writeFileSync(
+      join(sourceRoot, 'installable', 'pack.json'),
+      JSON.stringify({ name: 'installable', version: '2.0.0', description: 'v2' }),
+    );
+    await installPack('installable', {
+      cwd: projectCwd,
+      from: join(sourceRoot, 'installable'),
+      force: true,
+    });
+    const registry = await readInstallRegistry(projectCwd);
+    expect(registry.installedPacks['installable']!.version).toBe('2.0.0');
+  });
+
+  it('uninstall removes the directory and updates the registry', async () => {
+    makeFixturePack(sourceRoot, 'installable', {
+      manifest: { name: 'installable', version: '1', description: 'x' },
+    });
+    await installPack('installable', {
+      cwd: projectCwd,
+      from: join(sourceRoot, 'installable'),
+    });
+    const removed = await uninstallPack('installable', { cwd: projectCwd });
+    expect(removed).toBe(true);
+    expect(existsSync(join(projectCwd, '.agent-do', 'packs', 'installable'))).toBe(false);
+    const registry = await readInstallRegistry(projectCwd);
+    expect(registry.installedPacks['installable']).toBeUndefined();
+  });
+
+  it('uninstall of a pack that was never installed returns false', async () => {
+    const removed = await uninstallPack('ghost', { cwd: projectCwd });
+    expect(removed).toBe(false);
+  });
+
+  it('refuses to install when pack.json declares a different name', async () => {
+    makeFixturePack(sourceRoot, 'installable', {
+      manifest: { name: 'actual-name', version: '1', description: 'x' },
+    });
+    await expect(
+      installPack('installable', { cwd: projectCwd, from: join(sourceRoot, 'installable') }),
+    ).rejects.toThrow(/name mismatch/);
+  });
+});
+
+// ── bundled packs ────────────────────────────────────────────────────
+
+describe('bundled packs', () => {
+  it('findBundledPacksDir returns a directory that contains chief-of-staff', () => {
+    const dir = findBundledPacksDir();
+    expect(dir).not.toBeNull();
+    expect(existsSync(join(dir!, 'chief-of-staff', 'pack.json'))).toBe(true);
+  });
+
+  it('loadPack loads the bundled chief-of-staff pack with its policies and skills', async () => {
+    const loaded = await loadPack('chief-of-staff');
+    expect(loaded.manifest.name).toBe('chief-of-staff');
+    expect(loaded.policies.length).toBeGreaterThanOrEqual(2);
+    expect(loaded.skills.length).toBeGreaterThanOrEqual(3);
+    expect(loaded.routines.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('createTemplatePack composes the chief-of-staff pack end-to-end', async () => {
+    const pack = await createTemplatePack('chief-of-staff', {
+      model: createMockModel({ responses: [{ text: 'ok' }] }),
+      variables: { owner: 'Ada Lovelace' },
+      workingDir: scratchDir,
+    });
+    expect(pack.manifest.name).toBe('chief-of-staff');
+    expect(pack.systemPrompt).toContain('Ada Lovelace');
+    // The skills should be interpolated too — priority-triage references {{owner}}.
+    const triage = pack.skills.find((s) => s.id === 'priority-triage');
+    expect(triage).toBeDefined();
+    expect(triage!.content).toContain('Ada Lovelace');
+  });
+
+  it('chief-of-staff refuses to create without the required `owner` variable', async () => {
+    await expect(
+      createTemplatePack('chief-of-staff', {
+        model: createMockModel({ responses: [{ text: 'ok' }] }),
+      }),
+    ).rejects.toThrow(/owner/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the gap between "I understand the API" and "I have a working chief of staff" by shipping a composition primitive. Each **template pack** wires skills + routines + policy modules + tool groups + MCP server bindings into a single installable unit, so users get a turn-key agent for a real job — not just another example of how `createAgent` works.

Resolves #78.

### New runtime API

```ts
import { createTemplatePack } from 'agent-do';
import { createAnthropic } from '@ai-sdk/anthropic';

const { agent } = await createTemplatePack('chief-of-staff', {
  model: createAnthropic()('claude-sonnet-4-6'),
  variables: { owner: 'Paul Kinlan' },
  workingDir: './workspace',
  // mcpServers: { gmail: {...}, calendar: {...} },  // when the pack declares them
});

await agent.run('Triage the inbox and update tasks.md.');
```

- `createTemplatePack(name, options)` — resolves a bundled or user-installed pack, interpolates `{{variable}}` placeholders across the system prompt / policies / skills / routines, installs skills into a `SkillStore`, saves routines into a `RoutineStore`, wires workspace / memory tools plus any declared MCP servers, and returns the composed agent.
- `installPack` / `uninstallPack` / `listPacks` / `readInstallRegistry`
- `loadPack` / `loadPackFromDir` / `resolvePackDir` / `listPacksInDir`
- `parsePackManifest` + `PackManifestSchema` (zod)

### New CLI subcommands

```
npx agent-do install <pack> [--force] [--from <dir>]
npx agent-do uninstall <pack>
npx agent-do list-packs
```

Install copies the pack into `.agent-do/packs/<name>/` and records it in `.agent-do/packs/config.json` (version, installedAt, source). Copies are bounded in size / depth / entry count, refuse symlinks, and skip dotfiles to keep hostile or malformed packs out of the filesystem.

### Bundled packs

| Pack | Ships with |
|------|-----------|
| `chief-of-staff` | Full docs — 2 policy modules (`priority-map`, `auto-resolver`), 3 skills (`priority-triage`, `meeting-notes`, `follow-up-cadence`), 2 routines (`daily-task-prep`, `nightly-backup`), `owner` + `timezone` variables |
| `engineering-team` | Sprint-ordered system prompt + `plan-review` / `ship-checklist` / `retro` skills |
| `research-team` | Scout / analyst / synthesiser / fact-checker skills + `daily-digest` routine |

### Manifest shape

```json
{
  "name": "my-pack",
  "version": "0.1.0",
  "description": "One-line summary",
  "skills": ["skill-one"],
  "routines": ["routine-one"],
  "policies": ["policy-one"],
  "tools": ["workspace"],
  "mcpServers": ["gmail"],
  "variables": [{ "name": "owner", "required": true }],
  "systemPrompt": "You are {{owner}}'s assistant."
}
```

Validated with `zod`. Unknown keys rejected, prototype-pollution keys stripped, absolute paths and `..` segments refused in file references.

### Acceptance criteria

- [x] Pack manifest schema defined + validated (`PackManifestSchema`, 6 dedicated parse tests)
- [x] `createTemplatePack(name, config)` returns a ready-to-run agent (7 tests inc. var interpolation, required-var enforcement, MCP-name validation)
- [x] `agent-do install <pack>` CLI copies pack files + updates config (6 tests inc. `--force`, `--from`, name-mismatch refusal)
- [x] One pack shipped with full docs (`chief-of-staff`)
- [x] Pack can be uninstalled cleanly (directory + registry deletion tested)
- [x] Tests for manifest parsing, install, uninstall (30 pack tests total, all passing; full suite 653/653)

### Files

- `src/packs/` — new module (`types.ts`, `manifest.ts`, `loader.ts`, `create.ts`, `install.ts`, `index.ts`)
- `src/cli/pack-cmd.ts` — CLI handlers; `src/cli.ts` + `src/cli/args.ts` wire the new subcommands
- `packs/chief-of-staff`, `packs/engineering-team`, `packs/research-team` — bundled pack directories
- `tests/packs.test.ts` — 30 tests covering parse, load, create, install, uninstall, list, bundled-pack end-to-end
- `examples/16-template-packs.ts` — library-usage walkthrough
- README, llms.txt, package.json `files` allowlist (adds `packs/`), changeset

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 35 test files, **653/653 passing**
- [x] `npx tsc` (full build) — `dist/src/packs/**` emits correctly
- [x] `node dist/src/cli.js list-packs` — shows all three bundled packs
- [x] `node dist/src/cli.js install chief-of-staff` — copies into `.agent-do/packs/`, writes registry
- [x] `node dist/src/cli.js uninstall chief-of-staff` — removes directory and registry entry
- [ ] Live end-to-end with a real model — left to reviewer (requires `ANTHROPIC_API_KEY`). `npx tsx examples/16-template-packs.ts` exercises the full path.

https://claude.ai/code/session_01V8UfRY4dYERa3q9SX5b3eh