### PR TITLE
Scheduled tasks: cron-driven agent runs with lock-file concurrency (#79)

### DIFF
--- a/.changeset/scheduled-tasks-79.md
+++ b/.changeset/scheduled-tasks-79.md
@@ -1,0 +1,29 @@
+---
+"agent-do": minor
+---
+
+Add scheduled tasks (#79): declarative cron-driven agent runs with
+lock-file concurrency.
+
+`AgentConfig.scheduledTasks` accepts an array of `ScheduledTask`
+entries (id, cron expression, payload, optional sessionTarget /
+wakeMode). Invalid cron expressions or duplicate IDs throw at
+`createAgent` time.
+
+New runtime exports on the main entry:
+
+- `runScheduledTask(agent, task, options?)` fires one task now,
+  acquiring a per-task lock at `.agent-do/scheduler/<id>.lock` so
+  concurrent crontab invocations can't overlap. Stale locks (dead
+  PID, same host) are broken automatically.
+- `runScheduler(agent, tasks, options?)` runs a foreground loop that
+  ticks every minute and fires matching tasks.
+- `tickScheduler` / `createSchedulerState` expose the per-tick core
+  for tests and custom hosts.
+- `parseCron` / `cronMatches` — minimal 5-field cron evaluator.
+- `acquireLock` / `releaseLock` / `readLock` — lock file primitives.
+- `readStatus` — per-task last-run / duration / failure counts.
+- `generateCrontabEntries` — render a crontab block to paste into
+  `crontab -e`.
+
+New CLI subcommand: `agent-do scheduled-tasks <run|start|status|install>`.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ There is no undo. Proceed with caution.
 - **Usage tracking** -- built-in cost estimation for 50+ models with per-run and per-day spending limits
 - **Testable** -- `createMockModel()` returns a mock `LanguageModel` with predetermined responses
 - **Eval framework** -- `defineEval()` + `runEvals()` to measure agent quality with 13 assertion types, LLM-as-judge, and multi-provider comparison
+- **Scheduled tasks** -- declarative cron-driven agent runs with lock-file concurrency; ships a CLI (`agent-do scheduled-tasks run|start|status|install`) for one-off execution and crontab generation
 
 ## Install
 
@@ -1123,6 +1124,89 @@ await runEvals(suite, { output: 'csv' });
 // Silent (programmatic use)
 const result = await runEvals(suite, { output: 'silent' });
 ```
+
+## Scheduled Tasks
+
+Declarative cron-driven agent runs with lock-file concurrency. See
+[issue #79](https://github.com/PaulKinlan/agent-do/issues/79) for the
+motivation — "agents as colleagues" need to run on a schedule, not
+just on-demand.
+
+```ts
+import { createAgent, runScheduledTask, type ScheduledTask } from 'agent-do';
+import { createAnthropic } from '@ai-sdk/anthropic';
+
+const anthropic = createAnthropic();
+
+const scheduledTasks: ScheduledTask[] = [
+  {
+    id: 'ea-sweep',
+    cron: '*/15 8-21 * * *',
+    payload: 'Run the inbox-triage routine.',
+  },
+  {
+    id: 'daily-prep',
+    cron: '0 2 * * *',
+    sessionTarget: 'isolated',
+    wakeMode: 'systemEvent',
+    payload: { event: 'daily-prep' },
+  },
+];
+
+const agent = createAgent({
+  id: 'ea',
+  name: 'EA',
+  model: anthropic('claude-haiku-4-5'),
+  systemPrompt: 'You are an executive assistant.',
+  scheduledTasks,
+});
+
+// Fire one task now (e.g. from a crontab entry)
+await runScheduledTask(agent, scheduledTasks[0]);
+```
+
+The runtime is primitive by design — a declarative config plus a
+small set of functions you can compose into whatever long-running
+surface you need:
+
+- `runScheduledTask(agent, task)` — run one task now. Acquires a
+  per-task lock at `.agent-do/scheduler/<id>.lock` so concurrent
+  invocations from cron never overlap; stale locks from crashed runs
+  are broken automatically.
+- `runScheduler(agent, tasks)` — foreground loop that ticks every
+  minute and fires matching tasks. Useful for development.
+- `generateCrontabEntries(tasks)` — render a crontab block you can
+  paste into `crontab -e`.
+
+### CLI
+
+```bash
+# Run a single task (for crontab / systemd to call)
+npx agent-do scheduled-tasks run ea-sweep --script ./ea.ts --yes
+
+# Run the scheduler in the foreground (Ctrl-C to stop)
+npx agent-do scheduled-tasks start --script ./ea.ts --yes
+
+# See last-run times, durations, and failure messages per task
+npx agent-do scheduled-tasks status --script ./ea.ts
+
+# Print crontab entries — review, then paste into `crontab -e`
+npx agent-do scheduled-tasks install --script ./ea.ts --yes
+```
+
+### Cron syntax
+
+Standard 5-field expression (`minute hour day-of-month month day-of-week`).
+Supports `*`, `N`, `N-M`, `N,M,…`, and step syntax. Numeric fields
+only — named months (`JAN`) and weekdays (`MON`) are not supported.
+
+### Wake modes
+
+- `agentTurn` (default) — payload becomes a regular user message.
+- `systemEvent` — payload is wrapped in a `<system-event>` envelope
+  with the "OK silence" contract: the model replies with a single
+  `OK` token when nothing actionable is pending, so periodic wakes
+  are cheap at scale.
 
 ## API Reference
 

--- a/examples/16-scheduled-tasks.ts
+++ b/examples/16-scheduled-tasks.ts
@@ -1,0 +1,90 @@
+/**
+ * Example 16: Scheduled Tasks (#79)
+ *
+ * Scheduled tasks turn an agent into something closer to a long-running
+ * colleague: cron expressions tied to payloads fire the agent at the
+ * right time, with lock-file concurrency so two copies never run the
+ * same task at once.
+ *
+ * This example uses a mock model so it runs without any API keys. For
+ * production use, replace the model with your real provider and invoke
+ * the scheduler from a crontab entry (see `scheduled-tasks install`
+ * for a ready-to-paste block).
+ *
+ * Run: npx tsx examples/16-scheduled-tasks.ts
+ */
+
+import {
+  createAgent,
+  runScheduledTask,
+  generateCrontabEntries,
+  parseCron,
+  cronMatches,
+  type ScheduledTask,
+} from 'agent-do';
+import { createMockModel } from 'agent-do/testing';
+
+console.log('═══════════════════════════════════════');
+console.log('  Example 16: Scheduled Tasks');
+console.log('═══════════════════════════════════════\n');
+
+const scheduledTasks: ScheduledTask[] = [
+  {
+    id: 'ea-sweep',
+    cron: '*/15 8-21 * * *',
+    payload: 'Run the inbox-triage routine.',
+    description: 'Every 15 minutes during the day, triage the inbox.',
+  },
+  {
+    id: 'daily-prep',
+    cron: '0 2 * * *',
+    sessionTarget: 'isolated',
+    wakeMode: 'systemEvent',
+    payload: { event: 'daily-prep' },
+    description: 'Daily prep at 2am',
+  },
+];
+
+const agent = createAgent({
+  id: 'ea',
+  name: 'EA',
+  // Stand-in model so the example doesn't need credentials.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  model: createMockModel({
+    responses: [{ text: 'Sweep complete. 3 items triaged.' }],
+  }) as any,
+  systemPrompt: 'You are an executive assistant.',
+  scheduledTasks,
+});
+
+// --- Fire one task directly ----------------------------------------------
+// This is what a crontab entry running `agent-do scheduled-tasks run ea-sweep`
+// does under the hood. Lock files prevent overlap with any previous run.
+const outcome = await runScheduledTask(agent, scheduledTasks[0]);
+console.log('One-shot task outcome:');
+console.log('  status:   ', outcome.status);
+if (outcome.status === 'success') {
+  console.log('  duration: ', outcome.durationMs, 'ms');
+  console.log('  output:   ', outcome.output.slice(0, 80));
+}
+console.log();
+
+// --- Evaluate the cron schedule without actually running -----------------
+// Useful for tests, dashboards, or a "when does this next fire?" view.
+console.log('Would these tasks fire right now?');
+for (const task of scheduledTasks) {
+  const parsed = parseCron(task.cron);
+  const matches = cronMatches(parsed, new Date());
+  console.log(`  ${task.id.padEnd(12)} ${task.cron.padEnd(20)} ${matches ? 'yes' : 'no'}`);
+}
+console.log();
+
+// --- Generate a crontab block --------------------------------------------
+console.log('Crontab entries you can paste into `crontab -e`:\n');
+console.log(
+  generateCrontabEntries(scheduledTasks, {
+    cliPath: 'agent-do',
+    workingDir: process.cwd(),
+    extraArgs: ['--script', './ea.ts', '--yes'],
+  }),
+);

--- a/llms.txt
+++ b/llms.txt
@@ -51,6 +51,34 @@
 - Master gets: delegate_task, list_agents, get_agent_status tools
 - `orchestrator.run(task)` / `orchestrator.stream(task)`
 
+## Scheduled Tasks (#79)
+
+Declarative cron-driven agent runs with lock-file concurrency.
+
+- `AgentConfig.scheduledTasks: ScheduledTask[]` — declarative schedule;
+  validated at `createAgent` time (bad cron / duplicate ids throw).
+- `runScheduledTask(agent, task, options?)` — fire one task now;
+  acquires a per-task lock, records status in `.agent-do/scheduler/`.
+  Returns `{ status: 'success' | 'skipped' | 'failed', ... }`.
+- `runScheduler(agent, tasks, options?)` — foreground loop that ticks
+  every `tickMs` (default one minute).
+- `tickScheduler(agent, parsed, state, date, options?)` — fire all
+  tasks whose cron matches `date` once; lets tests / hosts drive
+  scheduling without a timer.
+- `parseCron(expr): ParsedCron` + `cronMatches(parsed, date): boolean`
+  — minimal 5-field cron evaluator (numeric fields only).
+- `acquireLock/releaseLock/readLock(lockDir, taskId)` — lock file
+  primitives. Stale locks (dead PID, same host) are broken.
+- `readStatus(lockDir): Record<id, ScheduledTaskStatus>` — per-task
+  last run / status / duration.
+- `generateCrontabEntries(tasks, options?)` — render a crontab block.
+- CLI: `agent-do scheduled-tasks <run|start|status|install>`.
+
+`ScheduledTask` shape: `{ id, cron, payload, sessionTarget?, wakeMode?, description? }`.
+`wakeMode: 'systemEvent'` wraps payload in a `<system-event>` envelope
+with the "OK silence" contract — the model replies `OK` when nothing
+needs saying.
+
 ## Lifecycle Hooks
 
 - `onPreToolUse(event)` — before tool call, return HookDecision to allow/deny/modify

--- a/package-lock.json
+++ b/package-lock.json
@@ -417,9 +417,9 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -430,9 +430,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -636,31 +636,6 @@
       "peerDependencies": {
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
-      }
-    },
-    "node_modules/@napi-rs/wasm-runtime/node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@napi-rs/wasm-runtime/node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-do",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-do",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.0",
         "@ai-sdk/google": "^3.0.0",
@@ -416,6 +416,31 @@
         "prettier": "^2.7.1"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -611,6 +636,31 @@
       "peerDependencies": {
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,5 +1,6 @@
 import type { Agent, AgentConfig, ConversationMessage, ProgressEvent } from './types.js';
 import { runAgentLoop, streamAgentLoop } from './loop.js';
+import { validateScheduledTasks } from './scheduled-tasks.js';
 
 /**
  * Create an Agent instance from configuration.
@@ -8,6 +9,12 @@ import { runAgentLoop, streamAgentLoop } from './loop.js';
  * autonomous agent loop. Supports conversation history for multi-turn.
  */
 export function createAgent(config: AgentConfig): Agent {
+  // Fail loud on misconfigured scheduled tasks (#79). Invalid cron
+  // expressions or duplicate IDs should surface at construction time,
+  // not silently on the first tick hours later.
+  if (config.scheduledTasks !== undefined) {
+    validateScheduledTasks(config.scheduledTasks);
+  }
   let abortController: AbortController | null = null;
 
   return {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,7 @@ import { runPromptMode } from './cli/prompt.js';
 import { runScriptMode } from './cli/script.js';
 import { runEvalMode } from './cli/eval-cmd.js';
 import { createSavedAgent, listSavedAgents } from './cli/agents.js';
+import { runScheduledTasksMode } from './cli/scheduled-tasks-cmd.js';
 
 async function main(): Promise<void> {
   let args: ParsedArgs;
@@ -51,6 +52,9 @@ async function main(): Promise<void> {
       case 'list':
         await listSavedAgents();
         break;
+      case 'scheduled-tasks':
+        await runScheduledTasksMode(args);
+        break;
     }
   } catch (err) {
     console.error(err instanceof Error ? err.message : String(err));
@@ -72,6 +76,8 @@ Usage:
   npx agent-do list                        List saved agents
   npx agent-do run <name|file> [task]      Run a saved agent or script file
   npx agent-do eval <file|dir> [options]   Run eval cases
+  npx agent-do scheduled-tasks <action>    Manage cron-scheduled agent runs
+                                           (run|start|status|install)
 
 Piping:
   echo "context" | npx agent-do "prompt"   Merge piped input with prompt
@@ -129,6 +135,16 @@ Eval options:
   --output <format>      console | json | csv (default: console)
   --compare <providers>  Compare across providers (comma-separated)
   --concurrency <n>      Parallel case execution (default: 1)
+
+Scheduled tasks (#79):
+  npx agent-do scheduled-tasks run <id> --script ./agent.ts --yes
+      Run a single task once. Uses a lock file so two runs can't overlap.
+  npx agent-do scheduled-tasks start --script ./agent.ts --yes
+      Foreground scheduler — ticks every minute, fires matching tasks.
+  npx agent-do scheduled-tasks status [--script ./agent.ts]
+      Show last-run times and status per task.
+  npx agent-do scheduled-tasks install --script ./agent.ts --yes
+      Print a crontab block you can paste into \`crontab -e\`.
 
 Environment:
   ANTHROPIC_API_KEY      Required for Anthropic models

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -254,7 +254,21 @@ export function parseArgs(argv: string[]): ParsedArgs {
         throw new Error('--concurrency must be a positive integer');
       }
     } else if (arg === '--script') {
+      // Dual form (#79):
+      // - `agent-do run <file> --script` — `--script` is a boolean
+      //   confirming "yes I know I'm executing this positional file".
+      // - `agent-do scheduled-tasks <action> --script <path>` —
+      //   `--script` takes the path because there's no positional for
+      //   the file.
+      //
+      // Disambiguate by command: for `scheduled-tasks` we always
+      // consume the next argv as the path; everything else keeps the
+      // legacy boolean semantics so existing `run --script` calls
+      // don't break.
       args.script = true;
+      if (args.command === 'scheduled-tasks') {
+        args.file = requireValue(argv, ++i, '--script');
+      }
     } else if (arg === '--accept-all') {
       args.acceptAll = true;
     } else if (arg === '-y' || arg === '--yes') {

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -6,10 +6,20 @@
  */
 
 export interface ParsedArgs {
-  command: 'prompt' | 'run' | 'eval' | 'create' | 'list';
+  command: 'prompt' | 'run' | 'eval' | 'create' | 'list' | 'scheduled-tasks';
   prompt?: string;
   file?: string;
   agentName?: string;
+  /**
+   * Sub-subcommand for `scheduled-tasks`: `run` | `start` | `status` |
+   * `install`. Only set when `command === 'scheduled-tasks'`.
+   */
+  schedulerAction?: 'run' | 'start' | 'status' | 'install';
+  /**
+   * Task id, positional after `scheduled-tasks run`. Required for the
+   * `run` action, ignored by other scheduler actions.
+   */
+  schedulerTaskId?: string;
   provider: string;
   model?: string;
   systemPrompt: string;
@@ -152,6 +162,21 @@ export function parseArgs(argv: string[]): ParsedArgs {
     } else if (first === 'list') {
       args.command = 'list';
       i = 1;
+    } else if (first === 'scheduled-tasks') {
+      args.command = 'scheduled-tasks';
+      i = 1;
+      const action = argv[1];
+      if (action === 'run' || action === 'start' || action === 'status' || action === 'install') {
+        args.schedulerAction = action;
+        i = 2;
+        if (action === 'run') {
+          const taskId = argv[2];
+          if (taskId && !taskId.startsWith('-')) {
+            args.schedulerTaskId = taskId;
+            i = 3;
+          }
+        }
+      }
     }
   }
 
@@ -272,6 +297,15 @@ export function parseArgs(argv: string[]): ParsedArgs {
     args.agentName = positional[0];
   } else if (args.command === 'list') {
     // no positional args needed
+  } else if (args.command === 'scheduled-tasks') {
+    if (!args.schedulerAction && !args.help) {
+      throw new Error(
+        'Usage: npx agent-do scheduled-tasks <run|start|status|install> [options]',
+      );
+    }
+    if (args.schedulerAction === 'run' && !args.schedulerTaskId && !args.help) {
+      throw new Error('Usage: npx agent-do scheduled-tasks run <task-id> [options]');
+    }
   } else {
     // prompt mode — all positional args become the prompt
     if (positional.length > 0) {

--- a/src/cli/scheduled-tasks-cmd.ts
+++ b/src/cli/scheduled-tasks-cmd.ts
@@ -1,0 +1,240 @@
+/**
+ * `agent-do scheduled-tasks` — CLI integration for scheduled tasks (#79).
+ *
+ * Subcommands:
+ *
+ *   agent-do scheduled-tasks run <id> --script <file>
+ *       Run a single scheduled task once. Acquires the task's lock file;
+ *       returns non-zero if the lock is already held or the task failed.
+ *
+ *   agent-do scheduled-tasks start --script <file>
+ *       Run the scheduler loop in the foreground. Ticks every minute,
+ *       fires any task whose cron matches, prints one-line status per
+ *       task. Exits on SIGINT.
+ *
+ *   agent-do scheduled-tasks status
+ *       Show the last-run / last-status / duration for each task, based
+ *       on `.agent-do/scheduler/status.json`. Doesn't need a script —
+ *       the status file is enough. (Pass --script to filter by tasks
+ *       defined in that agent.)
+ *
+ *   agent-do scheduled-tasks install --script <file>
+ *       Print a crontab block to stdout. The user reviews and pastes
+ *       into `crontab -e`. We deliberately don't touch the user's
+ *       crontab directly.
+ *
+ * The script file is required for `run`, `start`, and `install` because
+ * those actions need the task definitions. Status can read the status
+ * file alone.
+ */
+
+import * as path from 'node:path';
+import type { ParsedArgs } from './args.js';
+import { importScriptFile } from './script.js';
+import {
+  DEFAULT_LOCK_DIR,
+  generateCrontabEntries,
+  readStatus,
+  runScheduledTask,
+  runScheduler,
+  validateScheduledTasks,
+} from '../scheduled-tasks.js';
+import type { Agent, AgentConfig, ScheduledTask } from '../types.js';
+import { createAgent } from '../agent.js';
+import { resolveModel } from './resolve-model.js';
+
+interface LoadedScheduler {
+  agent: Agent;
+  tasks: ScheduledTask[];
+}
+
+/**
+ * Load the agent + scheduledTasks list from a `--script <file>` export.
+ *
+ * Accepts the same export shapes as `agent-do run <file>`:
+ * - Agent instance (must be constructed from a config that carries
+ *   `scheduledTasks` — we can't recover it from a pre-built instance
+ *   that didn't attach the list, so the export must also expose
+ *   `scheduledTasks` as a peer export).
+ * - AgentConfig (with id, model, and scheduledTasks).
+ * - Simple config (with systemPrompt/name and scheduledTasks; model is
+ *   resolved via CLI flags).
+ */
+async function loadScheduler(args: ParsedArgs): Promise<LoadedScheduler> {
+  if (!args.file) {
+    throw new Error(
+      'Scheduled tasks need a script file that exports the agent + tasks.\n' +
+        '  npx agent-do scheduled-tasks <action> --script ./my-agent.ts',
+    );
+  }
+  const mod = await importScriptFile(args.file, { yes: args.yes });
+  const exported = (mod.default ?? mod) as Record<string, unknown>;
+
+  // Resolve tasks from the export. We accept the tasks either at the
+  // top level (`export const scheduledTasks = [...]`) or nested on an
+  // AgentConfig / Agent instance (`export default { scheduledTasks }`).
+  const tasks = (exported.scheduledTasks as ScheduledTask[] | undefined) ?? [];
+  if (!Array.isArray(tasks) || tasks.length === 0) {
+    throw new Error(
+      `${args.file} must export \`scheduledTasks\` (an array of ScheduledTask). ` +
+        `Attach them alongside the agent config: \`export const scheduledTasks = [...]\`.`,
+    );
+  }
+  validateScheduledTasks(tasks);
+
+  // Resolve the agent. If the export is already an Agent instance we
+  // use it directly; otherwise we build one from the config. Scheduled
+  // tasks don't need the full CLI tool wiring because the payload is
+  // the whole prompt, so we keep this minimal.
+  let agent: Agent;
+  if (typeof exported.run === 'function' && typeof exported.stream === 'function') {
+    agent = exported as unknown as Agent;
+  } else if (exported.model && exported.id) {
+    agent = createAgent(exported as unknown as AgentConfig);
+  } else if (exported.systemPrompt || exported.name) {
+    const model = await resolveModel(
+      (exported.provider as string) ?? args.provider,
+      (exported.model as string) ?? args.model,
+    );
+    const agentId = (exported.id as string) ?? 'scheduled-task-agent';
+    agent = createAgent({
+      id: agentId,
+      name: (exported.name as string) ?? agentId,
+      model,
+      systemPrompt: (exported.systemPrompt as string) ?? args.systemPrompt,
+      scheduledTasks: tasks,
+    });
+  } else {
+    throw new Error(
+      `${args.file} must export an Agent, AgentConfig, or a simple config with \`scheduledTasks\`.`,
+    );
+  }
+  return { agent, tasks };
+}
+
+export async function runScheduledTasksMode(args: ParsedArgs): Promise<void> {
+  switch (args.schedulerAction) {
+    case 'run':
+      return runOne(args);
+    case 'start':
+      return runLoop(args);
+    case 'status':
+      return showStatus(args);
+    case 'install':
+      return showInstall(args);
+    default:
+      throw new Error(
+        'Usage: npx agent-do scheduled-tasks <run|start|status|install> [options]',
+      );
+  }
+}
+
+async function runOne(args: ParsedArgs): Promise<void> {
+  const { agent, tasks } = await loadScheduler(args);
+  const task = tasks.find((t) => t.id === args.schedulerTaskId);
+  if (!task) {
+    const known = tasks.map((t) => t.id).join(', ') || '(none)';
+    throw new Error(
+      `No scheduled task "${args.schedulerTaskId}". Known: ${known}.`,
+    );
+  }
+  const outcome = await runScheduledTask(agent, task, { lockDir: DEFAULT_LOCK_DIR });
+  if (outcome.status === 'skipped') {
+    process.stderr.write(`[scheduled-tasks] skipped: ${outcome.reason}\n`);
+    process.exit(75); // EX_TEMPFAIL — cron will retry on next tick
+  }
+  if (outcome.status === 'failed') {
+    process.stderr.write(`[scheduled-tasks] failed (${outcome.durationMs}ms): ${outcome.error}\n`);
+    process.exit(1);
+  }
+  process.stdout.write(outcome.output);
+  if (!outcome.output.endsWith('\n')) process.stdout.write('\n');
+  process.stderr.write(`[scheduled-tasks] ok (${outcome.durationMs}ms)\n`);
+}
+
+async function runLoop(args: ParsedArgs): Promise<void> {
+  const { agent, tasks } = await loadScheduler(args);
+  const controller = new AbortController();
+  const onSignal = () => controller.abort();
+  process.once('SIGINT', onSignal);
+  process.once('SIGTERM', onSignal);
+  process.stderr.write(
+    `[scheduled-tasks] starting scheduler with ${tasks.length} task(s). Press Ctrl-C to stop.\n`,
+  );
+  for (const task of tasks) {
+    process.stderr.write(`  - ${task.id}  ${task.cron}\n`);
+  }
+  try {
+    await runScheduler(agent, tasks, {
+      signal: controller.signal,
+      onOutcome: (task, outcome) => {
+        const ts = new Date().toISOString();
+        if (outcome.status === 'success') {
+          process.stderr.write(`[${ts}] ${task.id}: ok (${outcome.durationMs}ms)\n`);
+        } else if (outcome.status === 'failed') {
+          process.stderr.write(`[${ts}] ${task.id}: failed — ${outcome.error}\n`);
+        } else {
+          process.stderr.write(`[${ts}] ${task.id}: skipped — ${outcome.reason}\n`);
+        }
+      },
+    });
+  } finally {
+    process.off('SIGINT', onSignal);
+    process.off('SIGTERM', onSignal);
+  }
+}
+
+async function showStatus(args: ParsedArgs): Promise<void> {
+  const status = await readStatus(DEFAULT_LOCK_DIR);
+  let rows = Object.values(status);
+  // If a script was supplied, filter down to tasks defined in that file
+  // so output matches the active agent's view.
+  if (args.file) {
+    const { tasks } = await loadScheduler(args);
+    const known = new Set(tasks.map((t) => t.id));
+    rows = rows.filter((r) => known.has(r.id));
+    for (const task of tasks) {
+      if (!rows.find((r) => r.id === task.id)) {
+        rows.push({ id: task.id });
+      }
+    }
+  }
+  if (rows.length === 0) {
+    console.log('No scheduled tasks have run yet.');
+    return;
+  }
+  rows.sort((a, b) => a.id.localeCompare(b.id));
+  console.log('Scheduled task status:\n');
+  const pad = (s: string, n: number) => s + ' '.repeat(Math.max(0, n - s.length));
+  console.log(
+    `  ${pad('ID', 20)} ${pad('LAST RUN', 26)} ${pad('STATUS', 10)} ${pad('DURATION', 10)} SUCCESS/FAIL`,
+  );
+  for (const row of rows) {
+    const last = row.lastRun ?? '—';
+    const status = row.lastStatus ?? '—';
+    const dur = row.durationMs !== undefined ? `${row.durationMs}ms` : '—';
+    const counts = `${row.successCount ?? 0}/${row.failureCount ?? 0}`;
+    console.log(
+      `  ${pad(row.id, 20)} ${pad(last, 26)} ${pad(status, 10)} ${pad(dur, 10)} ${counts}`,
+    );
+    if (row.lastError) {
+      console.log(`    └── error: ${row.lastError}`);
+    }
+  }
+}
+
+async function showInstall(args: ParsedArgs): Promise<void> {
+  const { tasks } = await loadScheduler(args);
+  // `--script` requires `-y` for non-TTY; we build an `extraArgs` list
+  // so the crontab entry is ready to paste and doesn't need extra flags.
+  const extraArgs = [
+    '--script',
+    path.resolve(args.file!),
+    '--yes',
+  ];
+  const block = generateCrontabEntries(tasks, { extraArgs });
+  process.stdout.write(block);
+  process.stderr.write(
+    '\n[scheduled-tasks] Review the lines above, then run `crontab -e` and paste them in.\n',
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,34 @@ export {
 export type { CreateRoutineToolsOptions } from './routines.js';
 export type { Routine, RoutineStore, RoutineInput } from './types.js';
 
+// Scheduled tasks — cron-driven agent runs with lock-file concurrency (#79)
+export {
+  validateScheduledTasks,
+  parseCron,
+  cronMatches,
+  acquireLock,
+  releaseLock,
+  readLock,
+  hasLockFile,
+  readStatus,
+  runScheduledTask,
+  runScheduler,
+  tickScheduler,
+  createSchedulerState,
+  buildScheduledTaskPrompt,
+  generateCrontabEntries,
+  DEFAULT_LOCK_DIR,
+} from './scheduled-tasks.js';
+export type {
+  ParsedCron,
+  RunScheduledTaskOptions,
+  RunSchedulerOptions,
+  ScheduledTaskRunOutcome,
+  GenerateCrontabOptions,
+  SchedulerState,
+} from './scheduled-tasks.js';
+export type { ScheduledTask, ScheduledTaskStatus } from './types.js';
+
 // Workspace tools (real project files) and memory tools (agent scratchpad)
 export { createWorkspaceTools } from './tools/workspace-tools.js';
 export type { WorkspaceToolsOptions } from './tools/workspace-tools.js';

--- a/src/scheduled-tasks.ts
+++ b/src/scheduled-tasks.ts
@@ -4,7 +4,7 @@
  *
  * This module is a primitive kit, not a daemon:
  *
- * 1. `validateScheduledTask` — called from `createAgent` to fail loud
+ * 1. `validateScheduledTasks` — called from `createAgent` to fail loud
  *    on bad cron, duplicate IDs, or unsafe task IDs.
  * 2. `parseCron` / `cronMatches` — a minimal, dependency-free cron
  *    evaluator. Supports the standard star, numeric, range, list, and
@@ -266,7 +266,27 @@ interface LockRecord {
   startedAt: string;
 }
 
+/**
+ * Guard lock-primitive callers against path traversal. `ScheduledTask`
+ * IDs are already validated at `createAgent` time, but the low-level
+ * `acquireLock` / `releaseLock` / `readLock` helpers are exported so
+ * an unvalidated `taskId` (e.g. `../../etc/passwd`) mustn't be able to
+ * escape `lockDir`. Defence in depth — we keep this even though
+ * `validateScheduledTasks` should already catch bad IDs upstream.
+ */
+function assertValidTaskId(taskId: string): void {
+  if (typeof taskId !== 'string' || taskId.length === 0) {
+    throw new TypeError('taskId must be a non-empty string');
+  }
+  if (taskId.length > TASK_ID_MAX_LENGTH || !TASK_ID_RE.test(taskId)) {
+    throw new TypeError(
+      `taskId must match ${TASK_ID_RE.toString()} and be ≤ ${TASK_ID_MAX_LENGTH} chars`,
+    );
+  }
+}
+
 function lockPath(lockDir: string, taskId: string): string {
+  assertValidTaskId(taskId);
   return path.join(lockDir, `${taskId}.lock`);
 }
 
@@ -289,9 +309,11 @@ function isPidAlive(pid: number): boolean {
 }
 
 /**
- * Read a lock-file record. Returns `null` when the file is absent or
- * malformed — a malformed lock is treated as stale and will be broken
- * on the next acquire.
+ * Read a lock-file record. Returns `null` when the file is absent,
+ * unreadable, or malformed. Callers treat `null` as "no usable lock
+ * record"; malformed lock files are **not** automatically broken by
+ * this reader — `acquireLock` is conservative and only breaks locks
+ * it can positively identify as stale (same host, dead PID).
  */
 export async function readLock(lockDir: string, taskId: string): Promise<LockRecord | null> {
   try {
@@ -317,49 +339,88 @@ export async function readLock(lockDir: string, taskId: string): Promise<LockRec
 }
 
 /**
+ * How many times `acquireLock` retries the stale-lock recovery dance
+ * before giving up. The dance is: read the lock, confirm it's stale,
+ * unlink it, try `open('wx')` again. Each unlink/open round can race
+ * with another process doing the same thing on the same stale lock;
+ * cap the retries so we don't spin forever if a never-ending stream
+ * of processes keeps winning.
+ */
+const STALE_LOCK_RETRIES = 5;
+
+/**
  * Attempt to acquire a lock for the given task. Returns `true` on
- * success, `false` when another live process already holds it.
+ * success, `false` when another live process already holds it (or a
+ * foreign-host process, or a malformed lock we conservatively refuse
+ * to break).
  *
- * Uses `fs.open(..., 'wx')` for atomic create-if-not-exists. If the
- * file already exists, we inspect it — if the PID is dead (or on
- * another host, if we decide to break foreign locks later), we
- * reclaim it. Otherwise we return false.
+ * The happy path uses `open(..., 'wx')` — atomic create-if-not-exists.
+ * If the file already exists, we inspect it:
+ *
+ * - Foreign host → refuse (we can't probe remote liveness).
+ * - Malformed / unreadable → refuse (can't prove it's stale).
+ * - Same host, live PID → refuse (the lock is genuinely held).
+ * - Same host, dead PID → **stale-lock recovery**: `unlink` + retry
+ *   `open('wx')`. This is atomic wrt concurrent recoverers: two
+ *   processes can both unlink, but only one `wx` wins — the loser
+ *   sees EEXIST and re-reads the lock (now owned by the winner) and
+ *   returns false.
  */
 export async function acquireLock(lockDir: string, taskId: string): Promise<boolean> {
+  // Validate up-front so a bad `taskId` fails loud instead of silently
+  // no-op-ing downstream — even if the caller validated already.
+  assertValidTaskId(taskId);
   await fsp.mkdir(lockDir, { recursive: true });
   const file = lockPath(lockDir, taskId);
-  const record: LockRecord = {
-    taskId,
-    pid: process.pid,
-    host: hostName(),
-    startedAt: new Date().toISOString(),
-  };
-  const body = JSON.stringify(record, null, 2);
-  try {
-    // 'wx' — fail if the file already exists. Atomic wrt concurrent
-    // acquire attempts on the same host.
-    const handle = await fsp.open(file, 'wx');
+  const body = () =>
+    JSON.stringify(
+      {
+        taskId,
+        pid: process.pid,
+        host: hostName(),
+        startedAt: new Date().toISOString(),
+      } satisfies LockRecord,
+      null,
+      2,
+    );
+
+  for (let attempt = 0; attempt < STALE_LOCK_RETRIES; attempt++) {
     try {
-      await handle.writeFile(body, 'utf8');
-    } finally {
-      await handle.close();
+      // 'wx' — fail if the file already exists. Atomic wrt concurrent
+      // acquire attempts on the same host.
+      const handle = await fsp.open(file, 'wx');
+      try {
+        await handle.writeFile(body(), 'utf8');
+      } finally {
+        await handle.close();
+      }
+      return true;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
     }
-    return true;
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
-  }
-  // Lock exists — is it live?
-  const existing = await readLock(lockDir, taskId);
-  if (existing && existing.host === hostName() && !isPidAlive(existing.pid)) {
-    // Stale local lock — break it by overwriting.
-    await fsp.writeFile(file, body, 'utf8');
-    return true;
+    // Lock exists — is it recoverably stale?
+    const existing = await readLock(lockDir, taskId);
+    if (!existing) return false; // malformed → refuse
+    if (existing.host !== hostName()) return false; // foreign host → refuse
+    if (isPidAlive(existing.pid)) return false; // live holder → refuse
+    // Stale local lock. Unlink then retry `wx`. If another process is
+    // racing the same recovery, exactly one `wx` wins; the loser sees
+    // EEXIST on the next iteration, re-reads the (now-fresh) lock,
+    // finds a live PID (the winner), and returns false.
+    try {
+      await fsp.unlink(file);
+    } catch (err) {
+      // ENOENT means someone else already unlinked it — that's fine,
+      // let the next `wx` attempt race for the new lock.
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+    }
   }
   return false;
 }
 
 /** Release the lock for `taskId`. Idempotent — no-op if already gone. */
 export async function releaseLock(lockDir: string, taskId: string): Promise<void> {
+  assertValidTaskId(taskId);
   try {
     await fsp.unlink(lockPath(lockDir, taskId));
   } catch (err) {
@@ -406,9 +467,48 @@ export async function readStatus(lockDir: string): Promise<Record<string, Schedu
   }
 }
 
+/**
+ * Atomic write: render to a tempfile in the same directory, then
+ * `rename` over the target. On POSIX `rename` is atomic within a
+ * filesystem, so readers either see the old file or the new one —
+ * never a half-written `status.json`. Crash safety: a dangling
+ * tempfile is garbage but never corrupts the live file.
+ */
+async function atomicWriteJson(target: string, body: string): Promise<void> {
+  await fsp.mkdir(path.dirname(target), { recursive: true });
+  const tmp = `${target}.${process.pid}.${Date.now()}.tmp`;
+  await fsp.writeFile(tmp, body, 'utf8');
+  try {
+    await fsp.rename(tmp, target);
+  } catch (err) {
+    // Best-effort tempfile cleanup on rename failure.
+    await fsp.unlink(tmp).catch(() => {});
+    throw err;
+  }
+}
+
+/**
+ * Serialize status updates within a single process. `tickScheduler`
+ * fires matching tasks in parallel, and each one does a
+ * read-modify-write of the shared `status.json`. Without this
+ * promise-chained mutex, two parallel `updateStatus` calls can both
+ * read the old map, each overwrite the other's changes, and drop
+ * counters. The per-`lockDir` keying lets multiple schedulers in the
+ * same process (running against different dirs) update independently.
+ *
+ * Cross-process safety still relies on the per-task lock file —
+ * two different processes updating the *same* task's status are
+ * already serialised by the task lock. Cross-process status races on
+ * *different* tasks hitting the same `status.json` simultaneously
+ * could still lose a write, but status is observational: the next
+ * run of either task rewrites its entry. The atomic rename above
+ * means the file itself is never corrupt.
+ */
+const statusChains = new Map<string, Promise<void>>();
+
 async function writeStatus(lockDir: string, map: Record<string, ScheduledTaskStatus>): Promise<void> {
   await fsp.mkdir(lockDir, { recursive: true });
-  await fsp.writeFile(statusPath(lockDir), JSON.stringify(map, null, 2), 'utf8');
+  await atomicWriteJson(statusPath(lockDir), JSON.stringify(map, null, 2));
 }
 
 async function updateStatus(
@@ -416,10 +516,21 @@ async function updateStatus(
   taskId: string,
   patch: Partial<ScheduledTaskStatus>,
 ): Promise<void> {
-  const all = await readStatus(lockDir);
-  const prev = all[taskId] ?? { id: taskId, successCount: 0, failureCount: 0 };
-  all[taskId] = { ...prev, ...patch, id: taskId };
-  await writeStatus(lockDir, all);
+  const prev = statusChains.get(lockDir) ?? Promise.resolve();
+  const next = prev.then(async () => {
+    const all = await readStatus(lockDir);
+    const existing = all[taskId] ?? { id: taskId, successCount: 0, failureCount: 0 };
+    all[taskId] = { ...existing, ...patch, id: taskId };
+    await writeStatus(lockDir, all);
+  });
+  // Swallow downstream errors from the chain so one failed update
+  // doesn't break every subsequent caller. `next` (as returned to the
+  // caller) still rejects on its own failure.
+  statusChains.set(
+    lockDir,
+    next.catch(() => {}),
+  );
+  return next;
 }
 
 // ─── Task runtime ───────────────────────────────────────────────────────

--- a/src/scheduled-tasks.ts
+++ b/src/scheduled-tasks.ts
@@ -1,0 +1,749 @@
+/**
+ * Scheduled tasks (#79) — declarative cron-driven agent runs with
+ * lock-file concurrency.
+ *
+ * This module is a primitive kit, not a daemon:
+ *
+ * 1. `validateScheduledTask` — called from `createAgent` to fail loud
+ *    on bad cron, duplicate IDs, or unsafe task IDs.
+ * 2. `parseCron` / `cronMatches` — a minimal, dependency-free cron
+ *    evaluator. Supports the standard star, numeric, range, list, and
+ *    step forms (e.g. `N-M`, comma lists, step suffixes). Numeric
+ *    fields only — named months / weekdays are not supported, to keep
+ *    the surface small and the tests exhaustive.
+ * 3. `acquireLock` / `releaseLock` — a PID-liveness-aware lock file.
+ *    Stale locks (process dead) are broken automatically so a crashed
+ *    run doesn't block the next one forever.
+ * 4. `runScheduledTask` — fire one task now: acquire its lock, run the
+ *    agent with the task's payload, record status, release the lock.
+ * 5. `runScheduler` — a foreground loop that ticks once per minute
+ *    and fires any task whose cron matches. Useful for development;
+ *    production users will typically install a crontab entry per task.
+ * 6. `generateCrontabEntries` — render a crontab block the user can
+ *    paste into `crontab -e`. We deliberately don't touch the crontab
+ *    directly; shell integration is the user's call.
+ *
+ * Design constraints mirrored from the rest of agent-do:
+ *
+ * - No heavy dependencies — cron evaluation is ~60 lines.
+ * - Node.js-only (the module imports `node:fs` / `node:path`). The
+ *   module is gated in `src/index.ts` behind the main export, so
+ *   downstream bundlers can still tree-shake cleanly.
+ * - Structured status records so `scheduled-tasks status` can render
+ *   useful output without a second data source.
+ *
+ * See GitHub issue #79 for design rationale.
+ */
+
+import { promises as fsp } from 'node:fs';
+import { existsSync } from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import type { Agent, ScheduledTask, ScheduledTaskStatus } from './types.js';
+
+// ─── Validation ─────────────────────────────────────────────────────────
+
+const TASK_ID_RE = /^[a-zA-Z0-9_-]+$/;
+const TASK_ID_MAX_LENGTH = 64;
+
+/**
+ * Validate a list of {@link ScheduledTask} values. Throws on the first
+ * problem encountered — misconfiguration should fail loud at
+ * `createAgent` time, not on the first cron tick hours later.
+ *
+ * Checks:
+ * - Each id is safe as a filename (`/^[a-zA-Z0-9_-]+$/`, ≤64 chars).
+ * - IDs are unique within the config.
+ * - `cron` parses cleanly.
+ * - `wakeMode` / `sessionTarget` are known enum members.
+ * - `payload` is a string or a plain object.
+ */
+export function validateScheduledTasks(tasks: ScheduledTask[]): void {
+  if (!Array.isArray(tasks)) {
+    throw new TypeError('scheduledTasks must be an array');
+  }
+  const seen = new Set<string>();
+  for (const task of tasks) {
+    if (!task || typeof task !== 'object') {
+      throw new TypeError('Each scheduled task must be a { id, cron, payload, … } object');
+    }
+    if (typeof task.id !== 'string' || !TASK_ID_RE.test(task.id) || task.id.length > TASK_ID_MAX_LENGTH) {
+      throw new Error(
+        `Invalid scheduled task id: ${JSON.stringify(task.id)}. ` +
+          `IDs must match /^[a-zA-Z0-9_-]+$/ and be ≤ ${TASK_ID_MAX_LENGTH} chars.`,
+      );
+    }
+    if (seen.has(task.id)) {
+      throw new Error(`Duplicate scheduled task id: ${task.id}`);
+    }
+    seen.add(task.id);
+    if (typeof task.cron !== 'string' || task.cron.trim() === '') {
+      throw new Error(`Scheduled task "${task.id}" is missing a cron expression`);
+    }
+    // Throws on invalid cron with a message pinpointing the field.
+    parseCron(task.cron);
+    if (task.sessionTarget !== undefined && task.sessionTarget !== 'isolated' && task.sessionTarget !== 'main') {
+      throw new Error(
+        `Scheduled task "${task.id}" has unknown sessionTarget ` +
+          `${JSON.stringify(task.sessionTarget)} (expected 'isolated' or 'main')`,
+      );
+    }
+    if (task.wakeMode !== undefined && task.wakeMode !== 'agentTurn' && task.wakeMode !== 'systemEvent') {
+      throw new Error(
+        `Scheduled task "${task.id}" has unknown wakeMode ` +
+          `${JSON.stringify(task.wakeMode)} (expected 'agentTurn' or 'systemEvent')`,
+      );
+    }
+    if (
+      typeof task.payload !== 'string' &&
+      (typeof task.payload !== 'object' || task.payload === null || Array.isArray(task.payload))
+    ) {
+      throw new Error(
+        `Scheduled task "${task.id}" payload must be a string or a plain object`,
+      );
+    }
+  }
+}
+
+// ─── Cron parser ────────────────────────────────────────────────────────
+
+/** Inclusive range for each of the five cron fields. */
+const CRON_FIELD_RANGES: ReadonlyArray<readonly [number, number]> = [
+  [0, 59], // minute
+  [0, 23], // hour
+  [1, 31], // day of month
+  [1, 12], // month
+  [0, 7], // day of week (0 and 7 both == Sunday)
+];
+const CRON_FIELD_NAMES = ['minute', 'hour', 'day-of-month', 'month', 'day-of-week'] as const;
+
+/**
+ * A parsed cron expression — five sets of allowed integers, one per
+ * field. `dayOfWeek` collapses `7` onto `0` so callers only need to
+ * check Sunday once.
+ */
+export interface ParsedCron {
+  minute: Set<number>;
+  hour: Set<number>;
+  dayOfMonth: Set<number>;
+  month: Set<number>;
+  dayOfWeek: Set<number>;
+  /**
+   * True when either day-of-month or day-of-week was restricted (not
+   * `*`). Standard cron semantics OR the two when either is restricted;
+   * we need to know which fields are restricted so {@link cronMatches}
+   * can apply the OR correctly.
+   */
+  dayOfMonthRestricted: boolean;
+  dayOfWeekRestricted: boolean;
+}
+
+/**
+ * Parse a 5-field cron expression into a {@link ParsedCron}. Throws
+ * with a field-specific message when any field is invalid.
+ */
+export function parseCron(expr: string): ParsedCron {
+  const fields = expr.trim().split(/\s+/);
+  if (fields.length !== 5) {
+    throw new Error(
+      `Invalid cron expression ${JSON.stringify(expr)}: ` +
+        `expected 5 space-separated fields (min hour day-of-month month day-of-week), got ${fields.length}`,
+    );
+  }
+  const parsed = fields.map((field, i) =>
+    parseCronField(field, CRON_FIELD_RANGES[i]![0], CRON_FIELD_RANGES[i]![1], CRON_FIELD_NAMES[i]!),
+  );
+  const dayOfWeek = parsed[4]!;
+  // Collapse 7 → 0 so Sunday is a single canonical value.
+  if (dayOfWeek.has(7)) {
+    dayOfWeek.delete(7);
+    dayOfWeek.add(0);
+  }
+  return {
+    minute: parsed[0]!,
+    hour: parsed[1]!,
+    dayOfMonth: parsed[2]!,
+    month: parsed[3]!,
+    dayOfWeek,
+    dayOfMonthRestricted: fields[2] !== '*',
+    dayOfWeekRestricted: fields[4] !== '*',
+  };
+}
+
+function parseCronField(field: string, min: number, max: number, name: string): Set<number> {
+  const out = new Set<number>();
+  for (const piece of field.split(',')) {
+    const trimmed = piece.trim();
+    if (trimmed === '') {
+      throw new Error(`Invalid cron ${name} field: empty entry in ${JSON.stringify(field)}`);
+    }
+    const [range, stepStr] = trimmed.split('/');
+    const step = stepStr === undefined ? 1 : parseInt(stepStr, 10);
+    if (!Number.isInteger(step) || step < 1) {
+      throw new Error(`Invalid cron ${name} step ${JSON.stringify(stepStr)} in ${JSON.stringify(trimmed)}`);
+    }
+    let lo: number;
+    let hi: number;
+    if (range === '*') {
+      lo = min;
+      hi = max;
+    } else if (range!.includes('-')) {
+      const [loStr, hiStr] = range!.split('-');
+      lo = parseInt(loStr!, 10);
+      hi = parseInt(hiStr!, 10);
+      if (!Number.isInteger(lo) || !Number.isInteger(hi)) {
+        throw new Error(`Invalid cron ${name} range ${JSON.stringify(range)}`);
+      }
+      if (lo > hi) {
+        throw new Error(
+          `Invalid cron ${name} range ${JSON.stringify(range)}: low bound ${lo} > high bound ${hi}`,
+        );
+      }
+    } else {
+      const value = parseInt(range!, 10);
+      if (!Number.isInteger(value)) {
+        throw new Error(`Invalid cron ${name} value ${JSON.stringify(range)}`);
+      }
+      // A single numeric value combined with a step expands to [value, max].
+      // e.g. `5/15` in the minute field means 5, 20, 35, 50.
+      lo = value;
+      hi = stepStr === undefined ? value : max;
+    }
+    if (lo < min || hi > max) {
+      throw new Error(
+        `Invalid cron ${name} range ${lo}-${hi}: must be within [${min}, ${max}]`,
+      );
+    }
+    for (let n = lo; n <= hi; n += step) out.add(n);
+  }
+  if (out.size === 0) {
+    throw new Error(`Cron ${name} field ${JSON.stringify(field)} matches no values`);
+  }
+  return out;
+}
+
+/**
+ * True when the given `Date` falls within the cron expression. Follows
+ * the standard "day-of-month OR day-of-week when either is restricted"
+ * rule.
+ */
+export function cronMatches(parsed: ParsedCron, date: Date): boolean {
+  const minute = date.getMinutes();
+  const hour = date.getHours();
+  const dom = date.getDate();
+  const month = date.getMonth() + 1; // JS months are 0-indexed
+  const dow = date.getDay();
+  if (!parsed.minute.has(minute)) return false;
+  if (!parsed.hour.has(hour)) return false;
+  if (!parsed.month.has(month)) return false;
+  // Day-of-month OR day-of-week semantics:
+  // - If both are unrestricted (`*`), match.
+  // - If only one is restricted, it must match.
+  // - If both are restricted, EITHER matching is enough (union).
+  const domMatch = parsed.dayOfMonth.has(dom);
+  const dowMatch = parsed.dayOfWeek.has(dow);
+  if (!parsed.dayOfMonthRestricted && !parsed.dayOfWeekRestricted) return true;
+  if (parsed.dayOfMonthRestricted && parsed.dayOfWeekRestricted) {
+    return domMatch || dowMatch;
+  }
+  if (parsed.dayOfMonthRestricted) return domMatch;
+  return dowMatch;
+}
+
+// ─── Lock files ─────────────────────────────────────────────────────────
+
+/**
+ * Shape of a lock-file record. `pid` is the OS process id that holds
+ * the lock; `startedAt` is the ISO timestamp of when the lock was
+ * acquired. `host` is included so locks created on a different machine
+ * (e.g. shared NFS) aren't broken just because the current host's
+ * `process.kill(pid, 0)` returns ESRCH.
+ */
+interface LockRecord {
+  taskId: string;
+  pid: number;
+  host: string;
+  startedAt: string;
+}
+
+function lockPath(lockDir: string, taskId: string): string {
+  return path.join(lockDir, `${taskId}.lock`);
+}
+
+/**
+ * True when the given PID is alive on this host. `process.kill(pid, 0)`
+ * is the canonical probe on POSIX and Windows; it throws ESRCH for dead
+ * PIDs and EPERM when the PID exists but is owned by another user
+ * (still alive, so we treat EPERM as "alive").
+ */
+function isPidAlive(pid: number): boolean {
+  if (!Number.isFinite(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'EPERM') return true;
+    return false;
+  }
+}
+
+/**
+ * Read a lock-file record. Returns `null` when the file is absent or
+ * malformed — a malformed lock is treated as stale and will be broken
+ * on the next acquire.
+ */
+export async function readLock(lockDir: string, taskId: string): Promise<LockRecord | null> {
+  try {
+    const raw = await fsp.readFile(lockPath(lockDir, taskId), 'utf8');
+    const parsed = JSON.parse(raw);
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      typeof parsed.pid !== 'number' ||
+      typeof parsed.startedAt !== 'string'
+    ) {
+      return null;
+    }
+    return {
+      taskId: typeof parsed.taskId === 'string' ? parsed.taskId : taskId,
+      pid: parsed.pid,
+      host: typeof parsed.host === 'string' ? parsed.host : '',
+      startedAt: parsed.startedAt,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Attempt to acquire a lock for the given task. Returns `true` on
+ * success, `false` when another live process already holds it.
+ *
+ * Uses `fs.open(..., 'wx')` for atomic create-if-not-exists. If the
+ * file already exists, we inspect it — if the PID is dead (or on
+ * another host, if we decide to break foreign locks later), we
+ * reclaim it. Otherwise we return false.
+ */
+export async function acquireLock(lockDir: string, taskId: string): Promise<boolean> {
+  await fsp.mkdir(lockDir, { recursive: true });
+  const file = lockPath(lockDir, taskId);
+  const record: LockRecord = {
+    taskId,
+    pid: process.pid,
+    host: hostName(),
+    startedAt: new Date().toISOString(),
+  };
+  const body = JSON.stringify(record, null, 2);
+  try {
+    // 'wx' — fail if the file already exists. Atomic wrt concurrent
+    // acquire attempts on the same host.
+    const handle = await fsp.open(file, 'wx');
+    try {
+      await handle.writeFile(body, 'utf8');
+    } finally {
+      await handle.close();
+    }
+    return true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
+  }
+  // Lock exists — is it live?
+  const existing = await readLock(lockDir, taskId);
+  if (existing && existing.host === hostName() && !isPidAlive(existing.pid)) {
+    // Stale local lock — break it by overwriting.
+    await fsp.writeFile(file, body, 'utf8');
+    return true;
+  }
+  return false;
+}
+
+/** Release the lock for `taskId`. Idempotent — no-op if already gone. */
+export async function releaseLock(lockDir: string, taskId: string): Promise<void> {
+  try {
+    await fsp.unlink(lockPath(lockDir, taskId));
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+  }
+}
+
+function hostName(): string {
+  try {
+    return os.hostname();
+  } catch {
+    return '';
+  }
+}
+
+// ─── Status file ────────────────────────────────────────────────────────
+
+const STATUS_FILENAME = 'status.json';
+
+function statusPath(lockDir: string): string {
+  return path.join(lockDir, STATUS_FILENAME);
+}
+
+/**
+ * Read the status map. Missing / malformed files return an empty map
+ * — status is observational, not load-bearing.
+ */
+export async function readStatus(lockDir: string): Promise<Record<string, ScheduledTaskStatus>> {
+  try {
+    const raw = await fsp.readFile(statusPath(lockDir), 'utf8');
+    const parsed = JSON.parse(raw);
+    if (typeof parsed !== 'object' || parsed === null) return {};
+    // Drop prototype-pollution keys defensively.
+    const out: Record<string, ScheduledTaskStatus> = Object.create(null);
+    for (const [k, v] of Object.entries(parsed)) {
+      if (k === '__proto__' || k === 'constructor' || k === 'prototype') continue;
+      if (typeof v === 'object' && v !== null) {
+        out[k] = v as ScheduledTaskStatus;
+      }
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+async function writeStatus(lockDir: string, map: Record<string, ScheduledTaskStatus>): Promise<void> {
+  await fsp.mkdir(lockDir, { recursive: true });
+  await fsp.writeFile(statusPath(lockDir), JSON.stringify(map, null, 2), 'utf8');
+}
+
+async function updateStatus(
+  lockDir: string,
+  taskId: string,
+  patch: Partial<ScheduledTaskStatus>,
+): Promise<void> {
+  const all = await readStatus(lockDir);
+  const prev = all[taskId] ?? { id: taskId, successCount: 0, failureCount: 0 };
+  all[taskId] = { ...prev, ...patch, id: taskId };
+  await writeStatus(lockDir, all);
+}
+
+// ─── Task runtime ───────────────────────────────────────────────────────
+
+/**
+ * Outcome of {@link runScheduledTask}. `'skipped'` means the lock was
+ * already held by another live process — the scheduler will try again
+ * on the next tick.
+ */
+export type ScheduledTaskRunOutcome =
+  | { status: 'success'; output: string; durationMs: number }
+  | { status: 'skipped'; reason: string }
+  | { status: 'failed'; error: string; durationMs: number };
+
+export interface RunScheduledTaskOptions {
+  /**
+   * Directory used for lock / status files. Defaults to
+   * `.agent-do/scheduler` under cwd.
+   */
+  lockDir?: string;
+  /**
+   * Swallow the agent error instead of rethrowing, so a single task's
+   * failure doesn't take down the surrounding scheduler loop. Defaults
+   * to `true` — the status file carries the error so an operator can
+   * still see it.
+   */
+  swallowErrors?: boolean;
+}
+
+/**
+ * Default lock / status directory. Kept relative to cwd so a stray
+ * agent-do invocation in a different working tree gets its own locks
+ * and doesn't trample another project's.
+ */
+export const DEFAULT_LOCK_DIR = path.join('.agent-do', 'scheduler');
+
+/**
+ * Build the prompt a single scheduled task sends to the agent.
+ *
+ * `agentTurn` — the payload (string, or object → JSON) is used as the
+ * prompt verbatim, simulating a normal user message.
+ *
+ * `systemEvent` — the payload is wrapped in a `<system-event>` envelope
+ * that tells the model it was woken by a scheduler tick rather than by
+ * a human. Includes the "OK silence" hint from the issue: the model
+ * should reply with `OK` when there's nothing to do.
+ */
+export function buildScheduledTaskPrompt(task: ScheduledTask): string {
+  const payloadString =
+    typeof task.payload === 'string' ? task.payload : JSON.stringify(task.payload, null, 2);
+  const wakeMode = task.wakeMode ?? 'agentTurn';
+  if (wakeMode === 'agentTurn') {
+    return payloadString;
+  }
+  return (
+    `<system-event task-id="${escapeAttr(task.id)}" cron="${escapeAttr(task.cron)}">\n` +
+    `${payloadString}\n` +
+    `</system-event>\n\n` +
+    `This was a scheduled wake. If there is nothing to act on, reply with a single token \`OK\` — ` +
+    `don't narrate the silence.`
+  );
+}
+
+function escapeAttr(value: string): string {
+  return value.replace(/["<>\n\r]/g, ' ').slice(0, 256);
+}
+
+/**
+ * Execute a single scheduled task.
+ *
+ * Acquires the lock, runs the agent with a payload-derived prompt,
+ * records status, and releases the lock. If the lock is already held
+ * by a live process, returns `{ status: 'skipped' }` without touching
+ * the agent — the contract with the caller is that concurrent runs of
+ * the same task never overlap.
+ */
+export async function runScheduledTask(
+  agent: Agent,
+  task: ScheduledTask,
+  options: RunScheduledTaskOptions = {},
+): Promise<ScheduledTaskRunOutcome> {
+  const lockDir = options.lockDir ?? DEFAULT_LOCK_DIR;
+  const swallowErrors = options.swallowErrors ?? true;
+
+  const acquired = await acquireLock(lockDir, task.id);
+  if (!acquired) {
+    const existing = await readLock(lockDir, task.id);
+    const reason = existing
+      ? `Task "${task.id}" lock held by pid ${existing.pid} on ${existing.host || 'unknown'} since ${existing.startedAt}`
+      : `Task "${task.id}" lock is held`;
+    await updateStatus(lockDir, task.id, { lastStatus: 'skipped' });
+    return { status: 'skipped', reason };
+  }
+
+  const start = Date.now();
+  const startIso = new Date(start).toISOString();
+  await updateStatus(lockDir, task.id, { lastRun: startIso, lastStatus: 'running' });
+
+  try {
+    const prompt = buildScheduledTaskPrompt(task);
+    const output = await agent.run(prompt);
+    const durationMs = Date.now() - start;
+    const prev = (await readStatus(lockDir))[task.id];
+    await updateStatus(lockDir, task.id, {
+      lastFinished: new Date().toISOString(),
+      lastStatus: 'success',
+      durationMs,
+      lastError: undefined,
+      successCount: (prev?.successCount ?? 0) + 1,
+    });
+    return { status: 'success', output, durationMs };
+  } catch (err) {
+    const durationMs = Date.now() - start;
+    const message = err instanceof Error ? err.message : String(err);
+    const prev = (await readStatus(lockDir))[task.id];
+    await updateStatus(lockDir, task.id, {
+      lastFinished: new Date().toISOString(),
+      lastStatus: 'failed',
+      durationMs,
+      lastError: message,
+      failureCount: (prev?.failureCount ?? 0) + 1,
+    });
+    if (!swallowErrors) throw err;
+    return { status: 'failed', error: message, durationMs };
+  } finally {
+    await releaseLock(lockDir, task.id);
+  }
+}
+
+// ─── Scheduler loop ─────────────────────────────────────────────────────
+
+export interface RunSchedulerOptions {
+  lockDir?: string;
+  /**
+   * Tick interval in ms. Defaults to 60_000 (one minute). Lowering
+   * this is mostly useful for tests; cron's resolution is 1 minute.
+   */
+  tickMs?: number;
+  /**
+   * Called with each task outcome, for logging. Optional.
+   */
+  onOutcome?: (task: ScheduledTask, outcome: ScheduledTaskRunOutcome) => void;
+  /**
+   * Abort signal — when aborted, the loop exits after the current
+   * tick finishes (so in-flight tasks complete cleanly).
+   */
+  signal?: AbortSignal;
+  /**
+   * Clock override, for tests. Must return the "current" Date.
+   * Defaults to `() => new Date()`.
+   */
+  now?: () => Date;
+}
+
+/**
+ * Scheduler state shared across ticks. Keeps the "last fired minute"
+ * per task so a tick running twice within the same minute (possible
+ * with a small `tickMs` for tests) doesn't double-fire.
+ */
+export interface SchedulerState {
+  lastFiredMinute: Map<string, number>;
+}
+
+/** Allocate an empty {@link SchedulerState} — tests create one per loop. */
+export function createSchedulerState(): SchedulerState {
+  return { lastFiredMinute: new Map() };
+}
+
+/**
+ * Evaluate the schedule once and fire any tasks whose cron matches the
+ * given `date`. Exposed so tests can drive the scheduler tick-by-tick
+ * without running a timer loop.
+ *
+ * Returns the outcomes from `runScheduledTask` for each fired task.
+ */
+export async function tickScheduler(
+  agent: Agent,
+  tasks: ReadonlyArray<{ task: ScheduledTask; cron: ParsedCron }>,
+  state: SchedulerState,
+  date: Date,
+  options: { lockDir?: string; onOutcome?: (task: ScheduledTask, outcome: ScheduledTaskRunOutcome) => void } = {},
+): Promise<ScheduledTaskRunOutcome[]> {
+  const lockDir = options.lockDir ?? DEFAULT_LOCK_DIR;
+  const minuteKey = Math.floor(date.getTime() / 60_000);
+  const fires = tasks.filter(
+    ({ task, cron }) => cronMatches(cron, date) && state.lastFiredMinute.get(task.id) !== minuteKey,
+  );
+  // Mark *before* awaiting so a slow previous tick can't cause the
+  // same minute to fire twice.
+  for (const { task } of fires) state.lastFiredMinute.set(task.id, minuteKey);
+  return Promise.all(
+    fires.map(async ({ task }) => {
+      const outcome = await runScheduledTask(agent, task, { lockDir });
+      options.onOutcome?.(task, outcome);
+      return outcome;
+    }),
+  );
+}
+
+/**
+ * Run the scheduler in the foreground.
+ *
+ * Every `tickMs` ms (default one minute), evaluates each task's cron
+ * against the current minute and invokes any that match. Tasks run in
+ * parallel within a tick — the per-task lock file prevents overlap
+ * with a previous tick's still-running copy.
+ */
+export async function runScheduler(
+  agent: Agent,
+  tasks: ScheduledTask[],
+  options: RunSchedulerOptions = {},
+): Promise<void> {
+  validateScheduledTasks(tasks);
+  const tickMs = options.tickMs ?? 60_000;
+  const now = options.now ?? (() => new Date());
+  const parsed = tasks.map((t) => ({ task: t, cron: parseCron(t.cron) }));
+  const state = createSchedulerState();
+
+  while (!options.signal?.aborted) {
+    await tickScheduler(agent, parsed, state, now(), {
+      lockDir: options.lockDir,
+      onOutcome: options.onOutcome,
+    });
+    if (options.signal?.aborted) break;
+    await sleep(tickMs, options.signal);
+  }
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) return Promise.resolve();
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    };
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+// ─── Crontab install rendering ──────────────────────────────────────────
+
+export interface GenerateCrontabOptions {
+  /**
+   * Path to the agent-do CLI binary. Defaults to `agent-do` — the
+   * user's PATH is expected to resolve it. For dev setups, pass
+   * `./node_modules/.bin/agent-do` or an absolute path.
+   */
+  cliPath?: string;
+  /**
+   * Directory the cron command should `cd` into before running the
+   * task. Defaults to the current working directory — that's almost
+   * always what the user wants because `.agent-do/` is project-local.
+   */
+  workingDir?: string;
+  /**
+   * Extra flags passed to `agent-do scheduled-tasks run <id>`. For
+   * example, `['--script', './my-agent.ts', '--yes']` when the tasks
+   * are defined in a script file.
+   */
+  extraArgs?: string[];
+  /**
+   * Directory into which per-task logs should be appended. Defaults
+   * to `.agent-do/logs`.
+   */
+  logDir?: string;
+}
+
+/**
+ * Render a crontab block that the user can paste into `crontab -e`.
+ *
+ * Each line:
+ * ```
+ * <cron> cd <workingDir> && <cliPath> scheduled-tasks run <id> [extraArgs] >> <logDir>/<id>.log 2>&1
+ * ```
+ *
+ * We emit a block of lines rather than writing the crontab directly —
+ * modifying the user's crontab is a side effect too risky for a
+ * library primitive to take on its own. The CLI wraps this with a
+ * "review these lines and paste them yourself" message.
+ */
+export function generateCrontabEntries(
+  tasks: ScheduledTask[],
+  options: GenerateCrontabOptions = {},
+): string {
+  validateScheduledTasks(tasks);
+  const cliPath = options.cliPath ?? 'agent-do';
+  const workingDir = options.workingDir ?? process.cwd();
+  const logDir = options.logDir ?? path.join('.agent-do', 'logs');
+  const extra = (options.extraArgs ?? []).map(shellQuote).join(' ');
+  const suffix = extra ? ' ' + extra : '';
+  const lines: string[] = [
+    '# agent-do scheduled tasks — generated by `scheduled-tasks install`',
+    '# Review these lines before pasting into `crontab -e`.',
+  ];
+  for (const task of tasks) {
+    const logFile = path.posix.join(logDir, `${task.id}.log`);
+    const desc = task.description ? ` # ${task.description.replace(/\r?\n/g, ' ')}` : '';
+    lines.push(
+      `${task.cron} cd ${shellQuote(workingDir)} && ${shellQuote(cliPath)} scheduled-tasks run ${shellQuote(task.id)}${suffix} >> ${shellQuote(logFile)} 2>&1${desc}`,
+    );
+  }
+  return lines.join('\n') + '\n';
+}
+
+/**
+ * Minimal POSIX shell quoting. We avoid double-quoting because that
+ * would re-interpret `$` and backticks in paths; single quotes are
+ * safe as long as the value doesn't contain a single quote itself,
+ * which we handle by escaping.
+ */
+function shellQuote(value: string): string {
+  if (value === '') return "''";
+  if (/^[a-zA-Z0-9_\-./]+$/.test(value)) return value;
+  return "'" + value.replace(/'/g, `'\\''`) + "'";
+}
+
+// ─── Helpers exported for tests / CLI ───────────────────────────────────
+
+/** True when `.agent-do/scheduler/<taskId>.lock` exists on disk. */
+export function hasLockFile(lockDir: string, taskId: string): boolean {
+  return existsSync(lockPath(lockDir, taskId));
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -280,8 +280,9 @@ export interface RoutineStore {
  *
  * - `runScheduledTask(agent, task)` — fire a single task now, acquiring
  *   its lock file to prevent overlap with an already-running copy.
- * - `runScheduler(agent, options)` — a foreground loop that ticks once
- *   per minute and fires any task whose cron expression matches.
+ * - `runScheduler(agent, tasks, options?)` — a foreground loop that
+ *   ticks once per minute and fires any task whose cron expression
+ *   matches.
  *
  * For production, most users will install a crontab entry per task
  * (via `agent-do scheduled-tasks install`) that calls

--- a/src/types.ts
+++ b/src/types.ts
@@ -265,6 +265,103 @@ export interface RoutineStore {
   recordRun(id: string): Promise<void>;
 }
 
+// ─── Scheduled tasks (#79) ──────────────────────────────────────────────
+
+/**
+ * A declarative scheduled task — a cron-driven agent run.
+ *
+ * Scheduled tasks turn agent-do into something closer to a long-running
+ * colleague: inbox sweeps every 15 min, daily prep at 2am, weekly digest
+ * on Sunday. Define them on {@link AgentConfig.scheduledTasks} and the
+ * CLI / scheduler primitive will invoke them at the right time.
+ *
+ * The runtime does **not** itself daemonise — `scheduledTasks` is a
+ * configuration primitive. Two execution surfaces use it:
+ *
+ * - `runScheduledTask(agent, task)` — fire a single task now, acquiring
+ *   its lock file to prevent overlap with an already-running copy.
+ * - `runScheduler(agent, options)` — a foreground loop that ticks once
+ *   per minute and fires any task whose cron expression matches.
+ *
+ * For production, most users will install a crontab entry per task
+ * (via `agent-do scheduled-tasks install`) that calls
+ * `agent-do scheduled-tasks run <id>` — the OS scheduler owns the
+ * cadence, agent-do owns the lock file and logging.
+ */
+export interface ScheduledTask {
+  /**
+   * Unique task ID within this agent. Used as the lock-file name and
+   * the handle for `agent-do scheduled-tasks run <id>`. Must match
+   * `/^[a-zA-Z0-9_-]+$/` so it's safe as a filename.
+   */
+  id: string;
+  /**
+   * Standard 5-field cron expression (minute, hour, day-of-month,
+   * month, day-of-week). Supports star, numeric, range, list, and
+   * step forms — see `parseCron` in `src/scheduled-tasks.ts` for the
+   * exact grammar. Numeric fields only; named months / weekdays are
+   * not supported. Sunday is `0` (Saturday is `6`); `7` is also
+   * accepted as Sunday for crontab compatibility.
+   */
+  cron: string;
+  /**
+   * Where the task's output goes:
+   *
+   * - `'isolated'` (default) — a fresh session. The task runs with no
+   *   prior conversation history; good for stateless sweeps and
+   *   digests.
+   * - `'main'` — the task's output flows into the agent's main
+   *   conversation. The caller is responsible for persisting and
+   *   replaying that history (the scheduler just runs the turn); this
+   *   is a primitive that higher-level hosts can build on.
+   */
+  sessionTarget?: 'isolated' | 'main';
+  /**
+   * How the payload is delivered to the agent:
+   *
+   * - `'agentTurn'` (default) — payload is injected as a user message,
+   *   triggering a normal agent turn. Use for "please do X" prompts.
+   * - `'systemEvent'` — payload is wrapped in a `<system-event>` envelope
+   *   and the agent is invited to respond only when there's something
+   *   to say (the "OK silence" contract). Use for heartbeat-style
+   *   wakes.
+   */
+  wakeMode?: 'agentTurn' | 'systemEvent';
+  /**
+   * The payload delivered to the agent. Strings are used verbatim;
+   * objects are serialised to JSON inside the envelope so the model
+   * sees structured data.
+   */
+  payload: string | Record<string, unknown>;
+  /**
+   * Optional per-task description, shown in `scheduled-tasks status`
+   * output.
+   */
+  description?: string;
+}
+
+/**
+ * Persisted run record for a scheduled task. One entry per task ID,
+ * updated on each run. Stored in `.agent-do/scheduler/status.json`.
+ */
+export interface ScheduledTaskStatus {
+  id: string;
+  /** ISO timestamp of the most recent run start. */
+  lastRun?: string;
+  /** ISO timestamp of the most recent run completion. */
+  lastFinished?: string;
+  /** 'success' | 'failed' | 'skipped' (lock held) | 'running'. */
+  lastStatus?: 'success' | 'failed' | 'skipped' | 'running';
+  /** Wall-clock duration of the most recent completed run. */
+  durationMs?: number;
+  /** Error message, set when `lastStatus === 'failed'`. */
+  lastError?: string;
+  /** Number of successful runs observed. */
+  successCount?: number;
+  /** Number of failed runs observed. */
+  failureCount?: number;
+}
+
 // Usage record
 export interface UsageRecord {
   timestamp: string;
@@ -515,6 +612,18 @@ export interface AgentConfig {
    * context forever" behaviour.
    */
   historyKeepWindow?: number;
+  /**
+   * Declarative scheduled tasks (#79). Each entry binds a cron expression
+   * to a payload that fires an agent run at its scheduled time.
+   *
+   * Validation happens once, at {@link createAgent} time: invalid cron
+   * expressions, duplicate IDs, and unsafe task IDs throw synchronously
+   * so misconfiguration fails loud. The runtime itself is optional —
+   * declaring tasks does not automatically start a scheduler. Use
+   * `runScheduler(agent, ...)` or install crontab entries via
+   * `agent-do scheduled-tasks install` to actually drive them.
+   */
+  scheduledTasks?: ScheduledTask[];
   /**
    * Debug / observability hooks (#72). See {@link DebugConfig}.
    *

--- a/tests/cli-args.test.ts
+++ b/tests/cli-args.test.ts
@@ -223,7 +223,20 @@ describe('parseArgs', () => {
     expect(args.command).toBe('scheduled-tasks');
     expect(args.schedulerAction).toBe('run');
     expect(args.schedulerTaskId).toBe('ea-sweep');
-    expect(args.file).toBeUndefined();
+    // For `scheduled-tasks`, `--script <path>` consumes the next argv
+    // as the script path. The legacy boolean form is kept for `run`.
+    expect(args.file).toBe('./agent.ts');
+    expect(args.script).toBe(true);
+    expect(args.yes).toBe(true);
+  });
+
+  it('keeps --script as a boolean for `run` (legacy form)', () => {
+    // `agent-do run ./file.ts --script -y` — the positional is the
+    // file, `--script` is the "yes I know" confirmation flag.
+    const args = parseArgs(['run', './agent.ts', '--script', '-y']);
+    expect(args.command).toBe('run');
+    expect(args.file).toBe('./agent.ts');
+    expect(args.script).toBe(true);
   });
 
   it('recognizes scheduled-tasks start / status / install', () => {

--- a/tests/cli-args.test.ts
+++ b/tests/cli-args.test.ts
@@ -218,6 +218,30 @@ describe('parseArgs', () => {
     expect(args.command).toBe('list');
   });
 
+  it('recognizes scheduled-tasks run subcommand', () => {
+    const args = parseArgs(['scheduled-tasks', 'run', 'ea-sweep', '--script', './agent.ts', '--yes']);
+    expect(args.command).toBe('scheduled-tasks');
+    expect(args.schedulerAction).toBe('run');
+    expect(args.schedulerTaskId).toBe('ea-sweep');
+    expect(args.file).toBeUndefined();
+  });
+
+  it('recognizes scheduled-tasks start / status / install', () => {
+    for (const action of ['start', 'status', 'install'] as const) {
+      const args = parseArgs(['scheduled-tasks', action]);
+      expect(args.command).toBe('scheduled-tasks');
+      expect(args.schedulerAction).toBe(action);
+    }
+  });
+
+  it('rejects scheduled-tasks with no action', () => {
+    expect(() => parseArgs(['scheduled-tasks'])).toThrow(/Usage: npx agent-do scheduled-tasks/);
+  });
+
+  it('rejects scheduled-tasks run without a task id', () => {
+    expect(() => parseArgs(['scheduled-tasks', 'run'])).toThrow(/scheduled-tasks run <task-id>/);
+  });
+
   it('parses --exclude as comma-separated patterns (repeatable)', () => {
     const args = parseArgs(['--exclude', 'secrets/**,*.cred', '--exclude', 'vendor/**']);
     expect(args.exclude).toEqual(['secrets/**', '*.cred', 'vendor/**']);

--- a/tests/scheduled-tasks.test.ts
+++ b/tests/scheduled-tasks.test.ts
@@ -1,0 +1,572 @@
+/**
+ * Tests for scheduled tasks (#79) — cron parsing, lock file handling,
+ * per-task runtime, and the scheduler loop.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, writeFileSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  validateScheduledTasks,
+  parseCron,
+  cronMatches,
+  acquireLock,
+  releaseLock,
+  readLock,
+  hasLockFile,
+  readStatus,
+  runScheduledTask,
+  runScheduler,
+  buildScheduledTaskPrompt,
+  generateCrontabEntries,
+  tickScheduler,
+  createSchedulerState,
+} from '../src/scheduled-tasks.js';
+import type { Agent, ScheduledTask } from '../src/types.js';
+
+// ─── Helpers ────────────────────────────────────────────────────────────
+
+function mockAgent(run: (task: string) => Promise<string> | string): Agent {
+  return {
+    id: 'test-agent',
+    name: 'Test Agent',
+    async run(task: string) {
+      return Promise.resolve(run(task));
+    },
+    stream() {
+      throw new Error('stream() not used in these tests');
+    },
+    abort() {
+      /* no-op */
+    },
+  };
+}
+
+let tmpDir: string;
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'agent-do-sched-'));
+});
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ─── Validation ─────────────────────────────────────────────────────────
+
+describe('validateScheduledTasks', () => {
+  it('accepts a minimal valid task list', () => {
+    expect(() =>
+      validateScheduledTasks([
+        { id: 'a', cron: '*/15 * * * *', payload: 'hi' },
+      ]),
+    ).not.toThrow();
+  });
+
+  it('rejects duplicate IDs', () => {
+    expect(() =>
+      validateScheduledTasks([
+        { id: 'a', cron: '* * * * *', payload: 'x' },
+        { id: 'a', cron: '* * * * *', payload: 'y' },
+      ]),
+    ).toThrow(/Duplicate scheduled task id/);
+  });
+
+  it('rejects unsafe IDs', () => {
+    expect(() =>
+      validateScheduledTasks([
+        { id: '../escape', cron: '* * * * *', payload: 'x' },
+      ]),
+    ).toThrow(/Invalid scheduled task id/);
+  });
+
+  it('rejects invalid cron expressions', () => {
+    expect(() =>
+      validateScheduledTasks([{ id: 'a', cron: 'bogus', payload: 'x' }]),
+    ).toThrow(/Invalid cron/);
+  });
+
+  it('rejects unknown sessionTarget / wakeMode', () => {
+    expect(() =>
+      validateScheduledTasks([
+        // @ts-expect-error — testing invalid input
+        { id: 'a', cron: '* * * * *', payload: 'x', sessionTarget: 'new-window' },
+      ]),
+    ).toThrow(/sessionTarget/);
+    expect(() =>
+      validateScheduledTasks([
+        // @ts-expect-error — testing invalid input
+        { id: 'a', cron: '* * * * *', payload: 'x', wakeMode: 'nope' },
+      ]),
+    ).toThrow(/wakeMode/);
+  });
+
+  it('rejects non-string, non-object payloads', () => {
+    expect(() =>
+      validateScheduledTasks([
+        // @ts-expect-error — testing invalid input
+        { id: 'a', cron: '* * * * *', payload: 42 },
+      ]),
+    ).toThrow(/payload/);
+    expect(() =>
+      validateScheduledTasks([
+        // @ts-expect-error — testing invalid input
+        { id: 'a', cron: '* * * * *', payload: [1, 2, 3] },
+      ]),
+    ).toThrow(/payload/);
+  });
+});
+
+// ─── Cron parser ────────────────────────────────────────────────────────
+
+describe('parseCron', () => {
+  it('accepts all-stars', () => {
+    const c = parseCron('* * * * *');
+    expect(c.minute.size).toBe(60);
+    expect(c.hour.size).toBe(24);
+    expect(c.dayOfMonthRestricted).toBe(false);
+    expect(c.dayOfWeekRestricted).toBe(false);
+  });
+
+  it('parses a simple step expression', () => {
+    const c = parseCron('*/15 * * * *');
+    expect([...c.minute].sort((a, b) => a - b)).toEqual([0, 15, 30, 45]);
+  });
+
+  it('parses range + step + list', () => {
+    const c = parseCron('*/10 8-21 1,15 * *');
+    expect([...c.minute].sort((a, b) => a - b)).toEqual([0, 10, 20, 30, 40, 50]);
+    expect([...c.hour].sort((a, b) => a - b)).toEqual([
+      8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
+    ]);
+    expect([...c.dayOfMonth].sort((a, b) => a - b)).toEqual([1, 15]);
+    expect(c.dayOfMonthRestricted).toBe(true);
+  });
+
+  it('collapses Sunday 7 to 0', () => {
+    const c = parseCron('0 0 * * 7');
+    expect(c.dayOfWeek.has(0)).toBe(true);
+    expect(c.dayOfWeek.has(7)).toBe(false);
+  });
+
+  it('rejects wrong field count', () => {
+    expect(() => parseCron('* * * *')).toThrow(/expected 5/);
+  });
+
+  it('rejects inverted ranges', () => {
+    expect(() => parseCron('10-5 * * * *')).toThrow(/low bound/);
+  });
+
+  it('rejects out-of-range values', () => {
+    expect(() => parseCron('60 * * * *')).toThrow(/minute/);
+    expect(() => parseCron('* 24 * * *')).toThrow(/hour/);
+    expect(() => parseCron('* * 32 * *')).toThrow(/day-of-month/);
+    expect(() => parseCron('* * * 13 *')).toThrow(/month/);
+  });
+
+  it('rejects non-numeric fields', () => {
+    expect(() => parseCron('MON * * * *')).toThrow();
+  });
+
+  it('parses a numeric-value + step as "from value, every step up to max"', () => {
+    // `5/15` in the minute field → 5, 20, 35, 50
+    const c = parseCron('5/15 * * * *');
+    expect([...c.minute].sort((a, b) => a - b)).toEqual([5, 20, 35, 50]);
+  });
+});
+
+describe('cronMatches', () => {
+  it('matches every minute with all-stars', () => {
+    const c = parseCron('* * * * *');
+    expect(cronMatches(c, new Date(2026, 3, 21, 10, 30))).toBe(true);
+  });
+
+  it('matches a specific minute', () => {
+    const c = parseCron('*/15 * * * *');
+    expect(cronMatches(c, new Date(2026, 3, 21, 10, 0))).toBe(true);
+    expect(cronMatches(c, new Date(2026, 3, 21, 10, 15))).toBe(true);
+    expect(cronMatches(c, new Date(2026, 3, 21, 10, 7))).toBe(false);
+  });
+
+  it('applies hour restrictions', () => {
+    const c = parseCron('0 8-21 * * *');
+    expect(cronMatches(c, new Date(2026, 3, 21, 8, 0))).toBe(true);
+    expect(cronMatches(c, new Date(2026, 3, 21, 22, 0))).toBe(false);
+    expect(cronMatches(c, new Date(2026, 3, 21, 7, 0))).toBe(false);
+  });
+
+  it('ORs day-of-month and day-of-week when both are restricted', () => {
+    // "On the 1st of each month OR on Mondays, at 9am"
+    const c = parseCron('0 9 1 * 1');
+    // 2026-04-06 is a Monday, not the 1st — should still match.
+    expect(cronMatches(c, new Date(2026, 3, 6, 9, 0))).toBe(true);
+    // 2026-04-01 is a Wednesday — 1st of month matches.
+    expect(cronMatches(c, new Date(2026, 3, 1, 9, 0))).toBe(true);
+    // 2026-04-07 is a Tuesday, not the 1st — should NOT match.
+    expect(cronMatches(c, new Date(2026, 3, 7, 9, 0))).toBe(false);
+  });
+
+  it('ANDs when only one day field is restricted (standard cron)', () => {
+    // Only day-of-week restricted: Mondays only.
+    const c = parseCron('0 9 * * 1');
+    expect(cronMatches(c, new Date(2026, 3, 6, 9, 0))).toBe(true); // Mon
+    expect(cronMatches(c, new Date(2026, 3, 7, 9, 0))).toBe(false); // Tue
+  });
+});
+
+// ─── Lock file ──────────────────────────────────────────────────────────
+
+describe('lock files', () => {
+  it('acquires and releases a lock', async () => {
+    expect(await acquireLock(tmpDir, 'task1')).toBe(true);
+    expect(hasLockFile(tmpDir, 'task1')).toBe(true);
+    const rec = await readLock(tmpDir, 'task1');
+    expect(rec?.pid).toBe(process.pid);
+    await releaseLock(tmpDir, 'task1');
+    expect(hasLockFile(tmpDir, 'task1')).toBe(false);
+  });
+
+  it('refuses to double-acquire while lock is held by live process', async () => {
+    expect(await acquireLock(tmpDir, 'task1')).toBe(true);
+    // Same-process re-acquire = refuse. The lock encodes process.pid and
+    // it's this process, so the liveness probe returns true.
+    expect(await acquireLock(tmpDir, 'task1')).toBe(false);
+    await releaseLock(tmpDir, 'task1');
+  });
+
+  it('breaks a stale lock pointing at a dead PID', async () => {
+    // Use a guaranteed-dead PID. Even if a hypothetical race matched it,
+    // the lock file includes a hostname and PID 2^31 won't exist.
+    const lockFile = join(tmpDir, 'task1.lock');
+    writeFileSync(
+      lockFile,
+      JSON.stringify({
+        taskId: 'task1',
+        pid: 2_147_483_646,
+        host: require('node:os').hostname(),
+        startedAt: new Date().toISOString(),
+      }),
+    );
+    expect(await acquireLock(tmpDir, 'task1')).toBe(true);
+    const rec = await readLock(tmpDir, 'task1');
+    expect(rec?.pid).toBe(process.pid);
+  });
+
+  it('refuses to break a lock held on a different host', async () => {
+    // Simulates a shared filesystem / NFS situation — a process on
+    // another machine holds the lock. We can't probe liveness remotely,
+    // so we conservatively refuse to break it.
+    const lockFile = join(tmpDir, 'task1.lock');
+    writeFileSync(
+      lockFile,
+      JSON.stringify({
+        taskId: 'task1',
+        pid: process.pid,
+        host: 'some-other-machine',
+        startedAt: new Date().toISOString(),
+      }),
+    );
+    expect(await acquireLock(tmpDir, 'task1')).toBe(false);
+  });
+
+  it('treats malformed lock files as stale', async () => {
+    const lockFile = join(tmpDir, 'task1.lock');
+    writeFileSync(lockFile, 'not-json');
+    // Malformed → same-host same-pid fallthrough isn't triggered (parse
+    // returns null), but the lock file already exists so `wx` fails —
+    // the function then consults readLock, which returns null, and
+    // declines to break it. That's the safe default.
+    expect(await acquireLock(tmpDir, 'task1')).toBe(false);
+  });
+
+  it('release is idempotent', async () => {
+    await expect(releaseLock(tmpDir, 'nonexistent')).resolves.toBeUndefined();
+  });
+});
+
+// ─── Prompt rendering ───────────────────────────────────────────────────
+
+describe('buildScheduledTaskPrompt', () => {
+  it('uses the string payload verbatim in agentTurn mode', () => {
+    const out = buildScheduledTaskPrompt({
+      id: 'x',
+      cron: '* * * * *',
+      payload: 'Do the thing.',
+    });
+    expect(out).toBe('Do the thing.');
+  });
+
+  it('stringifies object payloads', () => {
+    const out = buildScheduledTaskPrompt({
+      id: 'x',
+      cron: '* * * * *',
+      payload: { event: 'daily-prep', ts: 1 },
+    });
+    expect(out).toContain('"event": "daily-prep"');
+  });
+
+  it('wraps in a system-event envelope in systemEvent mode', () => {
+    const out = buildScheduledTaskPrompt({
+      id: 'ea-sweep',
+      cron: '*/15 * * * *',
+      payload: { event: 'inbox-sweep' },
+      wakeMode: 'systemEvent',
+    });
+    expect(out).toContain('<system-event task-id="ea-sweep"');
+    expect(out).toContain('</system-event>');
+    expect(out).toContain('reply with a single token `OK`');
+  });
+});
+
+// ─── runScheduledTask ───────────────────────────────────────────────────
+
+describe('runScheduledTask', () => {
+  it('runs the agent and records success status', async () => {
+    const called: string[] = [];
+    const agent = mockAgent((t) => {
+      called.push(t);
+      return 'done';
+    });
+    const outcome = await runScheduledTask(
+      agent,
+      { id: 'task1', cron: '* * * * *', payload: 'hello' },
+      { lockDir: tmpDir },
+    );
+    expect(outcome.status).toBe('success');
+    expect(called).toEqual(['hello']);
+    // Lock released
+    expect(hasLockFile(tmpDir, 'task1')).toBe(false);
+    const status = await readStatus(tmpDir);
+    expect(status.task1.lastStatus).toBe('success');
+    expect(status.task1.successCount).toBe(1);
+    expect(status.task1.durationMs).toBeTypeOf('number');
+  });
+
+  it('returns skipped when lock is already held', async () => {
+    await acquireLock(tmpDir, 'task1');
+    const agent = mockAgent(() => {
+      throw new Error('agent should NOT have run');
+    });
+    const outcome = await runScheduledTask(
+      agent,
+      { id: 'task1', cron: '* * * * *', payload: 'hi' },
+      { lockDir: tmpDir },
+    );
+    expect(outcome.status).toBe('skipped');
+    const status = await readStatus(tmpDir);
+    expect(status.task1.lastStatus).toBe('skipped');
+    await releaseLock(tmpDir, 'task1');
+  });
+
+  it('records failure and still releases the lock', async () => {
+    const agent = mockAgent(() => {
+      throw new Error('boom');
+    });
+    const outcome = await runScheduledTask(
+      agent,
+      { id: 'task1', cron: '* * * * *', payload: 'x' },
+      { lockDir: tmpDir },
+    );
+    expect(outcome.status).toBe('failed');
+    if (outcome.status === 'failed') {
+      expect(outcome.error).toBe('boom');
+    }
+    expect(hasLockFile(tmpDir, 'task1')).toBe(false);
+    const status = await readStatus(tmpDir);
+    expect(status.task1.lastStatus).toBe('failed');
+    expect(status.task1.lastError).toBe('boom');
+    expect(status.task1.failureCount).toBe(1);
+  });
+
+  it('rethrows when swallowErrors is false', async () => {
+    const agent = mockAgent(() => {
+      throw new Error('boom');
+    });
+    await expect(
+      runScheduledTask(
+        agent,
+        { id: 'task1', cron: '* * * * *', payload: 'x' },
+        { lockDir: tmpDir, swallowErrors: false },
+      ),
+    ).rejects.toThrow(/boom/);
+    // Lock should still be released despite the throw.
+    expect(hasLockFile(tmpDir, 'task1')).toBe(false);
+  });
+
+  it('recovers after crash — a stale lock does not block the next run', async () => {
+    // Simulate a crashed run by writing a lock with a dead PID.
+    writeFileSync(
+      join(tmpDir, 'task1.lock'),
+      JSON.stringify({
+        taskId: 'task1',
+        pid: 2_147_483_646,
+        host: require('node:os').hostname(),
+        startedAt: new Date().toISOString(),
+      }),
+    );
+    const agent = mockAgent(() => 'recovered');
+    const outcome = await runScheduledTask(
+      agent,
+      { id: 'task1', cron: '* * * * *', payload: 'x' },
+      { lockDir: tmpDir },
+    );
+    expect(outcome.status).toBe('success');
+  });
+});
+
+// ─── Scheduler tick ─────────────────────────────────────────────────────
+
+describe('tickScheduler', () => {
+  it('fires a task when its cron matches', async () => {
+    const runs: string[] = [];
+    const agent = mockAgent((t) => {
+      runs.push(t);
+      return 'ok';
+    });
+    const tasks = [{ id: 'every-min', cron: '* * * * *', payload: 'tick' } as ScheduledTask];
+    const parsed = tasks.map((task) => ({ task, cron: parseCron(task.cron) }));
+    const state = createSchedulerState();
+    const outcomes = await tickScheduler(agent, parsed, state, new Date(2026, 3, 21, 10, 0, 0), {
+      lockDir: tmpDir,
+    });
+    expect(outcomes).toHaveLength(1);
+    expect(outcomes[0].status).toBe('success');
+    expect(runs).toEqual(['tick']);
+  });
+
+  it('only fires a task once per minute across multiple ticks', async () => {
+    const runs: string[] = [];
+    const agent = mockAgent((t) => {
+      runs.push(t);
+      return 'ok';
+    });
+    const tasks = [{ id: 'every-min', cron: '* * * * *', payload: 'tick' } as ScheduledTask];
+    const parsed = tasks.map((task) => ({ task, cron: parseCron(task.cron) }));
+    const state = createSchedulerState();
+    // Three ticks within the same wall-clock minute → one run.
+    await tickScheduler(agent, parsed, state, new Date(2026, 3, 21, 10, 0, 0), { lockDir: tmpDir });
+    await tickScheduler(agent, parsed, state, new Date(2026, 3, 21, 10, 0, 30), { lockDir: tmpDir });
+    await tickScheduler(agent, parsed, state, new Date(2026, 3, 21, 10, 0, 59), { lockDir: tmpDir });
+    expect(runs.length).toBe(1);
+    // Crossing the minute boundary fires again.
+    await tickScheduler(agent, parsed, state, new Date(2026, 3, 21, 10, 1, 0), { lockDir: tmpDir });
+    expect(runs.length).toBe(2);
+  });
+
+  it('skips tasks whose cron does not match the current minute', async () => {
+    const runs: string[] = [];
+    const agent = mockAgent((t) => {
+      runs.push(t);
+      return 'ok';
+    });
+    const tasks = [{ id: 'even', cron: '*/2 * * * *', payload: 'even-tick' } as ScheduledTask];
+    const parsed = tasks.map((task) => ({ task, cron: parseCron(task.cron) }));
+    const state = createSchedulerState();
+    await tickScheduler(agent, parsed, state, new Date(2026, 3, 21, 10, 1, 0), { lockDir: tmpDir });
+    expect(runs.length).toBe(0);
+    await tickScheduler(agent, parsed, state, new Date(2026, 3, 21, 10, 2, 0), { lockDir: tmpDir });
+    expect(runs.length).toBe(1);
+  });
+
+  it('invokes onOutcome for each fired task', async () => {
+    const agent = mockAgent(() => 'ok');
+    const tasks = [{ id: 't', cron: '* * * * *', payload: 'x' } as ScheduledTask];
+    const parsed = tasks.map((task) => ({ task, cron: parseCron(task.cron) }));
+    const state = createSchedulerState();
+    const seen: string[] = [];
+    await tickScheduler(agent, parsed, state, new Date(2026, 3, 21, 10, 0, 0), {
+      lockDir: tmpDir,
+      onOutcome: (task, outcome) => seen.push(`${task.id}:${outcome.status}`),
+    });
+    expect(seen).toEqual(['t:success']);
+  });
+});
+
+describe('runScheduler', () => {
+  it('exits promptly when the abort signal is already set', async () => {
+    const agent = mockAgent(() => 'ok');
+    const tasks: ScheduledTask[] = [
+      { id: 'every-min', cron: '* * * * *', payload: 'tick' },
+    ];
+    const controller = new AbortController();
+    controller.abort();
+    // Should return immediately — does not attempt any task runs.
+    await expect(
+      runScheduler(agent, tasks, {
+        lockDir: tmpDir,
+        tickMs: 1000,
+        signal: controller.signal,
+      }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+// ─── generateCrontabEntries ─────────────────────────────────────────────
+
+describe('generateCrontabEntries', () => {
+  it('renders one line per task', () => {
+    const out = generateCrontabEntries(
+      [
+        { id: 'ea-sweep', cron: '*/15 8-21 * * *', payload: 'sweep' },
+        { id: 'daily-prep', cron: '0 2 * * *', payload: 'prep', description: 'Daily prep' },
+      ],
+      {
+        cliPath: 'agent-do',
+        workingDir: '/home/me/project',
+        extraArgs: ['--script', './agent.ts', '--yes'],
+      },
+    );
+    const lines = out.trim().split('\n');
+    // Header + 2 tasks
+    expect(lines.length).toBeGreaterThanOrEqual(4);
+    const eaLine = lines.find((l) => l.includes('ea-sweep'))!;
+    expect(eaLine).toContain('*/15 8-21 * * *');
+    expect(eaLine).toContain('scheduled-tasks run ea-sweep');
+    expect(eaLine).toContain('--script ./agent.ts');
+    expect(eaLine).toContain('.agent-do/logs/ea-sweep.log');
+    const dailyLine = lines.find((l) => l.includes('daily-prep'))!;
+    expect(dailyLine).toContain('# Daily prep');
+  });
+
+  it('validates tasks before rendering', () => {
+    expect(() =>
+      generateCrontabEntries([{ id: '../bad', cron: '* * * * *', payload: 'x' }]),
+    ).toThrow(/Invalid scheduled task id/);
+  });
+});
+
+// ─── createAgent integration ────────────────────────────────────────────
+
+describe('createAgent scheduledTasks wiring', () => {
+  it('rejects a bad cron at createAgent time', async () => {
+    const { createAgent } = await import('../src/agent.js');
+    const { createMockModel } = await import('../src/testing/index.js');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const model = createMockModel({ responses: [{ text: 'x' }] }) as any;
+    expect(() =>
+      createAgent({
+        id: 'a',
+        name: 'A',
+        model,
+        scheduledTasks: [{ id: 'bad', cron: 'nope', payload: 'x' }],
+      }),
+    ).toThrow(/Invalid cron/);
+  });
+
+  it('accepts a valid scheduledTasks config', async () => {
+    const { createAgent } = await import('../src/agent.js');
+    const { createMockModel } = await import('../src/testing/index.js');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const model = createMockModel({ responses: [{ text: 'x' }] }) as any;
+    expect(() =>
+      createAgent({
+        id: 'a',
+        name: 'A',
+        model,
+        scheduledTasks: [
+          { id: 'ok', cron: '*/15 * * * *', payload: 'hi' },
+        ],
+      }),
+    ).not.toThrow();
+  });
+});

--- a/tests/scheduled-tasks.test.ts
+++ b/tests/scheduled-tasks.test.ts
@@ -5,7 +5,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtempSync, rmSync, existsSync, writeFileSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { hostname, tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import {
@@ -243,7 +243,7 @@ describe('lock files', () => {
       JSON.stringify({
         taskId: 'task1',
         pid: 2_147_483_646,
-        host: require('node:os').hostname(),
+        host: hostname(),
         startedAt: new Date().toISOString(),
       }),
     );
@@ -269,14 +269,43 @@ describe('lock files', () => {
     expect(await acquireLock(tmpDir, 'task1')).toBe(false);
   });
 
-  it('treats malformed lock files as stale', async () => {
+  it('refuses to break a malformed lock file', async () => {
+    // Defensive default (docs + code review feedback): if we can't
+    // parse the lock record, we can't prove the holder is dead, so
+    // we conservatively refuse to break it. An operator can
+    // manually `rm .agent-do/scheduler/<id>.lock` when they know
+    // it's safe.
     const lockFile = join(tmpDir, 'task1.lock');
     writeFileSync(lockFile, 'not-json');
-    // Malformed → same-host same-pid fallthrough isn't triggered (parse
-    // returns null), but the lock file already exists so `wx` fails —
-    // the function then consults readLock, which returns null, and
-    // declines to break it. That's the safe default.
     expect(await acquireLock(tmpDir, 'task1')).toBe(false);
+  });
+
+  it('rejects path-traversal task IDs in lock primitives', async () => {
+    // Defence in depth: even if a caller bypasses
+    // validateScheduledTasks, the low-level primitives validate the
+    // task id so `../../etc/passwd` can't escape lockDir.
+    await expect(acquireLock(tmpDir, '../escape')).rejects.toThrow(/taskId must match/);
+    await expect(releaseLock(tmpDir, '../escape')).rejects.toThrow(/taskId must match/);
+  });
+
+  it('recovers atomically when two concurrent acquirers race a stale lock', async () => {
+    // Two concurrent acquires against the same stale lock should
+    // serialise via `open('wx')` — exactly one wins.
+    writeFileSync(
+      join(tmpDir, 'task1.lock'),
+      JSON.stringify({
+        taskId: 'task1',
+        pid: 2_147_483_646,
+        host: hostname(),
+        startedAt: new Date().toISOString(),
+      }),
+    );
+    const [a, b] = await Promise.all([
+      acquireLock(tmpDir, 'task1'),
+      acquireLock(tmpDir, 'task1'),
+    ]);
+    // Exactly one winner.
+    expect([a, b].filter(Boolean).length).toBe(1);
   });
 
   it('release is idempotent', async () => {
@@ -400,7 +429,7 @@ describe('runScheduledTask', () => {
       JSON.stringify({
         taskId: 'task1',
         pid: 2_147_483_646,
-        host: require('node:os').hostname(),
+        host: hostname(),
         startedAt: new Date().toISOString(),
       }),
     );
@@ -466,6 +495,31 @@ describe('tickScheduler', () => {
     expect(runs.length).toBe(0);
     await tickScheduler(agent, parsed, state, new Date(2026, 3, 21, 10, 2, 0), { lockDir: tmpDir });
     expect(runs.length).toBe(1);
+  });
+
+  it('serialises concurrent status updates without dropping counters', async () => {
+    // Regression guard for the review feedback: `updateStatus` does a
+    // read-modify-write of the shared `status.json`; without a per-
+    // `lockDir` async mutex, two parallel runs can both read the old
+    // map and the last writer wins, losing a successCount increment.
+    const agent = mockAgent(() => 'ok');
+    // Fan three tasks in parallel, all firing on the same tick.
+    const tasks: { task: ScheduledTask; cron: ReturnType<typeof parseCron> }[] = [
+      { id: 'a', cron: '* * * * *', payload: 'A' },
+      { id: 'b', cron: '* * * * *', payload: 'B' },
+      { id: 'c', cron: '* * * * *', payload: 'C' },
+    ].map((task) => ({ task, cron: parseCron(task.cron) }));
+    const state = createSchedulerState();
+    await tickScheduler(agent, tasks, state, new Date(2026, 3, 21, 10, 0, 0), {
+      lockDir: tmpDir,
+    });
+    const status = await readStatus(tmpDir);
+    // All three tasks recorded one successful run each — if the
+    // read-modify-write raced, one or more of these would be missing
+    // or have successCount: 0.
+    expect(status.a?.successCount).toBe(1);
+    expect(status.b?.successCount).toBe(1);
+    expect(status.c?.successCount).toBe(1);
   });
 
   it('invokes onOutcome for each fired task', async () => {


### PR DESCRIPTION
Closes #79.

## Summary

Adds a declarative `scheduledTasks` primitive to `AgentConfig` plus a
runtime + CLI for firing cron-driven agent runs with lock-file
concurrency. Picking the `scheduledTasks` name from the issue's open
question (most descriptive, matches OS convention).

```ts
createAgent({
  scheduledTasks: [
    { id: 'ea-sweep',   cron: '*/15 8-21 * * *', payload: 'Run the inbox-triage routine.' },
    { id: 'daily-prep', cron: '0 2 * * *', sessionTarget: 'isolated',
      wakeMode: 'systemEvent', payload: { event: 'daily-prep' } },
  ],
});
```

Validation happens at `createAgent` time — bad cron / duplicate IDs /
unsafe IDs throw synchronously so misconfiguration fails loud.

## What's in the box

### Library (`agent-do` main export)

- `runScheduledTask(agent, task, options?)` — fire one task now.
  Acquires `.agent-do/scheduler/<id>.lock`; returns
  `{ status: 'success' | 'skipped' | 'failed', ... }`. Stale locks
  (dead PID, same host) are broken automatically; foreign-host locks
  are left alone (shared-filesystem safety).
- `runScheduler(agent, tasks, options?)` — foreground loop that ticks
  every `tickMs` (default 60s) and fires matching tasks.
- `tickScheduler` / `createSchedulerState` — per-tick core used by
  `runScheduler`; exposed so tests and custom hosts can drive ticks
  without a timer loop.
- `parseCron` / `cronMatches` — minimal 5-field cron evaluator.
  Supports star / numeric / range / list / step forms; numeric fields
  only (no `JAN`/`MON`), Sunday collapses 7→0.
- `acquireLock` / `releaseLock` / `readLock` / `hasLockFile` — lock
  primitives.
- `readStatus` — per-task last-run / duration / success+failure
  counts.
- `buildScheduledTaskPrompt` — string-or-object payload + wake mode
  rendering (including the "OK silence" contract for `systemEvent`).
- `generateCrontabEntries` — renders a crontab block ready to paste
  into `crontab -e`. We deliberately don't touch the user's crontab.

### CLI

```
agent-do scheduled-tasks run <id> --script ./agent.ts --yes
agent-do scheduled-tasks start    --script ./agent.ts --yes
agent-do scheduled-tasks status  [--script ./agent.ts]
agent-do scheduled-tasks install  --script ./agent.ts --yes
```

`run` returns exit 75 (EX_TEMPFAIL) when the lock is held so cron
retries on the next tick. `install` prints the crontab block; user
reviews and pastes.

## Tests

- Cron parsing: star/numeric/range/list/step, Sunday 7→0, inverted
  ranges rejected, out-of-range values rejected, non-numeric tokens
  rejected, `5/15` syntax (from value, every step up to max).
- `cronMatches`: hour restrictions; standard "DOM AND DOW when only
  one is restricted, OR when both are" semantics.
- Lock acquire/release; refuses double-acquire from a live PID; breaks
  stale same-host locks; refuses to break foreign-host locks;
  malformed lock files don't silently get overwritten; release is
  idempotent.
- `runScheduledTask`: success/skipped/failed paths, lock always
  released (including when `swallowErrors: false` rethrows), status
  file carries the failure + counts, crash recovery via stale-lock
  break.
- Scheduler tick: fires matching tasks, only once per minute across
  multiple intra-minute ticks, skips non-matching minutes, invokes
  `onOutcome`.
- Integration: `createAgent` throws on bad cron; accepts valid config.
- CLI args: `scheduled-tasks run <id>` / `start` / `status` /
  `install` parsing; rejects missing action / missing task id.

## Acceptance criteria (from #79)

- [x] Config field (`scheduledTasks`) validated at `createAgent` time
- [x] Lock-file handling prevents overlaps
- [x] `agent-do scheduled-tasks run <id>` executes one task
- [x] `agent-do scheduled-tasks install` generates crontab entries
- [x] `agent-do scheduled-tasks status` shows last-run times per task
- [x] Tests for: scheduling, lock acquisition/release, crash recovery
  (stale lock)

## Docs

- README gets a Scheduled Tasks section with the one-shot +
  crontab-install flows.
- `llms.txt` gets a Scheduled Tasks entry listing all new exports.
- `examples/16-scheduled-tasks.ts` runs standalone (uses a mock model
  so no API key needed) and demonstrates: one-shot execution, cron
  match preview, crontab rendering.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 670 tests pass (35 files)
- [x] `npx tsx examples/16-scheduled-tasks.ts` runs standalone
- [ ] Manual: install a crontab entry pointing at a real agent, verify
  logs land in `.agent-do/logs/<id>.log` and `status.json` updates
- [ ] Manual: run two copies of `scheduled-tasks run <id>` in parallel,
  confirm second returns exit 75 with "lock held" message