### PR TITLE
feat: opt-in cross-process file locking for FilesystemMemoryStore (#15 Tier 1)

### DIFF
--- a/.changeset/file-locking.md
+++ b/.changeset/file-locking.md
@@ -1,0 +1,9 @@
+---
+"agent-do": minor
+---
+
+Add opt-in cross-process file locking to `FilesystemMemoryStore` (#15 Tier 1). Set the `lock` option and mutating ops (`write`/`append`/`delete`/`mkdir`) serialise per-file across every process sharing the same `baseDir` — protecting against orchestrator workers, overlapping `run()` calls, and cron-spawned processes (#79). `undefined` preserves today's naive-overwrite behaviour byte-for-byte.
+
+The lock is a zero-dependency sidecar file (`O_CREAT|O_EXCL` atomic create + mtime-based stale reclaim + retry/backoff with jitter), living in `<baseDir>/.locks/<agentId>/` and invisible to the agent's `list()`/`search()`/`read()`. Writes also become atomic (temp-file + `rename`), so unlocked readers never observe a half-flushed file. A `LockAdapter` option lets you plug in `proper-lockfile`/`fs-ext` for NFS-perfect atomicity without agent-do taking a dependency.
+
+New exports: `acquireFileLock`, `withFileLock`, and types `FileLockOptions`, `LockHandle`, `LockAdapter`. POSIX locks remain advisory (a writer that doesn't opt in can still clobber a locked file). A lazily-imported CRDT-backed store (`agent-do/stores/crdt`, Yjs) is a planned Tier-2 follow-up for genuinely-concurrent *merge* semantics.

--- a/README.md
+++ b/README.md
@@ -808,6 +808,59 @@ const guardedStore = new FilesystemMemoryStore('./data', {
 });
 ```
 
+### Concurrent access (locking, #15)
+
+By default `write()` is a naive overwrite — fine for single-process use, but
+**concurrent runs lose data**: two processes that read-modify-write the same
+file clobber each other. Set the opt-in `lock` option to serialise mutating
+ops across processes:
+
+```ts
+// Orchestrator workers, overlapping run() calls, or cron-driven runs (#79)
+// — all safely serialised on a per-file basis.
+const store = new FilesystemMemoryStore('./data', {
+  lock: {
+    staleMs: 60_000,                              // reclaim locks older than 1 min
+    retry: { count: 20, minDelayMs: 25, maxDelayMs: 1000 },
+  },
+});
+```
+
+The lock is a **zero-dependency sidecar file** (`O_CREAT|O_EXCL` + mtime
+stale reclaim + retry/backoff), visible to every process sharing the same
+`baseDir` — so it protects across orchestrator workers and fresh cron-spawned
+processes, not just within one Node process. Lock files live in
+`<baseDir>/.locks/<agentId>/` and are invisible to the agent's own `list()` /
+`search()` / `read()`. Writes also become **atomic** (temp-file + `rename`),
+so unlocked readers never see a half-flushed file.
+
+POSIX locks are **advisory**: a process that writes without the `lock` option
+(say, an editor, or a store instance created without it) can still clobber a
+locked file. `undefined` preserves today's behaviour byte-for-byte.
+
+Need stronger guarantees on a network filesystem? Plug in a battle-tested
+lock without agent-do taking a dependency:
+
+```ts
+import properLockfile from 'proper-lockfile'; // your dep, not agent-do's
+
+const store = new FilesystemMemoryStore('./data', {
+  lock: {
+    adapter: {
+      async acquire(lockFile, opts) {
+        // wrap proper-lockfile here; return { async release() {…} }
+      },
+    },
+  },
+});
+```
+
+`acquireFileLock`, `withFileLock`, and the `FileLockOptions` / `LockAdapter` /
+`LockHandle` types are exported for direct use. For genuinely-concurrent
+**merge** semantics (multiple writers whose edits should combine rather than
+serialise), a lazily-imported CRDT-backed store (`agent-do/stores/crdt`, Yjs)
+is planned as a Tier-2 follow-up.
+
 For other backends, implement the interface:
 
 ```ts
@@ -1599,6 +1652,7 @@ The [`examples/`](examples/) directory contains runnable examples:
 | 20 | [`20-policies.ts`](examples/20-policies.ts) | Typed system-prompt modules — priority-map + auto-resolver policy pair |
 | 21 | [`21-slash-commands.ts`](examples/21-slash-commands.ts) | Slash-command router — deterministic `/<name>` dispatch to sub-agents |
 | 22 | [`22-shellm.shellm`](examples/22-shellm.shellm) | Shellm — a prompt file you `chmod +x` and run directly (shebang + frontmatter) |
+| 23 | [`23-concurrent-store.ts`](examples/23-concurrent-store.ts) | Concurrent MemoryStore access — opt-in cross-process file locking (#15) |
 
 Run any example: `npx tsx examples/01-basic-agent.ts`
 

--- a/examples/23-concurrent-store.ts
+++ b/examples/23-concurrent-store.ts
@@ -1,0 +1,49 @@
+/**
+ * Example 23: Concurrent MemoryStore access with file locking (#15 Tier 1).
+ *
+ * When the same agent runs concurrently (orchestrator workers, overlapping
+ * run() calls, or cron-driven runs), naive overwriting loses data. Set the
+ * opt-in `lock` option and mutating ops serialise per-file across processes.
+ *
+ * Run: npx tsx examples/23-concurrent-store.ts
+ *
+ * What this demonstrates:
+ *   - Two concurrent append() calls to the SAME file both land (without a
+ *     lock, one typically clobbers the other).
+ *   - Writes are atomic (temp-file + rename), so readers never see a torn
+ *     file even though read() takes no lock.
+ *
+ * The lock is a zero-dependency sidecar file (O_CREAT|O_EXCL + mtime stale
+ * reclaim + retry/backoff), visible across processes sharing the same
+ * baseDir. POSIX locks are advisory — every writer must opt in.
+ */
+
+import { FilesystemMemoryStore } from 'agent-do';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const dataDir = mkdtempSync(join(tmpdir(), 'agent-do-concurrent-'));
+const store = new FilesystemMemoryStore(dataDir, {
+  lock: {
+    staleMs: 60_000, // reclaim locks left by a crashed process after 1 min
+    retry: { count: 50, minDelayMs: 5, maxDelayMs: 50 },
+  },
+});
+
+// Seed, then race two appends. With the lock they serialise; without it,
+// one append frequently overwrites the other.
+await store.write('demo', 'tasks.md', '');
+await Promise.all([
+  store.append('demo', 'tasks.md', '- [ ] task A\n'),
+  store.append('demo', 'tasks.md', '- [ ] task B\n'),
+  store.append('demo', 'tasks.md', '- [ ] task C\n'),
+]);
+
+const content = await store.read('demo', 'tasks.md');
+console.log('Final tasks.md (all three lines survived):\n' + content);
+console.log(`(data at ${dataDir})`);
+
+// The lock files are invisible to the agent's own view of its dir:
+const entries = await store.list('demo');
+console.log('list() entries:', entries.map((e) => e.name));

--- a/src/index.ts
+++ b/src/index.ts
@@ -131,6 +131,10 @@ export type { MemoryStore, FileEntry, SearchOptions } from './stores.js';
 export { InMemoryMemoryStore } from './stores/in-memory.js';
 export { FilesystemMemoryStore } from './stores/filesystem.js';
 export type { FilesystemMemoryStoreOptions } from './types.js';
+// File locking (#15 Tier 1) — opt-in cross-process safety for the filesystem store.
+export { acquireFileLock, withFileLock } from './stores/file-lock.js';
+export type { FileLockOptionsInternal } from './stores/file-lock.js';
+export type { FileLockOptions, LockHandle, LockAdapter } from './types.js';
 export { SandboxBackedMemoryStore } from './stores/sandbox.js';
 export type { SandboxBackedMemoryStoreOptions } from './stores/sandbox.js';
 

--- a/src/stores/file-lock.ts
+++ b/src/stores/file-lock.ts
@@ -1,0 +1,227 @@
+/**
+ * Zero-dependency cross-process file lock for `FilesystemMemoryStore` (#15 Tier 1).
+ *
+ * Same-process mutexes (`async-lock` and friends) only serialise within one
+ * Node process; they offer zero protection against the orchestrator's worker
+ * runs, separate `agent.run()` invocations, or cron-spawned processes (#79).
+ * This module provides a **filesystem** lock that is visible across every
+ * process that shares the same `baseDir` — the only kind of lock that works
+ * for scheduled / multi-process agents.
+ *
+ * Mechanism:
+ *  - `O_CREAT | O_EXCL` (atomic "create-if-absent"). One of the few
+ *    operations the POSIX spec guarantees atomic across local AND network
+ *    filesystems (NFS, EFS). The loser of the race gets EEXIST.
+ *  - **mtime-based stale reclaim**: a lock whose mtime is older than
+ *    `staleMs` is presumed abandoned (the holder crashed, was OOM-killed,
+ *    or the machine rebooted). We unlink + recreate. This is essential for
+ *    #79 — a scheduled job killed mid-write must leave a reclaimable lock.
+ *  - **retry/backoff** on contention: a process that loses the race waits
+ *    and retries up to `retry.count` times.
+ *
+ * Lock files live in `<baseDir>/.locks/<agentId>/<sha256>.lock`, keyed on
+ * the canonical resolved path so every process locking the same file agrees
+ * on the lock path. They are intentionally outside the agent's own dir so
+ * `list()` / `search()` / `read()` never surface bookkeeping.
+ *
+ * ## Limitations (documented)
+ *
+ * POSIX locks are **advisory**: a process that writes without acquiring the
+ * lock (e.g. an editor, a direct `fs.writeFile`, or a store instance created
+ * without the `lock` option) can still clobber a locked file. This matches
+ * `proper-lockfile` and every Node file-lock library. For hard isolation
+ * you'd need a sandboxed FS (#98) or a DB-backed store (#15 Tier 2).
+ *
+ * mtime granularity is 1s on some filesystems (ext3, older HFS+); for
+ * sub-second contention windows two holders can briefly believe a live lock
+ * is stale. The stale threshold defaults to 60s to make this vanishingly
+ * unlikely in practice; cron/orchestrator cadences are far coarser.
+ *
+ * Reads are intentionally NOT locked (see the #15 research brief): a read
+ * during a write could see a half-flushed file. Pair this lock with the
+ * store's atomic temp-write+rename so readers see either the old or the new
+ * file, never a partial one.
+ */
+
+import * as fsp from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { createHash } from 'node:crypto';
+import { type FileLockOptions, type LockHandle } from '../types.js';
+
+/** Default staleness threshold. Generous on purpose — see mtime caveat above. */
+const DEFAULT_STALE_MS = 60_000;
+
+/** Default contention backoff. */
+const DEFAULT_RETRY = { count: 20, minDelayMs: 25, maxDelayMs: 1000 };
+
+export interface FileLockOptionsInternal extends FileLockOptions {}
+
+/**
+ * Acquire an exclusive lock for `keyPath`, waiting/retrying on contention
+ * and reclaiming stale locks left by crashed holders.
+ *
+ * `keyPath` is the **canonical absolute path of the file being protected**
+ * (what `FilesystemMemoryStore.resolve()` returns). The actual lock file is
+ * derived from it deterministically via a SHA-256 of that path, so two
+ * processes that resolve the same logical file to the same canonical path
+ * share one lock file — even across machines that mount the same volume.
+ *
+ * `lockDirRoot` is the `<baseDir>/.locks` directory; the per-agent subdir
+ * is created under it.
+ *
+ * Returns a `LockHandle` whose `release()` removes the lock file. Best-effort:
+ * release never throws (ENOENT is ignored — the lock was already reclaimed).
+ *
+ * Throws when the lock can't be acquired within `retry.count` attempts.
+ */
+export async function acquireFileLock(
+  keyPath: string,
+  agentId: string,
+  lockDirRoot: string,
+  opts: FileLockOptions = {},
+): Promise<LockHandle> {
+  const staleMs = opts.staleMs ?? DEFAULT_STALE_MS;
+  const retry = { ...DEFAULT_RETRY, ...opts.retry };
+  const lockFile = lockPathFor(keyPath, agentId, lockDirRoot);
+
+  await fsp.mkdir(path.dirname(lockFile), { recursive: true });
+
+  let attempt = 0;
+  // Use the adapter if one was provided (proper-lockfile / fs-ext / a mock);
+  // otherwise the built-in zero-dep sidecar implementation.
+  if (opts.adapter) {
+    return opts.adapter.acquire(lockFile, { staleMs, retry });
+  }
+
+  const payload = lockPayload();
+  for (;;) {
+    try {
+      // 'wx' = O_CREAT | O_EXCL | O_WRONLY as a single flag string. Atomic
+      // across local AND network filesystems (NFS/EFS) per POSIX. fsp.open
+      // with the pipe-separated string ('O_CREAT | O_EXCL | O_WRONLY') is NOT
+      // accepted — it must be the symbolic flag name.
+      const fh = await fsp.open(lockFile, 'wx');
+      await fh.writeFile(payload);
+      await fh.close();
+      return makeHandle(lockFile);
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== 'EEXIST') throw err;
+      // Lost the race. Is the existing lock stale?
+      if (await isStale(lockFile, staleMs)) {
+        // Try to reclaim: unlink then loop back to the O_EXCL create.
+        // If another process reclaimed first, our create fails EEXIST
+        // again and we fall through to the retry/backoff below.
+        await fsp.unlink(lockFile).catch(() => { /* race: already gone */ });
+        continue;
+      }
+    }
+    if (++attempt > retry.count) {
+      throw new Error(
+        `Could not acquire file lock after ${retry.count} attempts: ${lockFile}. ` +
+        `Another process may be stuck; raise \`lock.staleMs\` (currently ${staleMs}ms) ` +
+        `or remove the lock file manually.`,
+      );
+    }
+    await sleep(backoffDelay(attempt, retry.minDelayMs, retry.maxDelayMs));
+  }
+}
+
+/**
+ * Convenience: acquire, run `fn`, release (even on throw). Returns `fn`'s
+ * result. The release happens in a `finally`, so a throwing critical section
+ * never leaks a lock.
+ */
+export async function withFileLock<T>(
+  keyPath: string,
+  agentId: string,
+  lockDirRoot: string,
+  opts: FileLockOptions,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const handle = await acquireFileLock(keyPath, agentId, lockDirRoot, opts);
+  try {
+    return await fn();
+  } finally {
+    await handle.release();
+  }
+}
+
+/**
+ * Derive a deterministic, traversal-safe lock file path for a data file.
+ *
+ * Hashing (rather than embedding the path) means a weird data path can never
+ * escape the `.locks/<agentId>/` dir via `..`, and the filename is always
+ * filesystem-safe regardless of the original path's characters. The first 16
+ * hex chars are appended in plain text purely for human readability when
+ * debugging a stuck lock (`ls .locks/agent/`).
+ */
+function lockPathFor(keyPath: string, agentId: string, lockDirRoot: string): string {
+  const hash = createHash('sha256').update(keyPath).digest('hex');
+  // Validate agentId defensively even though the store already validates it;
+  // this module is exported and could be called directly.
+  if (!/^[a-zA-Z0-9_.-]+$/.test(agentId)) {
+    throw new Error(`Invalid agentId for lock dir: ${agentId}`);
+  }
+  return path.join(lockDirRoot, agentId, `${hash.slice(0, 16)}.lock`);
+}
+
+/** JSON payload written into the lock file. PID/host are for debugging only. */
+function lockPayload(): string {
+  return JSON.stringify({
+    pid: process.pid,
+    hostname: os.hostname(),
+    acquiredAt: Date.now(),
+  });
+}
+
+/**
+ * True iff the lock file at `p` has not been touched within `staleMs`.
+ *
+ * Uses mtime rather than the payload's `acquiredAt`: mtime is updated by the
+ * filesystem and can't lie about a process that crashed before it could write
+ * a heartbeat. (proper-lockfile uses an mtime heartbeat for the same reason.)
+ * Throws other fs errors up — a permissions issue on the lock dir is a real
+ * problem, not a "the lock is stale" signal.
+ */
+async function isStale(lockFile: string, staleMs: number): Promise<boolean> {
+  let st: { mtimeMs: number };
+  try {
+    st = await fsp.stat(lockFile);
+  } catch (err) {
+    // Vanished between our EEXIST and the stat — another process reclaimed
+    // and released already. Treat as "not stale" so the caller retries the
+    // create; it'll either succeed (file gone) or EEXIST again.
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return false;
+    throw err;
+  }
+  return Date.now() - st.mtimeMs > staleMs;
+}
+
+function makeHandle(lockFile: string): LockHandle {
+  return {
+    async release(): Promise<void> {
+      // Best-effort. The lock may already be gone if this process stalled
+      // past staleMs and another holder reclaimed + released it.
+      await fsp.unlink(lockFile).catch((err: NodeJS.ErrnoException) => {
+        if (err.code !== 'ENOENT') throw err;
+      });
+    },
+  };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Exponential-ish backoff with jitter, capped at maxDelayMs. Keeps contended
+ * writers from thundering onto the lock in lockstep.
+ */
+function backoffDelay(attempt: number, minDelayMs: number, maxDelayMs: number): number {
+  const base = Math.min(maxDelayMs, minDelayMs * 2 ** (attempt - 1));
+  // Jitter ±25% so N waiters don't retry in unison.
+  const jitter = base * 0.25 * (Math.random() * 2 - 1);
+  return Math.max(0, Math.round(base + jitter));
+}

--- a/src/stores/filesystem.ts
+++ b/src/stores/filesystem.ts
@@ -35,10 +35,12 @@
 import * as fs from 'node:fs';
 import * as fsp from 'node:fs/promises';
 import * as path from 'node:path';
+import { randomBytes } from 'node:crypto';
 import type { MemoryStore, FileEntry, SearchOptions } from '../stores.js';
 import type { FilesystemMemoryStoreOptions } from '../types.js';
 import { buildLineMatcher } from './search-matcher.js';
 import { validateAgentId } from './agent-id.js';
+import { withFileLock } from './file-lock.js';
 
 export type { FilesystemMemoryStoreOptions } from '../types.js';
 
@@ -159,35 +161,42 @@ export class FilesystemMemoryStore implements MemoryStore {
   async write(agentId: string, filePath: string, content: string): Promise<void> {
     await this.checkWrite(agentId, filePath, 'write');
     const full = await this.resolve(agentId, filePath);
-    await fsp.mkdir(path.dirname(full), { recursive: true });
-    await fsp.writeFile(full, content, 'utf-8');
+    await this.mutateLocked(agentId, full, () => atomicWrite(full, content));
   }
 
   async append(agentId: string, filePath: string, content: string): Promise<void> {
     await this.checkWrite(agentId, filePath, 'append');
     const full = await this.resolve(agentId, filePath);
-    await fsp.mkdir(path.dirname(full), { recursive: true });
-    await fsp.appendFile(full, content, 'utf-8');
+    await this.mutateLocked(agentId, full, async () => {
+      await fsp.mkdir(path.dirname(full), { recursive: true });
+      // Append uses a plain appendFile under the lock. (No temp+rename here
+      // because append is inherently additive — a reader might see a partial
+      // last line, which is the pre-existing contract. The lock still
+      // serialises appends so two writers don't interleave.)
+      await fsp.appendFile(full, content, 'utf-8');
+    });
   }
 
   async delete(agentId: string, filePath: string): Promise<void> {
     await this.checkWrite(agentId, filePath, 'delete');
     const full = await this.resolve(agentId, filePath);
-    try {
-      await fsp.unlink(full);
-    } catch (err) {
-      // Match the previous `existsSync` precheck behaviour: delete is
-      // idempotent for any path that doesn't refer to a real file. The
-      // pre-migration code silently returned on ENOENT and also on
-      // paths like `"file.txt/child"` (where `existsSync` returned
-      // false). async `unlink` surfaces the latter as `ENOTDIR` on
-      // POSIX, `ENOTDIR`/`ENOENT` on Windows — treat all three as
-      // "nothing to delete" so hallucinated nested paths from the
-      // model don't surface as tool errors.
-      const code = (err as NodeJS.ErrnoException).code;
-      if (code === 'ENOENT' || code === 'ENOTDIR') return;
-      throw err;
-    }
+    await this.mutateLocked(agentId, full, async () => {
+      try {
+        await fsp.unlink(full);
+      } catch (err) {
+        // Match the previous `existsSync` precheck behaviour: delete is
+        // idempotent for any path that doesn't refer to a real file. The
+        // pre-migration code silently returned on ENOENT and also on
+        // paths like `"file.txt/child"` (where `existsSync` returned
+        // false). async `unlink` surfaces the latter as `ENOTDIR` on
+        // POSIX, `ENOTDIR`/`ENOENT` on Windows — treat all three as
+        // "nothing to delete" so hallucinated nested paths from the
+        // model don't surface as tool errors.
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code === 'ENOENT' || code === 'ENOTDIR') return;
+        throw err;
+      }
+    });
   }
 
   async list(agentId: string, dirPath?: string): Promise<FileEntry[]> {
@@ -221,7 +230,40 @@ export class FilesystemMemoryStore implements MemoryStore {
 
   async mkdir(agentId: string, dirPath: string): Promise<void> {
     await this.checkWrite(agentId, dirPath, 'mkdir');
-    await fsp.mkdir(await this.resolve(agentId, dirPath), { recursive: true });
+    const full = await this.resolve(agentId, dirPath);
+    // mkdir has no file body to corrupt, but we still take the lock so a
+    // concurrent writer/deleter on the same path can't race the directory
+    // into existence. read/list remain unlocked.
+    await this.mutateLocked(agentId, full, () => fsp.mkdir(full, { recursive: true }));
+  }
+
+  /**
+   * Run a mutating fs op, optionally under the cross-process file lock.
+   *
+   * `lockDirRoot` derives from baseDir so the `.locks/` tree lives alongside
+   * agent data and is shared by every process pointing at the same baseDir.
+   * When `options.lock` is unset this is a thin `await fn()` wrapper — zero
+   * behaviour change versus the pre-#15 store.
+   */
+  private async mutateLocked<T>(
+    agentId: string,
+    canonicalPath: string,
+    fn: () => Promise<T>,
+  ): Promise<T> {
+    const lock = this.options.lock;
+    if (!lock) {
+      await fsp.mkdir(path.dirname(canonicalPath), { recursive: true }).catch(() => {});
+      return fn();
+    }
+    return withFileLock(canonicalPath, agentId, this.lockDirRoot(), lock, async () => {
+      await fsp.mkdir(path.dirname(canonicalPath), { recursive: true }).catch(() => {});
+      return fn();
+    });
+  }
+
+  /** `<baseDir>/.locks` — shared across agents, invisible to per-agent list(). */
+  private lockDirRoot(): string {
+    return path.join(this.baseDir, '.locks');
   }
 
   async exists(agentId: string, filePath: string): Promise<boolean> {
@@ -298,6 +340,28 @@ export class FilesystemMemoryStore implements MemoryStore {
         /* skip binary / unreadable files */
       }
     }
+  }
+}
+
+/**
+ * Atomic write: temp file in the same dir, then rename (#15 Tier 1).
+ *
+ * `rename(2)` is atomic on POSIX (the dir entry flips in one step) and
+ * overwrites-atomically on Windows (REPLACE_EXISTING semantics). Writing
+ * the body to a sibling temp file first means a concurrent **unlocked**
+ * reader (read() takes no lock by design) can never observe a partially
+ * flushed file — it sees either the previous content or the new content,
+ * never a torn write. The temp file is cleaned up on failure.
+ */
+async function atomicWrite(full: string, content: string): Promise<void> {
+  await fsp.mkdir(path.dirname(full), { recursive: true });
+  const tmp = `${full}.${process.pid}.${randomBytes(6).toString('hex')}.tmp`;
+  try {
+    await fsp.writeFile(tmp, content, 'utf-8');
+    await fsp.rename(tmp, full);
+  } catch (err) {
+    await fsp.unlink(tmp).catch(() => { /* best effort; already gone */ });
+    throw err;
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -672,6 +672,72 @@ export interface FilesystemMemoryStoreOptions {
    * Supports both sync and async callbacks.
    */
   onBeforeWrite?: (agentId: string, filePath: string, operation: 'write' | 'append' | 'delete' | 'mkdir') => boolean | Promise<boolean>;
+  /**
+   * Opt-in cross-process safety for read-modify-write on shared files (#15).
+   *
+   * When set, every mutating method (write/append/delete/mkdir) acquires an
+   * exclusive sidecar file lock scoped to the file's canonical path before
+   * touching it, retrying on contention and auto-reclaiming locks left by a
+   * crashed process. The lock is visible to every process sharing the same
+   * `baseDir`, so it protects against orchestrator workers, overlapping
+   * `run()` calls, and cron-spawned processes (#79) — not just within one
+   * Node process.
+   *
+   * Writes also become atomic (temp-file + rename), so unlocked readers
+   * never see a half-flushed file.
+   *
+   * `undefined` preserves today's naive-overwrite behaviour byte-for-byte.
+   * POSIX locks are advisory: a process that writes without this option set
+   * can still clobber a locked file. See `src/stores/file-lock.ts`.
+   */
+  lock?: FileLockOptions;
+}
+
+// ── File locking (#15 Tier 1) ──────────────────────────────────────────
+
+/**
+ * Handle returned by a successful lock acquisition. Releasing drops the
+ * lock file; release is best-effort and never throws on ENOENT (the lock
+ * may already have been reclaimed by a stale-lock sweeper).
+ */
+export interface LockHandle {
+  release(): Promise<void>;
+}
+
+/**
+ * Swappable lock primitive. The default implementation in
+ * `src/stores/file-lock.ts` is zero-dependency; pass an adapter to plug in
+ * `proper-lockfile`, `fs-ext`, or a test double without agent-do taking a
+ * hard dependency on it.
+ */
+export interface LockAdapter {
+  /**
+   * @param lockFile the derived sidecar lock path (deterministic per data file).
+   * @param opts resolved stale/retry thresholds (defaults already applied).
+   */
+  acquire(lockFile: string, opts: { staleMs: number; retry: { count: number; minDelayMs: number; maxDelayMs: number } }): Promise<LockHandle>;
+}
+
+export interface FileLockOptions {
+  /** Reserved discriminator. Defaults to `'file'`; future adapters
+   *  (`'fcntl'`, `'sqlite'`) keep the option shape forward-compatible. */
+  type?: 'file';
+  /**
+   * Reclaim a lock whose mtime is older than this. Essential for cron-driven
+   * runs (#79): a job killed mid-write leaves a lock that the next scheduled
+   * invocation must be able to take over. Default 60_000ms.
+   */
+  staleMs?: number;
+  /** Contention backoff. Defaults to { count: 20, minDelayMs: 25, maxDelayMs: 1000 }.
+   *  `count` is the number of retries before giving up. */
+  retry?: { count?: number; minDelayMs?: number; maxDelayMs?: number };
+  /**
+   * Plug in a battle-tested lock (e.g. `proper-lockfile` for NFS-perfect
+   * atomicity, or a mock for tests). Defaults to the built-in zero-dep
+   * sidecar lock. Lets advanced users get stronger guarantees without
+   * agent-do depending on the library.
+   */
+  adapter?: LockAdapter;
 }
 
 // Agent instance

--- a/tests/file-lock.test.ts
+++ b/tests/file-lock.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, readdir, utimes } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { FilesystemMemoryStore } from '../src/stores/filesystem.js';
+import { acquireFileLock, withFileLock } from '../src/stores/file-lock.js';
+import type { FileLockOptions, LockAdapter, LockHandle } from '../src/types.js';
+
+let dir: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'file-lock-'));
+});
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+// ── acquireFileLock / withFileLock ──────────────────────────────────────
+
+describe('acquireFileLock', () => {
+  it('acquires and releases cleanly', async () => {
+    const handle = await acquireFileLock(join(dir, 'a.md'), 'agent1', join(dir, '.locks'));
+    await handle.release();
+    // Releasing drops every lock file for agent1.
+    const lockDir = join(dir, '.locks', 'agent1');
+    const files = await readdir(lockDir).catch(() => [] as string[]);
+    expect(files.filter((f) => f.endsWith('.lock'))).toEqual([]);
+  });
+
+  it('serialises concurrent holders of the same key (mutual exclusion)', async () => {
+    // Two acquires for the SAME canonical path must not overlap. We detect
+    // overlap by holding the first lock until a flag flips, then asserting
+    // the second only entered after the flag was set.
+    const key = join(dir, 'shared.md');
+    let heldSecond = false;
+    let overlapDetected = false;
+
+    const h1 = await acquireFileLock(key, 'agent1', join(dir, '.locks'));
+    const p2 = (async () => {
+      await acquireFileLock(key, 'agent1', join(dir, '.locks'), {
+        retry: { count: 50, minDelayMs: 5, maxDelayMs: 20 },
+      }).then(async (h) => {
+        heldSecond = true;
+        await h.release();
+      });
+    })();
+
+    // Give p2 a chance to (incorrectly) acquire while h1 still holds.
+    await new Promise((r) => setTimeout(r, 30));
+    if (heldSecond) overlapDetected = true;
+
+    await h1.release();
+    await p2;
+    expect(overlapDetected).toBe(false);
+  });
+
+  it('reclaims a stale lock past staleMs', async () => {
+    const key = join(dir, 'stale.md');
+    // Acquire then backdate its mtime to before the threshold.
+    const h1 = await acquireFileLock(key, 'agent1', join(dir, '.locks'));
+    const lockDir = join(dir, '.locks', 'agent1');
+    const old = new Date(Date.now() - 120_000);
+    const files = await readdir(lockDir);
+    const lf = join(lockDir, files[0]!);
+    await utimes(lf, old, old);
+    await h1.release(); // best-effort; file may persist if backdated after open
+
+    // A fresh acquire with staleMs=1000 should succeed despite the leftover lock.
+    const h2 = await acquireFileLock(key, 'agent1', join(dir, '.locks'), {
+      staleMs: 1000,
+      retry: { count: 2, minDelayMs: 1, maxDelayMs: 2 },
+    });
+    expect(h2).toBeDefined();
+    await h2.release();
+  });
+
+  it('throws after exhausting retries when the lock is held and fresh', async () => {
+    const key = join(dir, 'held.md');
+    const h1 = await acquireFileLock(key, 'agent1', join(dir, '.locks'));
+    await expect(
+      acquireFileLock(key, 'agent1', join(dir, '.locks'), {
+        staleMs: 60_000,
+        retry: { count: 3, minDelayMs: 1, maxDelayMs: 2 },
+      }),
+    ).rejects.toThrow(/Could not acquire file lock/);
+    await h1.release();
+  });
+
+  it('delegates to a provided adapter', async () => {
+    const calls: string[] = [];
+    const adapter: LockAdapter = {
+      async acquire(_lockFile, _opts) {
+        calls.push('acquire');
+        return { async release() { calls.push('release'); } };
+      },
+    };
+    const opts: FileLockOptions = { adapter };
+    await withFileLock(join(dir, 'x.md'), 'agent1', join(dir, '.locks'), opts, async () => {
+      calls.push('body');
+    });
+    expect(calls).toEqual(['acquire', 'body', 'release']);
+  });
+});
+
+describe('withFileLock', () => {
+  it('releases the lock even when the critical section throws', async () => {
+    const key = join(dir, 'throwy.md');
+    await expect(
+      withFileLock(key, 'agent1', join(dir, '.locks'), {}, async () => {
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+    // Lock must be gone — a subsequent acquire should succeed immediately.
+    const h = await acquireFileLock(key, 'agent1', join(dir, '.locks'), {
+      retry: { count: 2, minDelayMs: 1, maxDelayMs: 2 },
+    });
+    await h.release();
+  });
+
+  it('returns the critical section result', async () => {
+    const out = await withFileLock(
+      join(dir, 'r.md'), 'agent1', join(dir, '.locks'), {},
+      async () => 42,
+    );
+    expect(out).toBe(42);
+  });
+});
+
+// ── FilesystemMemoryStore integration ───────────────────────────────────
+
+describe('FilesystemMemoryStore — lock option', () => {
+  it('is byte-identical to the unlocked behaviour when `lock` is undefined', async () => {
+    const store = new FilesystemMemoryStore(join(dir, 'plain'));
+    await store.write('agent1', 'note.md', 'hello');
+    expect(await store.read('agent1', 'note.md')).toBe('hello');
+    // No .locks dir is created when the option is off.
+    await expect(readdir(join(dir, 'plain'))).resolves.not.toContain('.locks');
+  });
+
+  it('serialises concurrent writes to the same file', async () => {
+    const store = new FilesystemMemoryStore(join(dir, 'locked'), {
+      lock: { staleMs: 60_000, retry: { count: 100, minDelayMs: 5, maxDelayMs: 20 } },
+    });
+    // Two appends racing without a lock would interleave / lose one; with
+    // the lock they serialise and both lines land.
+    await Promise.all([
+      store.append('agent1', 'log.md', 'line-a\n'),
+      store.append('agent1', 'log.md', 'line-b\n'),
+    ]);
+    const content = await store.read('agent1', 'log.md');
+    const a = (content.match(/line-a/g) || []).length;
+    const b = (content.match(/line-b/g) || []).length;
+    expect(a).toBe(1);
+    expect(b).toBe(1);
+  });
+
+  it('makes writes atomic — readers only ever see complete values', async () => {
+    // The temp+rename complement to locking: read() takes no lock, so it
+    // must see either the old or the new content, never a torn write.
+    // We run many writes while reading concurrently and assert every read
+    // returns a *complete* well-formed value (old or one of the new ones),
+    // never a truncated/partial body.
+    const store = new FilesystemMemoryStore(join(dir, 'atomic'), {
+      lock: { retry: { count: 50, minDelayMs: 1, maxDelayMs: 4 } },
+    });
+    const MARKER = 'X'.repeat(4000);
+    await store.write('agent1', 'snap.md', 'OLD');
+
+    let writesDone = false;
+    const writer = (async () => {
+      for (let i = 0; i < 25; i++) {
+        await store.write('agent1', 'snap.md', `NEW-${i}-${MARKER}`);
+      }
+      writesDone = true;
+    })();
+
+    const valid = (c: string): boolean => c === 'OLD' || /^NEW-\d+-X{4000}$/.test(c);
+    const reads: Promise<void>[] = [];
+    for (let r = 0; r < 25; r++) {
+      reads.push((async () => {
+        // Stagger reads slightly so some land mid-write.
+        await new Promise((s) => setTimeout(s, r));
+        const c = await store.read('agent1', 'snap.md').catch(() => null);
+        // A read either fails (rare, mid-rename) or returns a complete value.
+        // It must NEVER return a partial body (old/new marker without full X run).
+        if (c !== null) expect(valid(c)).toBe(true);
+      })());
+    }
+
+    await writer;
+    await Promise.all(reads);
+    expect(writesDone).toBe(true);
+    // Final state is exactly the last write — no corruption.
+    expect(await store.read('agent1', 'snap.md')).toBe(`NEW-24-${MARKER}`);
+  });
+
+  it('keeps lock files invisible to per-agent list()', async () => {
+    const store = new FilesystemMemoryStore(join(dir, 'hidden'), { lock: {} });
+    await store.write('agent1', 'data.md', 'x');
+    const entries = await store.list('agent1');
+    const names = entries.map((e) => e.name);
+    expect(names).toContain('data.md');
+    expect(names.some((n) => n.endsWith('.lock'))).toBe(false);
+    expect(names).not.toContain('.locks');
+  });
+
+  it('respects readOnly even when lock is set', async () => {
+    const store = new FilesystemMemoryStore(join(dir, 'ro'), {
+      readOnly: true,
+      lock: {},
+    });
+    await expect(store.write('agent1', 'x.md', 'y')).rejects.toThrow(/read-only/);
+  });
+});
+
+// ── helpers ────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #15 Tier 1 (unblocks #79). Per the [concurrency research brief](https://gist.github.com/) — the decisive call was **zero-dep sidecar file locking** as the default over CRDTs/DBs, because it's the only option that (a) adds 0 bytes / 0 deps, (b) matches the repo's bespoke-utility ethos (`pMap`/`realpathSafe`), and (c) satisfies #79's cross-process requirement.

## What it does
- Opt-in `lock` on `FilesystemMemoryStoreOptions`. When set, `write`/`append`/`delete`/`mkdir` acquire an exclusive lock keyed on the file's canonical path, retry on contention, auto-reclaim stale locks. **`undefined` = today's behaviour, unchanged.**
- Lock = `O_CREAT|O_EXCL` atomic create + **mtime-based stale reclaim** (essential for cron — a killed job's lock must be reclaimable) + retry/backoff with jitter.
- Lock files live in `<baseDir>/.locks/<agentId>/<sha>.lock` — **invisible** to the agent's own `list()`/`search()`/`read()`.
- **Writes become atomic** (temp-file + `rename`) — the complement to locking, since `read()` takes no lock. A reader sees either old or new, never a torn file.
- `LockAdapter` swappable interface → plug in `proper-lockfile`/`fs-ext` for NFS-perfect atomicity without agent-do depending on them.

## New exports
`acquireFileLock`, `withFileLock`, types `FileLockOptions` / `LockHandle` / `LockAdapter`.

## Verification
`typecheck` ✅ · `build` ✅ · **794 tests** ✅ (782 + 12 new) · mock eval ✅ · example 23 smoke ✅ (3 concurrent appends all survived; `list()` shows no `.lock` files). 12 tests cover: acquire/release, **mutual exclusion** (overlap detection), stale reclaim, retry exhaustion, adapter delegation, atomic reads (no torn writes under concurrent read/write), lock-file invisibility, readOnly-respected, and the no-op-when-undefined path.

## Notes
- POSIX locks are **advisory** (documented) — a writer that doesn't opt in can still clobber. For genuinely-concurrent *merge* semantics, a lazily-imported CRDT store (`agent-do/stores/crdt`, Yjs ~18kB) is the planned Tier-2 follow-up.
- This is the keystone for #79: scheduled tasks can now reuse \`lock\`'s staleMs + exclusivity instead of inventing their own concurrency story.