### PR TITLE
feat: shellm — prompt files as executable scripts (#16)

### DIFF
--- a/.changeset/shellm.md
+++ b/.changeset/shellm.md
@@ -1,0 +1,16 @@
+---
+"agent-do": minor
+---
+
+Add **shellm** — prompt files you run like shell scripts (issue #16). A plain-text prompt with a shebang (`#!/usr/bin/env agent-do`) and optional YAML frontmatter becomes an executable:
+
+```sh
+echo '#!/usr/bin/env agent-do
+Summarize the git log.' > weekly.shellm
+chmod +x weekly.shellm
+./weekly.shellm
+```
+
+Prompt mode detects a shellm file when the first positional opts in via a `.shellm` extension OR an `agent-do` shebang on line 1 — so `agent-do readme.md` still means the literal prompt "readme.md". Frontmatter sets `provider`/`model`/`system`; piped stdin merges with the file prompt as context. A shellm file is data (never `import()`ed), so it's strictly safer than `--script`, but its contents reach the model — don't run untrusted shellm files.
+
+New `src/cli/shellm.ts` (`parseShellm`, `tryParseShellm`, `readShellmFile`) with a ReDoS-safe frontmatter splitter; sample at `examples/22-shellm.shellm`; README `## Shellm Scripts` section. Saved-agent (`agent:`) wiring and `{{stdin}}` template variables are noted follow-ups.

--- a/README.md
+++ b/README.md
@@ -573,6 +573,86 @@ sub-agent starts a fresh turn with just the remainder (and the same
 `parseSlashCommand(input)` and `unknownSlashCommandMessage(name, commands)`
 are exported for callers that want to inspect or build routing themselves.
 
+## Shellm Scripts
+
+A **shellm** file is a plain-text prompt you run like a shell script —
+"shell" + "LLM". Drop a prompt (optionally with a shebang and YAML
+frontmatter) into a file, make it executable, and run it directly:
+
+```bash
+$ cat > weekly-summary.shellm <<'EOF'
+#!/usr/bin/env agent-do
+Summarize the git log from the last week and list any breaking changes.
+EOF
+
+$ chmod +x weekly-summary.shellm
+$ ./weekly-summary.shellm
+```
+
+The kernel turns the shebang into `agent-do /abs/path/weekly-summary.shellm`,
+so the file path arrives as the CLI's first positional. Prompt mode
+detects it and uses the file body as the prompt — zero boilerplate, no
+imports, no config objects.
+
+### Opt-in detection
+
+A positional is treated as a shellm file only when it **opts in** via one
+of:
+
+- a **`.shellm` extension** (`agent-do ./analyze.shellm`), **or**
+- an **`agent-do` shebang** on the file's first line
+  (`#!/usr/bin/env agent-do`).
+
+This dual gate keeps `agent-do readme.md` meaning "the literal prompt
+`readme.md`" (today's behaviour) instead of silently reading the file.
+Both signals work alone — a `.shellm` file needs no shebang, and a shebanged
+file with any extension works too.
+
+### Frontmatter config
+
+Optional YAML frontmatter sets the run config:
+
+```bash
+$ cat > review.shellm <<'EOF'
+#!/usr/bin/env agent-do
+---
+provider: google
+model: gemini-2.5-flash
+system: You are a code reviewer. Be terse.
+---
+Review the staged git diff for bugs.
+EOF
+
+$ ./review.shellm
+```
+
+Frontmatter values override the CLI defaults for `provider`, `model`, and
+`system`. Flags like `--read-only`, `--verbose`, and `--no-tools` still
+apply (they have no frontmatter twin).
+
+### Piping
+
+Stdin is merged with the file prompt exactly as in
+`echo ctx | agent-do "prompt"` — the file is the instruction, piped data
+is the context:
+
+```bash
+$ cat data.csv | ./analyze.shellm          # analyze the piped CSV
+$ git diff --staged | ./review.shellm > review.md   # in a pipeline
+```
+
+### Trust model
+
+A shellm file is **data** (a prompt), not **code** — parsing it never
+`import()`s anything, so it's strictly safer than
+`agent-do run x.ts --script`. But its contents reach the model, and with
+the default workspace tools the agent can read/write/edit files in `--cwd`.
+**Don't run shellm files from sources you don't trust** — the same rule as
+shell scripts. `--read-only` and `--no-tools` narrow the blast radius.
+
+See [`examples/22-shellm.shellm`](examples/22-shellm.shellm) for a
+runnable sample with frontmatter.
+
 ## Tools
 
 Define tools using the Vercel AI SDK's `tool()` function:
@@ -1518,6 +1598,7 @@ The [`examples/`](examples/) directory contains runnable examples:
 | 19 | [`19-zai.ts`](examples/19-zai.ts) | Z.ai (GLM) via the bundled OpenAI-compatible provider — no extra install |
 | 20 | [`20-policies.ts`](examples/20-policies.ts) | Typed system-prompt modules — priority-map + auto-resolver policy pair |
 | 21 | [`21-slash-commands.ts`](examples/21-slash-commands.ts) | Slash-command router — deterministic `/<name>` dispatch to sub-agents |
+| 22 | [`22-shellm.shellm`](examples/22-shellm.shellm) | Shellm — a prompt file you `chmod +x` and run directly (shebang + frontmatter) |
 
 Run any example: `npx tsx examples/01-basic-agent.ts`
 

--- a/examples/22-shellm.shellm
+++ b/examples/22-shellm.shellm
@@ -1,0 +1,17 @@
+#!/usr/bin/env agent-do
+---
+# Shellm sample (issue #16). A prompt file you can chmod +x and run.
+#
+#   ./examples/22-shellm.shellm                 # uses frontmatter provider
+#   ANTHROPIC_API_KEY=sk-... ./examples/22-shellm.shellm
+#   cat README.md | ./examples/22-shellm.shellm # pipe data as context
+#
+# Frontmatter overrides the CLI defaults for provider/model/system.
+provider: anthropic
+model: claude-haiku-4-5
+system: You are a concise senior engineer. Prefer bullet points.
+---
+
+Summarize the most important thing this repository does in three
+bullet points or fewer. If input was piped on stdin, summarise that
+instead and ignore the rest of this prompt.

--- a/src/cli/prompt.ts
+++ b/src/cli/prompt.ts
@@ -21,6 +21,7 @@ import { FilesystemMemoryStore } from '../stores/filesystem.js';
 import { buildCliPermissions } from './permission-handler.js';
 import { buildDebugConfigFromArgs } from './debug-config.js';
 import { buildProviderTools } from './provider-tools.js';
+import { tryParseShellm } from './shellm.js';
 import type { ProgressEvent, ConversationMessage } from '../types.js';
 import type { ToolSet } from 'ai';
 
@@ -35,6 +36,28 @@ export async function runPromptMode(args: ParsedArgs): Promise<void> {
     readOnly: args.readOnly,
     json: args.json,
   });
+
+  // Shellm (#16): if the positional prompt is a readable file that opts
+  // in via `.shellm` extension OR an `agent-do` shebang, parse it and let
+  // the file's frontmatter override provider/model/system. The file body
+  // becomes the prompt (merged with piped stdin below, same as today).
+  // A non-shellm positional is left untouched — `agent-do readme.md` still
+  // passes the literal string "readme.md" to the model.
+  if (args.prompt) {
+    const shellm = await tryParseShellm(args.prompt);
+    if (shellm) {
+      args.prompt = shellm.prompt;
+      // Frontmatter is authoritative — the script is a self-contained
+      // program, so running ./foo.shellm behaves the same regardless of
+      // shell aliases or env. CLI flags for --read-only / --verbose /
+      // --no-tools still apply because they don't have frontmatter twins.
+      if (shellm.config.provider) args.provider = shellm.config.provider;
+      if (shellm.config.model) args.model = shellm.config.model;
+      if (shellm.config.system) args.systemPrompt = shellm.config.system;
+      // `agent:` is parsed but not yet wired (saved-agent loading is a
+      // follow-up); a future version will load the named agent here.
+    }
+  }
 
   const model = await resolveModel(args.provider, args.model);
 

--- a/src/cli/shellm.ts
+++ b/src/cli/shellm.ts
@@ -1,0 +1,220 @@
+/**
+ * Shellm — prompt files as executable scripts (#16).
+ *
+ * A shellm file is a plain-text prompt, optionally preceded by a shebang
+ * (`#!/usr/bin/env agent-do`) and YAML frontmatter. Run it directly:
+ *
+ *     $ chmod +x summary.shellm
+ *     $ ./summary.shellm            # kernel turns the shebang into
+ *                                   # `agent-do /abs/path/summary.shellm`
+ *
+ * …or explicitly:
+ *
+ *     $ agent-do ./summary.shellm
+ *     $ cat data.csv | ./analyze.shellm
+ *
+ * Prompt mode detects a shellm file when the first positional arg is a
+ * readable file AND it opts in via EITHER a `.shellm` extension OR an
+ * `agent-do` shebang on its first line. That dual opt-in keeps
+ * `agent-do readme.md` meaning "the prompt is the literal string
+ * readme.md" (today's behaviour) instead of silently reading the file.
+ *
+ * Frontmatter (optional) carries run config:
+ *
+ *     ---
+ *     provider: google
+ *     model: gemini-2.5-flash
+ *     system: You are a code reviewer. Be terse.
+ *     ---
+ *     Review the staged diff for bugs.
+ *
+ * ## Security
+ *
+ * A shellm file is DATA (a prompt), not CODE — parsing it never
+ * `import()`s anything (unlike `agent-do run x.ts --script`). The trust
+ * model matches `cat file | agent-do "prompt"`: the file's contents
+ * reach the model, and with the default workspace tools the agent can
+ * read/write/edit files in `--cwd`. Don't run shellm files from sources
+ * you don't trust — same rule as shell scripts. `--read-only` /
+ * `--no-tools` narrow the blast radius exactly as for a normal prompt.
+ */
+
+import { readFile, stat } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import YAML from 'yaml';
+
+/** Max bytes we'll read from a shellm file. Mirrors script-mode cap. */
+const SHELLM_MAX_BYTES = 2 * 1024 * 1024;
+
+export interface ShellmConfig {
+  /** Overrides `--provider` when present. */
+  provider?: string;
+  /** Overrides `--model` when present. */
+  model?: string;
+  /** Overrides `--system` when present. */
+  system?: string;
+  /**
+   * Saved agent name. Reserved in v1 — not wired (loading a saved agent
+   * is a follow-up; it needs the runSavedAgent machinery from script.ts).
+   * Parsed and validated so a typo surfaces clearly instead of being
+   * silently ignored.
+   */
+  agent?: string;
+}
+
+export interface ParsedShellm {
+  /** The prompt body (frontmatter and shebang stripped, trimmed). */
+  prompt: string;
+  config: ShellmConfig;
+}
+
+/**
+ * Read and validate a shellm file's raw contents. Throws on non-file
+ * targets or files exceeding the size cap.
+ */
+export async function readShellmFile(filePath: string): Promise<string> {
+  const s = await stat(filePath);
+  if (!s.isFile()) {
+    throw new Error(`Shellm target is not a regular file: ${filePath}`);
+  }
+  if (s.size > SHELLM_MAX_BYTES) {
+    throw new Error(
+      `Shellm file is ${s.size} bytes (limit ${SHELLM_MAX_BYTES}). ` +
+        `A prompt file this large is almost certainly a mistake.`,
+    );
+  }
+  return readFile(filePath, 'utf-8');
+}
+
+/**
+ * Parse raw shellm file contents into a prompt body + optional config.
+ * Strips a leading shebang line and an optional YAML frontmatter block.
+ */
+export function parseShellm(content: string): ParsedShellm {
+  let src = content;
+
+  // Strip a leading shebang. The kernel consumed it to dispatch when run
+  // via `./file.shellm`; when invoked as `agent-do file.shellm` the raw
+  // bytes still include it, and we don't want it reaching the model.
+  if (src.startsWith('#!')) {
+    const nl = src.indexOf('\n');
+    src = nl === -1 ? '' : src.slice(nl + 1);
+  }
+
+  const split = splitFrontmatter(src);
+  if (!split) {
+    return { prompt: src.trim(), config: {} };
+  }
+  return {
+    prompt: split.body.trim(),
+    config: parseFrontmatterConfig(split.frontmatter),
+  };
+}
+
+/**
+ * Detect whether a positional prompt argument is a shellm file and, if
+ * so, parse it. Returns `null` when the arg is NOT a shellm file — the
+ * caller then treats it as a literal prompt string (today's behaviour).
+ *
+ * Opt-in is explicit and unambiguous: the target must be a regular file
+ * AND either carry a `.shellm` extension OR begin with an `agent-do`
+ * shebang. Without this gate, `agent-do readme.md` would silently read
+ * the file instead of passing the literal string to the model.
+ */
+export async function tryParseShellm(
+  positional: string,
+): Promise<ParsedShellm | null> {
+  // A multi-line or multi-token positional is never a file path we want
+  // to auto-load — it's a literal prompt like "summarize ./readme.md".
+  if (positional.includes('\n')) return null;
+  if (positional.trim().split(/\s+/).length > 1) return null;
+
+  const filePath = resolve(positional);
+  let content: string;
+  try {
+    content = await readShellmFile(filePath);
+  } catch {
+    // Not a file, unreadable, or too large — fall through to literal.
+    return null;
+  }
+
+  const isShellmExt = /\.shellm$/i.test(positional);
+  const hasAgentDoShebang = /^#![^\n]*\bagent-do\b/.test(content);
+  if (!isShellmExt && !hasAgentDoShebang) return null;
+
+  return parseShellm(content);
+}
+
+// ── Frontmatter (ReDoS-safe) ───────────────────────────────────────────
+//
+// Same line-based, O(n) splitter used by policies.ts. A shared
+// `src/utils/frontmatter.ts` helper is the obvious future cleanup so
+// skills.ts / routines.ts / policies.ts / shellm.ts stop carrying
+// near-identical copies; tracked separately to keep this change focused.
+
+function parseFrontmatterConfig(frontmatter: string): ShellmConfig {
+  if (!frontmatter.trim()) return {};
+  let parsed: Record<string, unknown> = {};
+  try {
+    const out = YAML.parse(frontmatter);
+    if (out && typeof out === 'object' && !Array.isArray(out)) {
+      parsed = out as Record<string, unknown>;
+    }
+  } catch {
+    // Malformed YAML — ignore the config block but keep the prompt body.
+    return {};
+  }
+  const cfg: ShellmConfig = {};
+  if (typeof parsed.provider === 'string' && parsed.provider.trim()) {
+    cfg.provider = parsed.provider.trim();
+  }
+  if (typeof parsed.model === 'string' && parsed.model.trim()) {
+    cfg.model = parsed.model.trim();
+  }
+  if (typeof parsed.system === 'string' && parsed.system.trim()) {
+    cfg.system = parsed.system.trim();
+  }
+  if (typeof parsed.agent === 'string' && parsed.agent.trim()) {
+    cfg.agent = parsed.agent.trim();
+  }
+  return cfg;
+}
+
+/**
+ * Split a document into YAML frontmatter + body without the
+ * catastrophic-backtracking risk of `/^---\n([\s\S]*?)\n---\n/`
+ * (CodeQL `js/polynomial-redos`). See policies.ts for the full
+ * rationale; this is a copy pending shared-helper extraction.
+ */
+function splitFrontmatter(content: string): { frontmatter: string; body: string } | null {
+  const openEnd = fenceLineEnd(content, 0);
+  if (openEnd === -1) return null;
+  if (openEnd >= content.length || content[openEnd] !== '\n') return null;
+  const afterOpen = openEnd + 1;
+
+  let lineStart = afterOpen;
+  let searchFrom = afterOpen;
+  while (searchFrom <= content.length) {
+    const nextNl = content.indexOf('\n', searchFrom);
+    const lineEnd = nextNl === -1 ? content.length : nextNl;
+    if (fenceLineEnd(content, lineStart) === lineEnd) {
+      if (lineEnd >= content.length) break; // bare trailing `---` → no match
+      const frontEnd = Math.max(afterOpen, lineStart - 1);
+      return {
+        frontmatter: content.slice(afterOpen, frontEnd),
+        body: content.slice(lineEnd + 1),
+      };
+    }
+    if (nextNl === -1) break;
+    lineStart = nextNl + 1;
+    searchFrom = nextNl + 1;
+  }
+  return null;
+}
+
+function fenceLineEnd(s: string, start: number): number {
+  if (s[start] !== '-' || s[start + 1] !== '-' || s[start + 2] !== '-') return -1;
+  let i = start + 3;
+  while (s[i] === ' ' || s[i] === '\t' || s[i] === '\r') i++;
+  return i;
+}

--- a/tests/shellm.test.ts
+++ b/tests/shellm.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { parseShellm, tryParseShellm, readShellmFile } from '../src/cli/shellm.js';
+
+describe('parseShellm', () => {
+  it('strips a shebang and uses the rest as the prompt', () => {
+    const out = parseShellm('#!/usr/bin/env agent-do\nSummarize the git log.');
+    expect(out.prompt).toBe('Summarize the git log.');
+    expect(out.config).toEqual({});
+  });
+
+  it('handles a shebang-only file (empty prompt)', () => {
+    const out = parseShellm('#!/usr/bin/env agent-do');
+    expect(out.prompt).toBe('');
+    expect(out.config).toEqual({});
+  });
+
+  it('parses YAML frontmatter into run config', () => {
+    const out = parseShellm(
+      '#!/usr/bin/env agent-do\n---\nprovider: google\nmodel: gemini-2.5-flash\nsystem: Be terse.\n---\nReview this code.',
+    );
+    expect(out.prompt).toBe('Review this code.');
+    expect(out.config).toEqual({
+      provider: 'google',
+      model: 'gemini-2.5-flash',
+      system: 'Be terse.',
+    });
+  });
+
+  it('parses frontmatter without a shebang', () => {
+    const out = parseShellm('---\nprovider: openai\n---\nHello.');
+    expect(out.prompt).toBe('Hello.');
+    expect(out.config.provider).toBe('openai');
+  });
+
+  it('treats a body with no frontmatter as a plain prompt', () => {
+    const out = parseShellm('What is the capital of France?');
+    expect(out.prompt).toBe('What is the capital of France?');
+    expect(out.config).toEqual({});
+  });
+
+  it('keeps the prompt body when YAML is malformed', () => {
+    const out = parseShellm(
+      '---\nprovider: "unterminated\n---\nBody survives bad YAML.',
+    );
+    expect(out.prompt).toBe('Body survives bad YAML.');
+    // Malformed YAML → no config extracted, but the body is never dropped.
+    expect(out.config).toEqual({});
+  });
+
+  it('ignores unknown frontmatter keys and non-string values', () => {
+    const out = parseShellm(
+      '---\nprovider: anthropic\ncustom-field: whatever\ntools: 3\n---\nBody.',
+    );
+    expect(out.config).toEqual({ provider: 'anthropic' });
+    expect(out.prompt).toBe('Body.');
+  });
+
+  it('reserves but captures the `agent` key', () => {
+    const out = parseShellm('---\nagent: code-reviewer\n---\nReview this.');
+    // Reserved in v1 (not wired) but parsed so a typo surfaces later.
+    expect(out.config.agent).toBe('code-reviewer');
+  });
+
+  it('is ReDoS-safe on an adversarial frontmatter body', () => {
+    // Hostile input that would blow up a naive /^---\n([\s\S]*?)\n---\n/
+    // regex. The line-based parser must finish in O(n).
+    const hostile = '---\n' + '\n '.repeat(50_000) + 'no closing fence';
+    const start = Date.now();
+    const out = parseShellm(hostile);
+    const elapsed = Date.now() - start;
+    expect(out.prompt.length).toBeGreaterThan(0); // fell back to body-only
+    expect(out.config).toEqual({});
+    expect(elapsed).toBeLessThan(500);
+  });
+});
+
+describe('tryParseShellm — opt-in detection', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'shellm-'));
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('detects a .shellm file by extension', async () => {
+    const p = join(dir, 'summary.shellm');
+    await writeFile(p, '#!/usr/bin/env agent-do\nSummarize the log.');
+    const out = await tryParseShellm(p);
+    expect(out).not.toBeNull();
+    expect(out!.prompt).toBe('Summarize the log.');
+  });
+
+  it('detects a file with an agent-do shebang but no .shellm extension', async () => {
+    const p = join(dir, 'notes.txt');
+    await writeFile(p, '#!/usr/bin/env agent-do\nTake notes.');
+    const out = await tryParseShellm(p);
+    expect(out).not.toBeNull();
+    expect(out!.prompt).toBe('Take notes.');
+  });
+
+  it('does NOT treat a .md file without an agent-do shebang as shellm', async () => {
+    // The core ambiguity guard (issue #16, research Q4): `agent-do readme.md`
+    // must stay a literal prompt, not silently read the file.
+    const p = join(dir, 'readme.md');
+    await writeFile(p, '# README\n\nSome documentation.');
+    const out = await tryParseShellm(p);
+    expect(out).toBeNull();
+  });
+
+  it('returns null for a multi-token positional (literal prompt)', async () => {
+    const out = await tryParseShellm('summarize ./readme.md');
+    expect(out).toBeNull();
+  });
+
+  it('returns null for a non-existent path (falls back to literal)', async () => {
+    const out = await tryParseShellm(join(dir, 'no-such-file.shellm'));
+    expect(out).toBeNull();
+  });
+
+  it('returns null for a directory even with a .shellm-ish name', async () => {
+    const out = await tryParseShellm(dir);
+    expect(out).toBeNull();
+  });
+
+  it('detects by extension even without a shebang', async () => {
+    // A `.shellm` file with no shebang line is still a shellm file — the
+    // extension alone is sufficient opt-in.
+    const p = join(dir, 'plain.shellm');
+    await writeFile(p, 'Just a prompt, no shebang.');
+    const out = await tryParseShellm(p);
+    expect(out).not.toBeNull();
+    expect(out!.prompt).toBe('Just a prompt, no shebang.');
+  });
+
+  it('respects a shebang pointing at an absolute agent-do path', async () => {
+    const p = join(dir, 'abs.shellm');
+    await writeFile(p, '#!/usr/local/bin/agent-do\nRun.');
+    const out = await tryParseShellm(p);
+    expect(out).not.toBeNull();
+    expect(out!.prompt).toBe('Run.');
+  });
+
+  it('ignores a non-agent-do shebang without the .shellm extension', async () => {
+    const p = join(dir, 'script.sh');
+    await writeFile(p, '#!/bin/bash\necho hi');
+    const out = await tryParseShellm(p);
+    expect(out).toBeNull();
+  });
+});
+
+describe('readShellmFile', () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'shellm-io-'));
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('reads a normal shellm file', async () => {
+    const p = join(dir, 'x.shellm');
+    await writeFile(p, 'hello');
+    expect(await readShellmFile(p)).toBe('hello');
+  });
+
+  it('rejects a directory target', async () => {
+    await expect(readShellmFile(dir)).rejects.toThrow(/not a regular file/);
+  });
+
+  it('rejects a file over the size cap', async () => {
+    const p = join(dir, 'big.shellm');
+    // Just over 2 MB. Cap is 2 * 1024 * 1024.
+    await writeFile(p, 'x'.repeat(2 * 1024 * 1024 + 1));
+    await expect(readShellmFile(p)).rejects.toThrow(/limit/);
+  });
+});


### PR DESCRIPTION
Closes #16. Run a plain-text prompt file like a shell script — \"shell\" + \"LLM\".

\`\`\`sh
echo '#!/usr/bin/env agent-do
Summarize the git log.' > weekly.shellm
chmod +x weekly.shellm
./weekly.shellm
\`\`\`

## What it does
- **Detection**: prompt mode treats a positional as a shellm file only when it opts in via a **\`.shellm\` extension** OR an **\`agent-do\` shebang** on line 1. This dual gate is the key design call — it keeps \`agent-do readme.md\` meaning the literal prompt \"readme.md\" (today's behaviour) instead of silently reading the file (issue #16 research Q4).
- **Shebang strip + optional YAML frontmatter** for \`provider\`/\`model\`/\`system\` (frontmatter overrides CLI defaults; \`--read-only\`/\`--verbose\`/\`--no-tools\` still apply).
- **Pipe merge**: stdin merges with the file prompt as context, same as \`echo ctx | agent-do \"prompt\"\`.

## Security
A shellm file is **data** (a prompt), not **code** — parsing never \`import()\`s anything, so it's strictly safer than \`agent-do run x.ts --script\`. But its contents reach the model, and default workspace tools can touch files in \`--cwd\`. Trust model = shell scripts: don't run untrusted ones.

## Verification
\`typecheck\` ✅ · \`build\` ✅ · **782 tests** ✅ (761 + 21 new) · mock eval tier ✅. End-to-end smoke: a \`.shellm\` file's frontmatter \`provider/model\` honored through the full stack; \`readme.md\` correctly NOT detected (returned \`null\` from \`tryParseShellm\`).

## Implementation
New \`src/cli/shellm.ts\` (\`parseShellm\`, \`tryParseShellm\`, \`readShellmFile\`); thin wiring in \`src/cli/prompt.ts\` (detect before \`resolveModel\`). Frontmatter splitter is the ReDoS-safe line-based scanner (same as policies.ts — noted a shared-helper extraction as a future cleanup across skills/routines/policies/shellm). Sample at \`examples/22-shellm.shellm\`; README \`## Shellm Scripts\`.

## Follow-ups (out of v1 scope, noted in changeset)
- \`agent:\` frontmatter → load a saved agent (needs the runSavedAgent machinery).
- \`{{stdin}}\` template variables.
- Shebang-flag parsing (\`#!/usr/bin/env agent-do --provider X\` is non-portable across kernels anyway; frontmatter is the recommended path).