### PR TITLE
Update demo default model IDs to latest (April 2026)

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -23,10 +23,10 @@ Then install each demo's dependencies (using subshells so your working directory
 Each demo auto-detects which AI SDK provider to use from the environment. Set an API key for Anthropic, Google, or OpenAI:
 
 ```bash
-export ANTHROPIC_API_KEY=sk-ant-...              # picks Anthropic (claude-sonnet-4-6 / claude-haiku-4-5)
-export GOOGLE_GENERATIVE_AI_API_KEY=...          # picks Google    (gemini-2.5-pro   / gemini-2.5-flash)
+export ANTHROPIC_API_KEY=sk-ant-...              # picks Anthropic (claude-opus-4-7         / claude-haiku-4-5)
+export GOOGLE_GENERATIVE_AI_API_KEY=...          # picks Google    (gemini-3.1-pro-preview  / gemini-3.1-flash-lite-preview)
 #   …or GOOGLE_API_KEY / GEMINI_API_KEY, both accepted as aliases
-export OPENAI_API_KEY=sk-...                     # picks OpenAI    (gpt-5            / gpt-5-mini)
+export OPENAI_API_KEY=sk-...                     # picks OpenAI    (gpt-5.4                 / gpt-5.4-mini)
 ```
 
 If more than one is set, the demos pick **anthropic → google → openai** in that order. To force a specific provider (useful when you have multiple keys set), set `DEMO_PROVIDER`:
@@ -38,7 +38,7 @@ DEMO_PROVIDER=google npm start
 You can also override the default model IDs for a run:
 
 ```bash
-DEMO_MASTER_MODEL=claude-opus-4-6 DEMO_WORKER_MODEL=claude-sonnet-4-6 npm start
+DEMO_MASTER_MODEL=claude-opus-4-7 DEMO_WORKER_MODEL=claude-sonnet-4-6 npm start
 ```
 
 ## Demos

--- a/demos/assistant/provider.ts
+++ b/demos/assistant/provider.ts
@@ -37,9 +37,9 @@ export interface ResolvedProvider {
 }
 
 const DEFAULTS: Record<Provider, { master: string; worker: string }> = {
-  anthropic: { master: 'claude-sonnet-4-6', worker: 'claude-haiku-4-5' },
-  google: { master: 'gemini-2.5-pro', worker: 'gemini-2.5-flash' },
-  openai: { master: 'gpt-5', worker: 'gpt-5-mini' },
+  anthropic: { master: 'claude-opus-4-7', worker: 'claude-haiku-4-5' },
+  google: { master: 'gemini-3.1-pro-preview', worker: 'gemini-3.1-flash-lite-preview' },
+  openai: { master: 'gpt-5.4', worker: 'gpt-5.4-mini' },
 };
 
 /**

--- a/demos/chief-of-staff/provider.ts
+++ b/demos/chief-of-staff/provider.ts
@@ -37,9 +37,9 @@ export interface ResolvedProvider {
 }
 
 const DEFAULTS: Record<Provider, { master: string; worker: string }> = {
-  anthropic: { master: 'claude-sonnet-4-6', worker: 'claude-haiku-4-5' },
-  google: { master: 'gemini-2.5-pro', worker: 'gemini-2.5-flash' },
-  openai: { master: 'gpt-5', worker: 'gpt-5-mini' },
+  anthropic: { master: 'claude-opus-4-7', worker: 'claude-haiku-4-5' },
+  google: { master: 'gemini-3.1-pro-preview', worker: 'gemini-3.1-flash-lite-preview' },
+  openai: { master: 'gpt-5.4', worker: 'gpt-5.4-mini' },
 };
 
 /**

--- a/demos/code-reviewer/provider.ts
+++ b/demos/code-reviewer/provider.ts
@@ -37,9 +37,9 @@ export interface ResolvedProvider {
 }
 
 const DEFAULTS: Record<Provider, { master: string; worker: string }> = {
-  anthropic: { master: 'claude-sonnet-4-6', worker: 'claude-haiku-4-5' },
-  google: { master: 'gemini-2.5-pro', worker: 'gemini-2.5-flash' },
-  openai: { master: 'gpt-5', worker: 'gpt-5-mini' },
+  anthropic: { master: 'claude-opus-4-7', worker: 'claude-haiku-4-5' },
+  google: { master: 'gemini-3.1-pro-preview', worker: 'gemini-3.1-flash-lite-preview' },
+  openai: { master: 'gpt-5.4', worker: 'gpt-5.4-mini' },
 };
 
 /**

--- a/demos/engineering-team/provider.ts
+++ b/demos/engineering-team/provider.ts
@@ -37,9 +37,9 @@ export interface ResolvedProvider {
 }
 
 const DEFAULTS: Record<Provider, { master: string; worker: string }> = {
-  anthropic: { master: 'claude-sonnet-4-6', worker: 'claude-haiku-4-5' },
-  google: { master: 'gemini-2.5-pro', worker: 'gemini-2.5-flash' },
-  openai: { master: 'gpt-5', worker: 'gpt-5-mini' },
+  anthropic: { master: 'claude-opus-4-7', worker: 'claude-haiku-4-5' },
+  google: { master: 'gemini-3.1-pro-preview', worker: 'gemini-3.1-flash-lite-preview' },
+  openai: { master: 'gpt-5.4', worker: 'gpt-5.4-mini' },
 };
 
 /**

--- a/demos/research-team/README.md
+++ b/demos/research-team/README.md
@@ -48,7 +48,7 @@ This demo auto-detects the provider from whichever API key is set. To force a sp
 User (topic)
   |
   v
-Master Agent (master model — e.g. claude-sonnet-4-6 / gemini-2.5-pro / gpt-5)
+Master Agent (master model — e.g. claude-opus-4-7 / gemini-3.1-pro-preview / gpt-5.4)
   |--- delegate_task("researcher", "Research X...")
   |      |
   |      v

--- a/demos/research-team/provider.ts
+++ b/demos/research-team/provider.ts
@@ -37,9 +37,9 @@ export interface ResolvedProvider {
 }
 
 const DEFAULTS: Record<Provider, { master: string; worker: string }> = {
-  anthropic: { master: 'claude-sonnet-4-6', worker: 'claude-haiku-4-5' },
-  google: { master: 'gemini-2.5-pro', worker: 'gemini-2.5-flash' },
-  openai: { master: 'gpt-5', worker: 'gpt-5-mini' },
+  anthropic: { master: 'claude-opus-4-7', worker: 'claude-haiku-4-5' },
+  google: { master: 'gemini-3.1-pro-preview', worker: 'gemini-3.1-flash-lite-preview' },
+  openai: { master: 'gpt-5.4', worker: 'gpt-5.4-mini' },
 };
 
 /**


### PR DESCRIPTION
## Summary

Flagged by @PaulKinlan — the Gemini defaults in the demos were out of date. Same was true across all three providers. My originals shipped with Jan-2026-era model IDs; I didn't check for newer releases. Fixed.

| Provider | Before | After |
|---|---|---|
| Anthropic master | `claude-sonnet-4-6` | `claude-opus-4-7` |
| Anthropic worker | `claude-haiku-4-5` | `claude-haiku-4-5` (already current) |
| Google master | `gemini-2.5-pro` | `gemini-3.1-pro-preview` |
| Google worker | `gemini-2.5-flash` | `gemini-3.1-flash-lite-preview` |
| OpenAI master | `gpt-5` | `gpt-5.4` |
| OpenAI worker | `gpt-5-mini` | `gpt-5.4-mini` |

Context on the Google update: `gemini-3-pro-preview` was deprecated + shut down on 2026-03-09, so 3.1 is the current generation (confirmed against Google's model docs).

Applied to all five demo `provider.ts` files. Top-level `demos/README.md` plus `demos/research-team/README.md` updated to match. `DEMO_MASTER_MODEL` / `DEMO_WORKER_MODEL` env vars still let callers override to any ID they want.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` clean (623 tests)
- [ ] Manual: run a demo against each provider with the new defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)