### PR TITLE
Z.ai provider, Node engines, cost-safe eval suite, CI hardening

### DIFF
--- a/.changeset/doc-engines-and-ci.md
+++ b/.changeset/doc-engines-and-ci.md
@@ -1,0 +1,5 @@
+---
+"agent-do": patch
+---
+
+Document the Node 20+ runtime requirement via `package.json` `engines` (npm emits a clean `EBADENGINE` instead of a confusing ESM/`node:` failure on older runtimes). README examples table now lists the MCP (14) and routines (15) examples that were missing. `docs/supply-chain.md` zod row corrected to `^4.4.3` (it still read `^3.23.0` through 0.6.0).

--- a/.changeset/zai-provider.md
+++ b/.changeset/zai-provider.md
@@ -1,0 +1,5 @@
+---
+"agent-do": minor
+---
+
+Add Z.ai (Zhipu AI / GLM) as a first-class CLI provider via its OpenAI-compatible endpoint. `npx agent-do --provider zai --model glm-4.6` works out of the box — it reuses the bundled `@ai-sdk/openai` against `https://api.z.ai/api/paas/v4`, so no new dependency. Set `ZAI_API_KEY`; override the endpoint with `ZAI_BASE_URL` (e.g. for the GLM Coding Plan endpoint at `/api/coding/paas/v4`). Library example added at `examples/19-zai.ts`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Active LTS + Current. agent-do targets Node 18+ in practice via the
-        # ai SDK; pin to LTS lines so we catch regressions on the versions
-        # users are most likely to be on.
+        # Active LTS + Current. package.json declares engines >=20.
         node: ['20', '22', '24']
 
     steps:
@@ -44,3 +42,94 @@ jobs:
 
       - name: Test
         run: npm test
+
+  evals:
+    # Mock-tier evals are deterministic and free (no provider calls), so they
+    # gate every PR. The live tier is opt-in locally via `npm run eval:live`.
+    name: Evals (mock tier)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: Run mock-tier evals
+        run: npm run eval
+
+  docs:
+    # Catches typedoc regressions without paying for the 3-node matrix.
+    name: API docs build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: Build API docs (typedoc)
+        run: npm run docs
+
+  require-changeset:
+    # Enforces the documented release discipline (README / AGENTS.md):
+    # a PR that changes the *shipping surface* must add a changeset.
+    #
+    # Shipping surface = src/ (runtime/types) OR a shipping-relevant key in
+    # package.json (exports/bin/files/engines/main/types/module/dependencies/
+    # peerDependencies/peerDependenciesMeta). Pure dev-tooling changes —
+    # scripts, devDependencies bumps — are intentionally NOT gated, matching
+    # AGENTS.md ("devDependencies bumps — consumers don't see these").
+    name: Changeset present when shipping surface changes
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Require a changeset
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          CHANGED="$(git diff --name-only "${BASE_SHA}..${HEAD_SHA}")"
+          echo "Files changed in this PR:"
+          echo "${CHANGED}"
+
+          SHIPPING_CHANGED=0
+
+          # src/ is always shipping surface.
+          if echo "${CHANGED}" | grep -Eq '^src/'; then
+            SHIPPING_CHANGED=1
+          fi
+
+          # For package.json, only count it as shipping if a shipping-relevant
+          # key actually changed (not just scripts / devDependencies).
+          if echo "${CHANGED}" | grep -q '^package\.json$'; then
+            PKG_DIFF="$(git diff "${BASE_SHA}..${HEAD_SHA}" -- package.json)"
+            if echo "${PKG_DIFF}" | grep -Eq '^[+-][[:space:]]*"(exports|bin|files|engines|main|types|module|dependencies|peerDependencies|peerDependenciesMeta)"'; then
+              SHIPPING_CHANGED=1
+            fi
+          fi
+
+          if [ "${SHIPPING_CHANGED}" -eq 1 ]; then
+            if echo "${CHANGED}" | grep -Eq '^\.changeset/.*\.md$'; then
+              echo "OK — shipping surface changed and a changeset is present."
+            else
+              echo "::error::This PR changes the shipping surface (src/ or a package.json shipping key) but adds no changeset. Run \`npm run changeset\` and commit the generated .changeset/*.md alongside your code."
+              exit 1
+            fi
+          else
+            echo "OK — no shipping-surface changes detected; changeset not required."
+          fi

--- a/README.md
+++ b/README.md
@@ -1335,9 +1335,12 @@ The [`examples/`](examples/) directory contains runnable examples:
 | 11 | [`11-filesystem-store.ts`](examples/11-filesystem-store.ts) | Persistent filesystem storage — explore the created files |
 | 12 | [`12-prompt-builder.ts`](examples/12-prompt-builder.ts) | Composable system prompts from templates + sections + variables |
 | 13 | [`13-eval-framework.ts`](examples/13-eval-framework.ts) | Eval framework — define cases, assert quality, compare providers |
+| 14 | [`14-mcp.ts`](examples/14-mcp.ts) | Mount external MCP servers and expose their tools to the agent |
+| 15 | [`15-routines.ts`](examples/15-routines.ts) | Saved routines — reusable named procedures with `{{arg}}` interpolation |
 | 16 | [`16-sandbox-bash.ts`](examples/16-sandbox-bash.ts) | Pluggable sandbox + `bash` tool (host connector) |
 | 17 | [`17-sandbox-with-memory.ts`](examples/17-sandbox-with-memory.ts) | Sandbox alongside `InMemoryMemoryStore` (different substrates) |
 | 18 | [`18-sandbox-with-filesystem.ts`](examples/18-sandbox-with-filesystem.ts) | Sandbox alongside `FilesystemMemoryStore` (soft policy + sandboxed bash, plus a strong-isolation pattern) |
+| 19 | [`19-zai.ts`](examples/19-zai.ts) | Z.ai (GLM) via the bundled OpenAI-compatible provider — no extra install |
 
 Run any example: `npx tsx examples/01-basic-agent.ts`
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ about the others being missing, but the CLI covers them all.
 
 ### Using a different provider
 
-The CLI only knows about `anthropic`, `google`, `openai`, and `ollama`. For
+The CLI knows about `anthropic`, `google`, `openai`, `ollama`, and `zai`. For
 any other provider (Mistral, Groq, Cohere, OpenRouter, Bedrock, xAI, etc.),
 install the SDK and use agent-do as a library:
 
@@ -87,6 +87,39 @@ await agent.run('your task');
 
 Any Vercel AI SDK `LanguageModel` works — see
 [sdk.vercel.ai/providers](https://sdk.vercel.ai/providers) for the full list.
+
+### Z.ai (GLM)
+
+The CLI supports Z.ai (Zhipu AI's GLM models) out of the box via its
+OpenAI-compatible endpoint — no extra install:
+
+```bash
+export ZAI_API_KEY=...           # get one at https://z.ai/
+npx agent-do --provider zai --model glm-4.6 "Explain CRDTs"
+```
+
+`zai` reuses the bundled `@ai-sdk/openai` against
+`https://api.z.ai/api/paas/v4`, so it adds no dependency. To target the
+GLM Coding Plan endpoint instead, set
+`ZAI_BASE_URL=https://api.z.ai/api/coding/paas/v4`.
+
+As a library, the same thing with any OpenAI-compatible client:
+
+```ts
+import { createAgent } from 'agent-do';
+import { createOpenAI } from '@ai-sdk/openai';
+
+const zai = createOpenAI({
+  baseURL: 'https://api.z.ai/api/paas/v4',
+  apiKey: process.env.ZAI_API_KEY!,
+  name: 'zai',
+});
+
+const agent = createAgent({ model: zai('glm-4.6') });
+await agent.run('your task');
+```
+
+See [`examples/19-zai.ts`](examples/19-zai.ts) for a runnable example.
 
 ## CLI
 
@@ -137,7 +170,7 @@ npx agent-do run <name|file> [task]      Run a saved agent OR a script file
 npx agent-do eval <file|dir> [options]   Run evals
 
 Options:
-  --provider <name>      anthropic | google | openai | ollama (default: anthropic)
+  --provider <name>      anthropic | google | openai | ollama | zai (default: anthropic)
   --model <id>           Model ID (default: provider-specific)
   --system <prompt>      System prompt
   --cwd <dir>            Working directory for workspace tools (default: cwd)

--- a/demos/README.md
+++ b/demos/README.md
@@ -16,6 +16,8 @@ Then install each demo's dependencies (using subshells so your working directory
 (cd demos/assistant && npm install)
 (cd demos/research-team && npm install)
 (cd demos/code-reviewer && npm install)
+(cd demos/chief-of-staff && npm install)
+(cd demos/engineering-team && npm install)
 ```
 
 ### Choose a model provider
@@ -84,4 +86,30 @@ An agent that reads source files from a directory and produces a structured code
 
 ```bash
 (cd demos/code-reviewer && npm start /path/to/project)
+```
+
+### 4. Chief of Staff (`demos/chief-of-staff/`)
+
+Founder's chief-of-staff pattern built on the orchestrator. A master agent coordinates three specialists — Executive Assistant, Business Development, Task Manager — against a shared workspace of markdown files.
+
+- **Policy-as-markdown**: `priority-map.md` + `auto-resolver.md` are re-read at the start of every run and ground every decision
+- **Source-of-truth rule**: specialists always check the current state of `inbox.md` / `tracker.md` / `tasks.md` before acting
+- **Silence contract**: if there's nothing to do, the master returns `OK` and calls no tools — cheap to run on a cron
+- **Role-handoff pattern**: each specialist has a narrow brief and defers to the others
+
+```bash
+(cd demos/chief-of-staff && npm start "Triage the inbox and add follow-ups to tasks.md")
+```
+
+### 5. Engineering Team (`demos/engineering-team/`)
+
+Sprint-ordered planning pipeline. A master runs five phases in order — Think → Plan → Review → Test → Ship — each handed off to a specialist that produces a written artifact the next phase consumes.
+
+- **Sprint-ordered pipeline**: each phase strictly follows the previous
+- **Specialist role prompts**: opinionated stances baked into each system prompt
+- **Forcing questions as scaffolding**: office-hours interrogates rather than designs
+- **Shared workspace**: every artifact lives in `./sprint/` so phases can reference each other
+
+```bash
+(cd demos/engineering-team && npm start "Add an audit log for write operations")
 ```

--- a/docs/supply-chain.md
+++ b/docs/supply-chain.md
@@ -14,7 +14,7 @@ sensitive, this is the file to read.
 | `ai` | `^6.0.0` | Vercel AI SDK core. We use a wide range because the SDK itself is the source of truth for the provider versions above; pinning would just delay upgrades. |
 | `ignore` | `^7.0.5` | gitignore-style matcher for the workspace deny list (#23). Tiny, no transitive deps. |
 | `yaml` | `^2.8.3` | Skill frontmatter parser (#37). Maintained by `eemeli`; well-audited. |
-| `zod` | `^3.23.0` | Schema validation. Peer-of-peer with the AI SDK. |
+| `zod` | `^4.4.3` | Schema validation. Bumped from `^3.23.0` (the `^3.23.0` range in this table was stale through 0.6.0). Peer-of-peer with the AI SDK. |
 
 The provider SDKs are pinned exactly in `dependencies` (so the CLI is
 reproducible) but kept at `^3.0.0` in `peerDependencies` so library

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,68 @@
+# agent-do evals
+
+Behavioural and quality eval suites for agent-do, run through the shipped
+`agent-do/eval` framework.
+
+## Two tiers (cost-safe by design)
+
+| Tier | Command | Model | Cost | CI |
+|------|---------|-------|------|----|
+| **Mock** | `npm run eval` | `createMockModel()` (scripted) | **free** | ✅ runs on every PR |
+| **Live** | `npm run eval:live` | real provider | real money | ❌ opt-in only |
+
+### Mock tier — what it checks
+
+Deterministic regression coverage of the **plumbing**: the loop dispatches a
+tool call, the tool writes to the store, the assertion sees it, steps stay
+within budget, permissions/hook wiring holds. Each case in `behaviour.ts`
+carries its own scripted `responses`, so the suite is fully isolated and
+order-independent.
+
+The mock returns canned text regardless of what the tools returned, so the
+mock tier does **not** measure model quality — add those cases to the live
+tier.
+
+### Live tier — what it checks
+
+Real model quality against `quality.live.ts`: factual recall, tool-use
+correctness, and `llm-rubric` judged explanations. It resolves the model
+through the same provider path as `npx agent-do`, so it exercises the CLI's
+`resolveModel` too. Skipped automatically when no API key is set.
+
+## Running
+
+```bash
+# Mock — always safe, no key needed
+npm run eval
+
+# Live — needs a provider key
+export ANTHROPIC_API_KEY=sk-ant-...
+npm run eval:live
+
+# Live against a different provider / model
+EVAL_PROVIDER=google EVAL_MODEL=gemini-2.5-flash npm run eval:live
+EVAL_PROVIDER=zai      EVAL_MODEL=glm-4.6           npm run eval:live
+```
+
+Both scripts exit non-zero on any failure, so they're safe to gate CI or a
+pre-commit hook on.
+
+## Adding a case
+
+- **Plumbing regression** → add a `MockEvalCase` to `behaviour.ts` with
+  scripted `responses` and assertions. It runs in CI for free.
+- **Quality** → add an `EvalCase` to `quality.live.ts`. Keep it small and
+  prefer cheap models by default; `llm-rubric` adds a judge call.
+
+The assertion types are documented in the README and in
+`src/eval/types.ts` (13 types: `contains`, `regex`, `tool-called`,
+`tool-args`, `file-contains`, `max-steps`, `max-cost`, `llm-rubric`,
+`custom`, …).
+
+## Why split tiers?
+
+Provider calls are the single biggest source of eval cost. Running quality
+evals on every push is unsustainable; running *no* evals lets regressions
+slip. The mock tier gives a free, fast gate that catches the most common
+breakage (plumbing), while the live tier is run deliberately — before a
+release, or on a schedule — when the spend is justified.

--- a/evals/behaviour.ts
+++ b/evals/behaviour.ts
@@ -1,0 +1,87 @@
+/**
+ * Mock-tier eval cases — deterministic, free, run in CI (`npm run eval`).
+ *
+ * Each case carries its own scripted `responses` so the harness builds a
+ * fresh `createMockModel()` per case. The mock consumes its response queue
+ * in order, so per-case isolation keeps the suite maintainable as cases are
+ * added or removed (no fragile cross-case queue indexing).
+ *
+ * IMPORTANT — what these verify vs. what they don't:
+ *
+ *   ✓ Loop plumbing: prompt → tool call → result → assertion.
+ *   ✓ Tool dispatch, file persistence, step budgets, permission wiring.
+ *   ✗ Model intelligence. The mock returns canned text regardless of what
+ *     the tools actually returned.
+ *
+ * Measure *quality* with the live tier (`evals/quality.live.ts`).
+ */
+import type { Assertion } from '../src/eval/types.js';
+import type { MockResponse } from '../src/testing/index.js';
+import type { PricingTable } from '../src/types.js';
+
+export interface MockEvalCase {
+  name: string;
+  input: string;
+  /** Scripted model outputs, consumed in order across the loop steps. */
+  responses: MockResponse[];
+  assert: Assertion[];
+  runs?: number;
+}
+
+export const MOCK_SYSTEM_PROMPT =
+  'You are a helpful assistant with access to file tools for note-taking.';
+
+/**
+ * Zero-cost pricing for the mock model so the runner doesn't log
+ * "no pricing entry" warnings and `max-cost` assertions stay meaningful
+ * (0 <= maxUsd).
+ */
+export const MOCK_PRICING: PricingTable = {
+  'mock-eval': { input: 0, output: 0 },
+};
+
+export const MOCK_CASES: MockEvalCase[] = [
+  {
+    name: 'answers a factual question',
+    input: 'What is the capital of France? Reply with just the city.',
+    responses: [{ text: 'Paris' }],
+    assert: [
+      { type: 'contains', value: 'Paris' },
+      { type: 'not-contains', value: 'Berlin' },
+      { type: 'max-steps', max: 1 },
+    ],
+  },
+  {
+    name: 'writes a note via write_file and persists it',
+    input: 'Save a note that says "Buy milk" to shopping.md',
+    responses: [
+      { toolCalls: [{ toolName: 'write_file', args: { path: 'shopping.md', content: 'Buy milk' } }] },
+      { text: 'Saved the note to shopping.md.' },
+    ],
+    assert: [
+      { type: 'tool-called', tool: 'write_file' },
+      { type: 'tool-not-called', tool: 'delete_file' },
+      { type: 'tool-args', tool: 'write_file', args: { path: 'shopping.md' } },
+      { type: 'file-exists', path: 'shopping.md' },
+      { type: 'file-contains', path: 'shopping.md', value: 'Buy milk' },
+      { type: 'max-steps', max: 2 },
+    ],
+  },
+  {
+    name: 'does not call tools for a pure-text answer',
+    input: 'What is 2 + 2? Reply with just the number.',
+    responses: [{ text: '4' }],
+    assert: [
+      { type: 'contains', value: '4' },
+      { type: 'tool-not-called', tool: 'read_file' },
+      { type: 'tool-not-called', tool: 'write_file' },
+      { type: 'max-steps', max: 1 },
+    ],
+  },
+  {
+    name: 'completes within a step budget',
+    input: 'Say hello.',
+    responses: [{ text: 'Hello!' }],
+    assert: [{ type: 'max-steps', max: 1 }],
+  },
+];

--- a/evals/quality.live.ts
+++ b/evals/quality.live.ts
@@ -1,0 +1,46 @@
+/**
+ * Live-tier eval cases — real provider, real cost, opt-in (`npm run eval:live`).
+ *
+ * These measure *quality*, not plumbing. They are NOT run in CI. The harness
+ * skips the live tier with a clear message when no provider API key is set.
+ *
+ * Keep the case set small and the models cheap by default — every case makes
+ * real API calls, and `llm-rubric` adds a judge call on top.
+ */
+import type { EvalCase } from '../src/eval/types.js';
+
+export const LIVE_SYSTEM_PROMPT =
+  'You are a concise, helpful assistant with access to file tools for notes.';
+
+export const LIVE_CASES: EvalCase[] = [
+  {
+    name: 'knows the capital of France',
+    input: 'What is the capital of France? Reply with just the city name.',
+    assert: [
+      { type: 'contains', value: 'Paris' },
+      { type: 'max-steps', max: 2 },
+    ],
+  },
+  {
+    name: 'saves and persists a note',
+    input: 'Save a note that says "Standup at 9am" to standup.md, then confirm.',
+    assert: [
+      { type: 'tool-called', tool: 'write_file' },
+      { type: 'file-contains', path: 'standup.md', value: '9am' },
+      { type: 'max-steps', max: 4 },
+    ],
+  },
+  {
+    name: 'explains a concept clearly (rubric)',
+    input: 'Explain what a mutex is to a junior developer in two sentences.',
+    assert: [
+      {
+        type: 'llm-rubric',
+        rubric:
+          'The explanation is accurate, concise, and avoids unnecessary jargon. ' +
+          'It should convey mutual exclusion / preventing concurrent access to a resource.',
+        score: 'pass-fail',
+      },
+    ],
+  },
+];

--- a/evals/run.ts
+++ b/evals/run.ts
@@ -1,0 +1,104 @@
+/**
+ * Eval harness — two cost tiers.
+ *
+ *   npm run eval          → mock tier (deterministic, free, CI-safe)
+ *   npm run eval:live     → live tier (real provider, real cost, opt-in)
+ *
+ * Mock tier: each case in `behaviour.ts` runs against a fresh
+ * `createMockModel()` with its own scripted responses, via the real
+ * `runEvals` + `runAgentLoop` path. Free; no API key needed.
+ *
+ * Live tier: runs `quality.live.ts` against a real model resolved through
+ * the CLI's provider resolution (same env surface as `npx agent-do`).
+ * Skipped with a clear message when no API key is present.
+ *
+ * Exit code is non-zero if any case fails — safe to gate CI / hooks on.
+ */
+import { defineEval, runEvals, type EvalResult } from '../src/eval/index.js';
+import { createMockModel } from '../src/testing/index.js';
+import { MOCK_CASES, MOCK_SYSTEM_PROMPT, MOCK_PRICING } from './behaviour.js';
+import { LIVE_CASES, LIVE_SYSTEM_PROMPT } from './quality.live.js';
+
+const live = process.argv.includes('--live');
+
+// ── Mock tier ────────────────────────────────────────────────────────
+
+async function runMockTier(): Promise<boolean> {
+  console.log('\n── Mock tier (deterministic · no API calls) ──\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  for (const c of MOCK_CASES) {
+    // Fresh mock per case → no cross-case queue coupling.
+    const model = createMockModel({ responses: c.responses, modelId: 'mock-eval' });
+
+    const suite = defineEval({
+      name: `mock/${c.name}`,
+      systemPrompt: MOCK_SYSTEM_PROMPT,
+      model,
+      pricing: MOCK_PRICING,
+      cases: [{ name: c.name, input: c.input, assert: c.assert, runs: c.runs }],
+    });
+
+    const res: EvalResult = await runEvals(suite, { output: 'silent' });
+    const caseResult = res.providers[0]!.cases[0]!;
+
+    const icon = caseResult.passed ? '✓' : '✗';
+    const status = caseResult.passed ? 'PASS' : 'FAIL';
+    console.log(`  ${icon} ${status}  ${c.name}  (${caseResult.steps} steps)`);
+
+    if (!caseResult.passed) {
+      if (caseResult.error) console.log(`         error: ${caseResult.error}`);
+      for (const a of caseResult.assertions.filter(a => !a.passed)) {
+        console.log(`         ✗ ${a.message}`);
+      }
+    }
+
+    if (caseResult.passed) passed++;
+    else failed++;
+  }
+
+  console.log(`\n  mock tier: ${passed} passed, ${failed} failed\n`);
+  return failed === 0;
+}
+
+// ── Live tier ────────────────────────────────────────────────────────
+
+async function runLiveTier(): Promise<boolean> {
+  const provider = process.env.EVAL_PROVIDER ?? 'anthropic';
+  const modelId = process.env.EVAL_MODEL; // provider default if unset
+
+  const { resolveModel } = await import('../src/cli/resolve-model.js');
+
+  let model;
+  try {
+    model = await resolveModel(provider, modelId);
+  } catch (err) {
+    console.log(
+      `\n  live tier skipped: ${(err as Error).message}\n` +
+      `  set an API key (e.g. ANTHROPIC_API_KEY) to run it.\n`,
+    );
+    // Skipping is not a failure — the mock tier is the gate.
+    return true;
+  }
+
+  console.log(`\n── Live tier (${provider}${modelId ? '/' + modelId : ''}) · REAL API CALLS · costs money ──\n`);
+
+  const suite = defineEval({
+    name: 'quality-live',
+    systemPrompt: LIVE_SYSTEM_PROMPT,
+    model,
+    cases: LIVE_CASES,
+  });
+
+  // The eval reporter prints its own table for the live tier.
+  const res = await runEvals(suite, { output: 'console' });
+  const anyFailed = res.providers.some(p => p.failed > 0);
+  return !anyFailed;
+}
+
+// ── main ─────────────────────────────────────────────────────────────
+
+const ok = live ? await runLiveTier() : await runMockTier();
+process.exit(ok ? 0 : 1);

--- a/examples/19-zai.ts
+++ b/examples/19-zai.ts
@@ -1,0 +1,43 @@
+/**
+ * Example 19: Z.ai (GLM) provider
+ *
+ * Z.ai (Zhipu AI) exposes an OpenAI-compatible API, so we reuse the
+ * bundled @ai-sdk/openai against Z.ai's endpoint — no extra install
+ * beyond agent-do and @ai-sdk/openai.
+ *
+ * Equivalent CLI invocation:
+ *
+ *   export ZAI_API_KEY=...
+ *   npx agent-do --provider zai --model glm-4.6 "Explain CRDTs"
+ *
+ * Run:
+ *
+ *   export ZAI_API_KEY=...        # https://z.ai/
+ *   npx tsx examples/19-zai.ts
+ *
+ * Optional:
+ *   ZAI_BASE_URL  override the endpoint (e.g. the GLM Coding Plan
+ *                endpoint at https://api.z.ai/api/coding/paas/v4).
+ */
+
+import { createAgent } from 'agent-do';
+import { createOpenAI } from '@ai-sdk/openai';
+
+// Z.ai is OpenAI-compatible: same client, different baseURL + apiKey.
+// Setting `name: 'zai'` keeps provider metadata/debug output honest.
+const zai = createOpenAI({
+  baseURL: process.env.ZAI_BASE_URL ?? 'https://api.z.ai/api/paas/v4',
+  apiKey: process.env.ZAI_API_KEY,
+  name: 'zai',
+});
+
+const agent = createAgent({
+  id: 'zai-demo',
+  name: 'Z.ai Demo',
+  model: zai('glm-4.6'),
+  systemPrompt: 'You are a concise, helpful assistant.',
+});
+
+const prompt = process.argv[2] ?? 'Explain CRDTs in two sentences.';
+const result = await agent.run(prompt);
+console.log(result);

--- a/llms.txt
+++ b/llms.txt
@@ -135,7 +135,7 @@
 - `npx agent-do list` — list saved agents
 - `npx agent-do run <name|file>` — run a saved agent by name, or a script file
 - `npx agent-do eval <file|dir>` — run eval cases from file or directory
-- `--provider <name>` — anthropic | google | openai | ollama (default: anthropic)
+- `--provider <name>` — anthropic | google | openai | ollama | zai (default: anthropic)
 - `--model <id>` — model ID (default: provider-specific)
 - `--system <prompt>` — system prompt
 - `--memory <dir>` — memory directory (default: .agent-do/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,10 +25,14 @@
         "@changesets/cli": "^2.31.0",
         "@types/node": "^25.6.0",
         "agent-do-changelog-formatter": "file:./scripts/changelog-formatter",
+        "tsx": "^4.0.0",
         "typedoc": "^0.28.0",
         "typedoc-plugin-markdown": "^4.4.0",
         "typescript": "^6.0.3",
         "vitest": "^4.1.5"
+      },
+      "engines": {
+        "node": ">=20"
       },
       "peerDependencies": {
         "@ai-sdk/anthropic": "^3.0.75",
@@ -506,6 +510,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@gerrit0/mini-shiki": {
@@ -1743,6 +2189,48 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escape-html": {
@@ -3766,6 +4254,25 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-is": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,8 @@
     "docs": "typedoc",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
+    "eval": "tsx evals/run.ts",
+    "eval:live": "tsx evals/run.ts --live",
     "changeset": "changeset",
     "release": "bash scripts/release.sh",
     "prepublishOnly": "npm run typecheck && npm test && npm run build"
@@ -85,6 +87,7 @@
     "@changesets/cli": "^2.31.0",
     "@types/node": "^25.6.0",
     "agent-do-changelog-formatter": "file:./scripts/changelog-formatter",
+    "tsx": "^4.0.0",
     "typedoc": "^0.28.0",
     "typedoc-plugin-markdown": "^4.4.0",
     "typescript": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "agent-do",
   "version": "0.6.0",
   "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "bin": {

--- a/src/cli/resolve-model.ts
+++ b/src/cli/resolve-model.ts
@@ -17,6 +17,7 @@ const DEFAULT_MODELS = new Map<string, string>([
   ['google', 'gemini-2.5-flash'],
   ['openai', 'gpt-4.1-mini'],
   ['ollama', 'llama3.2'],
+  ['zai', 'glm-4.6'],
 ]);
 
 /**
@@ -28,12 +29,14 @@ const REQUIRED_ENV = new Map<string, string | null>([
   ['google', 'GOOGLE_GENERATIVE_AI_API_KEY'],
   ['openai', 'OPENAI_API_KEY'],
   ['ollama', null],
+  ['zai', 'ZAI_API_KEY'],
 ]);
 
 const PROVIDER_HINTS = new Map<string, string>([
   ['anthropic', 'https://console.anthropic.com/'],
   ['google', 'https://aistudio.google.com/'],
   ['openai', 'https://platform.openai.com/api-keys'],
+  ['zai', 'https://z.ai/'],
 ]);
 
 function assertApiKey(provider: string): void {
@@ -87,6 +90,19 @@ export async function resolveModel(
       return createOpenAI({
         baseURL: process.env.OLLAMA_BASE_URL ?? 'http://127.0.0.1:11434/v1',
         apiKey: 'ollama',
+      })(id) as LanguageModel;
+    }
+    case 'zai': {
+      // Z.ai (Zhipu AI / GLM) exposes an OpenAI-compatible API, so we reuse
+      // the bundled @ai-sdk/openai against Z.ai's endpoint — no extra
+      // dependency required. Override the endpoint with ZAI_BASE_URL (e.g.
+      // for the GLM Coding Plan endpoint at /api/coding/paas/v4).
+      // Docs: https://docs.z.ai
+      const { createOpenAI } = await tryImport('@ai-sdk/openai', 'zai (via @ai-sdk/openai)', 'createOpenAI');
+      return createOpenAI({
+        baseURL: process.env.ZAI_BASE_URL ?? 'https://api.z.ai/api/paas/v4',
+        apiKey: process.env.ZAI_API_KEY,
+        name: 'zai',
       })(id) as LanguageModel;
     }
     default:

--- a/tests/resolve-model.test.ts
+++ b/tests/resolve-model.test.ts
@@ -5,6 +5,7 @@ const ENV_VARS = [
   'ANTHROPIC_API_KEY',
   'GOOGLE_GENERATIVE_AI_API_KEY',
   'OPENAI_API_KEY',
+  'ZAI_API_KEY',
 ] as const;
 
 describe('resolveModel — API key preflight', () => {
@@ -37,8 +38,22 @@ describe('resolveModel — API key preflight', () => {
     await expect(resolveModel('openai')).rejects.toThrow(/OPENAI_API_KEY/);
   });
 
+  it('throws when ZAI_API_KEY is missing', async () => {
+    await expect(resolveModel('zai')).rejects.toThrow(/ZAI_API_KEY/);
+    await expect(resolveModel('zai')).rejects.toThrow(/Missing API key/);
+  });
+
   it('does not require an API key for ollama', async () => {
     const model = await resolveModel('ollama');
+    expect(model).toBeDefined();
+  });
+
+  it('proceeds for zai when a plausible key is present (OpenAI-compatible client, no network)', async () => {
+    // zai reuses @ai-sdk/openai against Z.ai's endpoint. Constructing the
+    // provider/model does not hit the network — only generateText would —
+    // so this is safe to assert without a live key.
+    process.env.ZAI_API_KEY = 'zai-stub-key';
+    const model = await resolveModel('zai');
     expect(model).toBeDefined();
   });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,5 @@
     "skipLibCheck": true,
     "types": ["node"]
   },
-  "include": ["src", "tests"]
+  "include": ["src", "tests", "evals"]
 }


### PR DESCRIPTION
Three logical commits on top of \`main\`. All gated locally: \`typecheck\` ✅, \`build\` ✅, \`708 tests\` ✅, mock eval tier ✅.

## 1. \`docs\` — examples 14/15, Node >=20 engines, zod supply-chain fix (patch)
- README examples table was still missing the **MCP (14)** and **routines (15)** rows through 0.6.0.
- \`package.json\` \`engines.node >=20\` so npm emits a clean \`EBADENGINE\` instead of a confusing ESM/\`node:\` failure on older runtimes.
- \`demos/README\` documents the **chief-of-staff** and **engineering-team** template demos.
- \`docs/supply-chain.md\` zod row corrected to \`^4.4.3\` (it still read \`^3.23.0\` through 0.6.0).

## 2. \`feat\` — Z.ai (GLM) CLI provider (minor)
\`npx agent-do --provider zai --model glm-4.6\` works out of the box — Z.ai's endpoint is OpenAI-compatible, so this reuses the **bundled \`@ai-sdk/openai\`** against \`https://api.z.ai/api/paas/v4\` (zero new dependencies). Set \`ZAI_API_KEY\`; override the endpoint with \`ZAI_BASE_URL\` (e.g. the GLM Coding Plan endpoint at \`/api/coding/paas/v4\`). Library example at \`examples/19-zai.ts\` (renumbered past the sandbox examples 16–18).

## 3. \`chore\` — eval framework + CI hardening (dev-only, no changeset)
**Cost-safe evals** via two tiers:
- **Mock tier** (\`npm run eval\`) — \`createMockModel()\` per case, deterministic, **free**, gates every PR in CI.
- **Live tier** (\`npm run eval:live\`) — real-model quality (\`llm-rubric\`, tool-use, recall); **auto-skips** with a clear message when no provider key is set, so it never costs money unintentionally.

New \`evals/\` (\`behaviour.ts\`, \`quality.live.ts\`, \`run.ts\`, \`README.md\`), \`tsx\` devDep, \`eval\`/\`eval:live\` scripts, tsconfig coverage.

CI gains three jobs:
- **\`evals\`** — runs the mock tier on every PR.
- **\`docs\`** — typedoc API-docs build gate.
- **\`require-changeset\`** — fails PRs touching the shipping surface (\`src/\` or \`package.json\` shipping keys) without a changeset. **Key-aware**: devDep/script-only \`package.json\` changes don't trip it (matches AGENTS.md).

## Notes
- Two changesets queued: \`patch\` (#1) and \`minor\` (#2). #3 is dev-only → no changeset (correct per the new require-changeset rule).
- Built on \`main @ ec57d00\`; rebased cleanly over the 0.5.0/0.6.0 sandbox + provider-tools releases.
- My earlier draft used \`examples/16-zai.ts\`, which collided with upstream's \`16-sandbox-bash.ts\` → renumbered to **19**.

Rebases wanted — say the word.