### PR TITLE
feat: scheduled tasks — cron-driven agent runs with lock-file concurrency (#79)

### DIFF
--- a/.changeset/scheduled-tasks.md
+++ b/.changeset/scheduled-tasks.md
@@ -1,0 +1,19 @@
+---
+"agent-do": minor
+---
+
+Add **scheduled tasks** — declarative cron-driven agent runs with lock-file concurrency (#79). Many useful agents run on a schedule (inbox sweep every 15 min, daily brief at 8am, weekly digest); now that's a first-class primitive instead of hand-rolled cron/systemd per agent.
+
+```bash
+npx agent-do scheduled-tasks list        # show configured tasks
+npx agent-do scheduled-tasks install     # emit crontab lines for your tasks
+npx agent-do scheduled-tasks run <id>    # run one task (lock-protected)
+npx agent-do scheduled-tasks status      # last-run times + outcomes
+npx agent-do scheduled-tasks start       # foreground loop (dev/test)
+```
+
+Tasks live in a JSON file (`<memoryDir>/scheduled-tasks.json`). The production wiring is **system cron**: `install` emits one crontab line per task that calls `scheduled-tasks run <id>`, so the system cron does the timing and agent-do does the safe execution. Every run acquires the #15 file lock, so **overlapping firings skip** and a crashed run is reclaimed after `staleMs` — the cross-process guarantee a scheduler needs and an in-process mutex can't provide. Last-run metadata is recorded in `scheduler-status.json`.
+
+The cron matcher (`matchesCron`) is dependency-free, supports the portable 5-field numeric subset (`*/n`, ranges, lists, Vixie dom/dow OR-semantics), and throws clearly on malformed expressions. New exports: `matchesCron`, `validateScheduledTasks`, `readStatus`/`writeStatus`/`recordRun`, `runScheduledTask`, and types `ScheduledTask`/`ScheduledTasksConfig`/`TaskStatus`. `AgentConfig.scheduledTasks?: ScheduledTask[]` is validated at `createAgent()` time.
+
+Builds directly on #15 Tier 1's file lock. `sessionTarget: 'main'` (persistent conversation) and `wakeMode: 'systemEvent'` (structured wake event) are reserved in v1 — every run is isolated and the payload is treated as the task text; they're follow-ups pending a history store and an event channel.

--- a/README.md
+++ b/README.md
@@ -653,6 +653,103 @@ shell scripts. `--read-only` and `--no-tools` narrow the blast radius.
 See [`examples/22-shellm.shellm`](examples/22-shellm.shellm) for a
 runnable sample with frontmatter.
 
+## Scheduled Tasks
+
+Many useful agents don't run on-demand — they run on a schedule. Inbox
+sweep every 15 min, daily brief at 8am, weekly digest on Sunday.
+`agent-do scheduled-tasks` turns a cron entry into a safe, overlap-proof
+agent run. The production wiring is **system cron**: `install` emits the
+crontab lines, and the system cron invokes `run <id>` on schedule.
+
+### Define tasks
+
+Tasks live in a JSON file (`<memoryDir>/scheduled-tasks.json` by default,
+overridable with `--tasks <path>`):
+
+```json
+[
+  {
+    "id": "inbox-triage",
+    "cron": "*/15 8-21 * * *",
+    "payload": "Read inbox.md and move anything actionable into tasks.md. If there's nothing new, reply with just OK.",
+    "description": "inbox sweep every 15 min during work hours"
+  },
+  {
+    "id": "daily-brief",
+    "cron": "0 8 * * 1-5",
+    "payload": "Summarise this week's tracker.md into a three-line daily brief.",
+    "description": "weekday 8am brief"
+  }
+]
+```
+
+`cron` is standard 5-field (minute hour dom month dow; 0 and 7 both Sunday).
+The portable numeric subset is supported — `*/n`, ranges, comma lists, and
+Vixie dom/dow OR-semantics. Month/weekday names and `L`/`W`/`#` are not
+(support varies by platform cron).
+
+### CLI
+
+```bash
+npx agent-do scheduled-tasks list                          # show configured tasks
+npx agent-do scheduled-tasks status                        # last-run times + outcomes
+npx agent-do scheduled-tasks install                       # emit crontab lines to stdout
+npx agent-do scheduled-tasks run inbox-triage              # run one task now (lock-protected)
+npx agent-do scheduled-tasks start                         # foreground loop (dev/test)
+```
+
+`install` prints one crontab line per task that calls
+`agent-do scheduled-tasks run <id>`. Append the output to your crontab
+(`crontab -e`) or a systemd timer — the system cron does the timing,
+agent-do does the safe execution:
+
+```
+*/15 8-21 * * * /usr/bin/env agent-do scheduled-tasks run inbox-triage --tasks "/abs/tasks.json" --memory "/abs/.data"
+```
+
+### Overlap safety
+
+Every `run` acquires the [#15 file lock](#concurrent-access-locking-15)
+before executing, so **overlapping firings skip** (cron fired before the
+previous run finished, or two hosts share the same `--memory` dir). A
+run killed mid-execution leaves a lock that the next firing reclaims after
+`staleMs` (default 15 min) — exactly the cross-process guarantee a scheduler
+needs and an in-process mutex can't provide. Last-run times, outcomes, and
+run counts are recorded in `<memoryDir>/scheduler-status.json`.
+
+### Library API
+
+```ts
+import { createAgent } from 'agent-do';
+import { matchesCron, runScheduledTask } from 'agent-do';
+
+const agent = createAgent({
+  /* ... */
+  scheduledTasks: [
+    { id: 'sweep', cron: '*/15 * * * *', payload: 'triage inbox' },
+  ],
+});
+
+// Drive a run yourself (the lock + status recording are reusable):
+await runScheduledTask('sweep', {
+  memoryDir: './.data',
+  statusFile: './.data/scheduler-status.json',
+  payload: 'triage inbox',
+  run: (text) => agent.run(text),
+});
+
+matchesCron('*/15 * * * *', new Date()); // → boolean, for your own scheduler
+```
+
+`sessionTarget: 'main'` (persistent conversation) and
+`wakeMode: 'systemEvent'` (structured wake event) are accepted in the schema
+but **reserved in v1** — every run is isolated, and the payload is treated as
+the task text. They're noted follow-ups once agent-do ships a history store
+and an event channel.
+
+See [`examples/scheduled-tasks/tasks.json`](examples/scheduled-tasks/tasks.json)
+for a runnable task file.
+
 ## Tools
 
 Define tools using the Vercel AI SDK's `tool()` function:
@@ -1653,6 +1750,7 @@ The [`examples/`](examples/) directory contains runnable examples:
 | 21 | [`21-slash-commands.ts`](examples/21-slash-commands.ts) | Slash-command router — deterministic `/<name>` dispatch to sub-agents |
 | 22 | [`22-shellm.shellm`](examples/22-shellm.shellm) | Shellm — a prompt file you `chmod +x` and run directly (shebang + frontmatter) |
 | 23 | [`23-concurrent-store.ts`](examples/23-concurrent-store.ts) | Concurrent MemoryStore access — opt-in cross-process file locking (#15) |
+| 24 | [`scheduled-tasks/tasks.json`](examples/scheduled-tasks/tasks.json) | Scheduled tasks — cron-driven agent runs with lock-file concurrency (#79) |
 
 Run any example: `npx tsx examples/01-basic-agent.ts`
 

--- a/examples/scheduled-tasks/tasks.json
+++ b/examples/scheduled-tasks/tasks.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": "inbox-triage",
+    "cron": "*/15 8-21 * * *",
+    "payload": "Read inbox.md and move anything actionable into tasks.md. If there's nothing new, reply with just OK.",
+    "description": "Chief-of-staff inbox sweep, every 15 min during work hours"
+  },
+  {
+    "id": "daily-brief",
+    "cron": "0 8 * * 1-5",
+    "payload": "Summarise this week's tracker.md into a three-line daily brief for today.",
+    "description": "Weekday 8am brief"
+  }
+]

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,6 +1,7 @@
 import type { Agent, AgentConfig, ConversationMessage, ProgressEvent } from './types.js';
 import { runAgentLoop, streamAgentLoop } from './loop.js';
 import { validateSlashCommands, markHasSlashCommands } from './slash-commands.js';
+import { validateScheduledTasks } from './scheduled-tasks.js';
 
 /**
  * Create an Agent instance from configuration.
@@ -17,6 +18,11 @@ export function createAgent(config: AgentConfig): Agent {
   const slashError = validateSlashCommands(config.slashCommands);
   if (slashError) {
     throw new Error(`Invalid agent config: ${slashError}`);
+  }
+  // Scheduled tasks are validated up front so a typo in a cron expression
+  // surfaces at construction, not on the first firing (#79).
+  if (config.scheduledTasks) {
+    validateScheduledTasks(config.scheduledTasks);
   }
 
   let abortController: AbortController | null = null;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,7 @@ import { parseArgs, type ParsedArgs } from './cli/args.js';
 import { runPromptMode } from './cli/prompt.js';
 import { runScriptMode } from './cli/script.js';
 import { runEvalMode } from './cli/eval-cmd.js';
+import { runScheduledTasksMode } from './cli/scheduled-tasks-cmd.js';
 import { createSavedAgent, listSavedAgents } from './cli/agents.js';
 
 async function main(): Promise<void> {
@@ -51,6 +52,9 @@ async function main(): Promise<void> {
       case 'list':
         await listSavedAgents();
         break;
+      case 'scheduled-tasks':
+        await runScheduledTasksMode(args);
+        break;
     }
   } catch (err) {
     console.error(err instanceof Error ? err.message : String(err));
@@ -72,6 +76,7 @@ Usage:
   npx agent-do list                        List saved agents
   npx agent-do run <name|file> [task]      Run a saved agent or script file
   npx agent-do eval <file|dir> [options]   Run eval cases
+  npx agent-do scheduled-tasks <verb>      Cron-driven runs (run|list|status|install|start)
 
 Piping:
   echo "context" | npx agent-do "prompt"   Merge piped input with prompt
@@ -153,6 +158,8 @@ Examples:
   npx agent-do list
   cat README.md | npx agent-do "Summarize this"
   npx agent-do eval evals/basic.ts --compare anthropic,google --output json
+  npx agent-do scheduled-tasks install   # emit crontab lines for your tasks
+  npx agent-do scheduled-tasks run sweep  # run one task under a lock
 `);
 }
 

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -9,7 +9,7 @@ import { parseProviderOptions } from './provider-tools.js';
 import type { ProviderOptions } from '../types.js';
 
 export interface ParsedArgs {
-  command: 'prompt' | 'run' | 'eval' | 'create' | 'list';
+  command: 'prompt' | 'run' | 'eval' | 'create' | 'list' | 'scheduled-tasks';
   prompt?: string;
   file?: string;
   agentName?: string;
@@ -45,6 +45,13 @@ export interface ParsedArgs {
   output: 'console' | 'json' | 'csv';
   compare?: string[];
   concurrency: number;
+  // Scheduled-tasks-specific (#79)
+  /** Which scheduled-tasks verb: list|status|install|start|run. */
+  scheduledTasksSubcommand?: 'list' | 'status' | 'install' | 'start' | 'run';
+  /** Task id for `scheduled-tasks run <id>`. */
+  scheduledTaskId?: string;
+  /** Tasks registry file. Default <memoryDir>/scheduled-tasks.json. */
+  tasksFile?: string;
   /**
    * Opt-in for script-file import (#19, C-03). Without this flag, `run
    * <path>` refuses to `await import()` a local file. Only saved-agent
@@ -175,6 +182,17 @@ export function parseArgs(argv: string[]): ParsedArgs {
     } else if (first === 'list') {
       args.command = 'list';
       i = 1;
+    } else if (first === 'scheduled-tasks') {
+      args.command = 'scheduled-tasks';
+      i = 1;
+      // Sub-verb is the next positional.
+      const next = argv[1];
+      if (next === 'list' || next === 'status' || next === 'install' || next === 'start' || next === 'run') {
+        args.scheduledTasksSubcommand = next;
+        i = 2;
+      } else {
+        throw new Error('Usage: agent-do scheduled-tasks <list|status|install|start|run <id>>');
+      }
     }
   }
 
@@ -193,6 +211,8 @@ export function parseArgs(argv: string[]): ParsedArgs {
       args.workingDir = requireValue(argv, ++i, arg);
     } else if (arg === '--memory') {
       args.memoryDir = requireValue(argv, ++i, '--memory');
+    } else if (arg === '--tasks') {
+      args.tasksFile = requireValue(argv, ++i, '--tasks');
     } else if (arg === '--with-memory') {
       args.withMemory = true;
     } else if (arg === '--read-only') {
@@ -305,11 +325,21 @@ export function parseArgs(argv: string[]): ParsedArgs {
     args.agentName = positional[0];
   } else if (args.command === 'list') {
     // no positional args needed
+  } else if (args.command === 'scheduled-tasks') {
+    // `run` takes a task id as its first positional; the other verbs take none.
+    if (positional.length > 0) {
+      args.scheduledTaskId = positional[0];
+    }
   } else {
     // prompt mode — all positional args become the prompt
     if (positional.length > 0) {
       args.prompt = positional.join(' ');
     }
+  }
+
+  // Default the tasks file to <memoryDir>/scheduled-tasks.json unless overridden.
+  if (args.command === 'scheduled-tasks' && !args.tasksFile) {
+    args.tasksFile = `${args.memoryDir}/scheduled-tasks.json`;
   }
 
   // Derive `verbose` and `showContent` from the final `logLevel`.

--- a/src/cli/scheduled-tasks-cmd.ts
+++ b/src/cli/scheduled-tasks-cmd.ts
@@ -1,0 +1,235 @@
+/**
+ * CLI subcommand: `agent-do scheduled-tasks` (#79).
+ *
+ * Manages cron-driven agent runs. Tasks live in a JSON file
+ * (`<memoryDir>/scheduled-tasks.json` by default) so `install` can emit
+ * crontab entries from the same source the operator edits.
+ *
+ *   agent-do scheduled-tasks list [--tasks <file>]
+ *   agent-do scheduled-tasks run <id> [--tasks <file>] [--memory <dir>] [model opts]
+ *   agent-do scheduled-tasks status [--tasks <file>] [--memory <dir>]
+ *   agent-do scheduled-tasks install [--tasks <file>]
+ *   agent-do scheduled-tasks start [--tasks <file>] [--memory <dir>]
+ *
+ * Each `run` acquires the #15 file lock and records last-run status, so
+ * overlapping cron firings skip and a crashed run is reclaimed. `install`
+ * emits one crontab line per task that calls back into
+ * `agent-do scheduled-tasks run <id>` — the system cron does the timing;
+ * agent-do does the safe execution.
+ */
+
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { z } from 'zod';
+import type { ParsedArgs } from './args.js';
+import { resolveModel } from './resolve-model.js';
+import { createAgent } from '../agent.js';
+import { emitSandboxWarning } from './warnings.js';
+import {
+  matchesCron,
+  readStatus,
+  runScheduledTask,
+  validateScheduledTasks,
+  type ScheduledTask,
+} from '../scheduled-tasks.js';
+
+/** Tasks file: a JSON array of ScheduledTask, optionally with `description`. */
+const TasksFileSchema = z.array(
+  z.object({
+    id: z.string().regex(/^[a-zA-Z0-9_-]+$/),
+    cron: z.string(),
+    payload: z.union([z.string(), z.record(z.string(), z.unknown())]),
+    description: z.string().optional(),
+    sessionTarget: z.enum(['isolated', 'main']).optional(),
+    wakeMode: z.enum(['agentTurn', 'systemEvent']).optional(),
+  }),
+);
+
+export async function runScheduledTasksMode(args: ParsedArgs): Promise<void> {
+  const sub = args.scheduledTasksSubcommand;
+  const tasksFile = args.tasksFile!;
+
+  switch (sub) {
+    case 'list':
+      return printList(tasksFile);
+    case 'status':
+      return printStatus(tasksFile, args.memoryDir);
+    case 'install':
+      return printInstall(tasksFile, args);
+    case 'start':
+      return runForegroundLoop(tasksFile, args);
+    case 'run':
+      if (!args.scheduledTaskId) {
+        throw new Error('Usage: agent-do scheduled-tasks run <id>');
+      }
+      return runOne(tasksFile, args.memoryDir, args.scheduledTaskId, args);
+    default:
+      throw new Error(`Unknown scheduled-tasks subcommand: ${sub}`);
+  }
+}
+
+async function loadTasks(tasksFile: string): Promise<ScheduledTask[]> {
+  let raw: string;
+  try {
+    raw = await readFile(tasksFile, 'utf-8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new Error(
+        `No scheduled-tasks file at ${tasksFile}. Create one (a JSON array of {id,cron,payload}) or pass --tasks <path>.`,
+      );
+    }
+    throw err;
+  }
+  const parsed = TasksFileSchema.parse(JSON.parse(raw));
+  return validateScheduledTasks(parsed);
+}
+
+async function printList(tasksFile: string): Promise<void> {
+  const tasks = await loadTasks(tasksFile);
+  if (tasks.length === 0) {
+    console.log('(no scheduled tasks)');
+    return;
+  }
+  for (const t of tasks) {
+    const desc = t.description ? ` — ${t.description}` : '';
+    console.log(`${t.id}\t${t.cron}${desc}`);
+  }
+}
+
+async function printStatus(tasksFile: string, memoryDir: string): Promise<void> {
+  const tasks = await loadTasks(tasksFile);
+  const statusFile = resolveStatusFile(memoryDir);
+  const status = await readStatus(statusFile);
+  if (tasks.length === 0) {
+    console.log('(no scheduled tasks)');
+    return;
+  }
+  console.log('id\tschedule\tlast-run\toutcome\truns');
+  for (const t of tasks) {
+    const s = status[t.id];
+    const last = s?.lastRunAt ? new Date(s.lastRunAt).toISOString().replace('T', ' ').slice(0, 19) : 'never';
+    const outcome = s?.lastOutcome ?? '-';
+    console.log(`${t.id}\t${t.cron}\t${last}\t${outcome}\t${s?.runCount ?? 0}`);
+  }
+  console.log(`\n(status at ${statusFile})`);
+}
+
+/**
+ * Emit crontab lines that invoke `agent-do scheduled-tasks run <id>` per task.
+ * The operator appends the output to their crontab / systemd timer. We use the
+ * resolved absolute tasks-file path so the fired job reads the same file
+ * regardless of the cron user's cwd.
+ */
+async function printInstall(tasksFile: string, args: ParsedArgs): Promise<void> {
+  const tasks = await loadTasks(tasksFile);
+  const absTasks = resolve(tasksFile);
+  const memory = resolve(args.memoryDir);
+  const bin = process.argv[1] ?? 'agent-do';
+  const lines: string[] = [
+    '# agent-do scheduled tasks — append to your crontab (crontab -e) or systemd timer.',
+    `# tasks file: ${absTasks}`,
+    `# memory dir: ${memory}`,
+  ];
+  for (const t of tasks) {
+    const comment = t.description ? ` # ${t.description}` : '';
+    lines.push(
+      `${t.cron} ${bin} scheduled-tasks run ${t.id} --tasks "${absTasks}" --memory "${memory}"${comment}`,
+    );
+  }
+  console.log(lines.join('\n'));
+}
+
+async function runOne(tasksFile: string, memoryDir: string, taskId: string, args: ParsedArgs): Promise<void> {
+  const tasks = await loadTasks(tasksFile);
+  const task = tasks.find((t) => t.id === taskId);
+  if (!task) {
+    throw new Error(`No scheduled task "${taskId}" in ${tasksFile}. Available: ${tasks.map((t) => t.id).join(', ') || '(none)'}`);
+  }
+
+  // Same warning posture as prompt mode — a scheduled run can touch files.
+  emitSandboxWarning({ toolsEnabled: !args.noTools, readOnly: args.readOnly, json: args.json });
+
+  const model = await resolveModel(args.provider, args.model);
+  // Build a fresh agent from CLI flags. sessionTarget 'main' (persistent
+  // conversation) is accepted in the schema but not yet wired — every run
+  // is isolated in v1.
+  const agent = createAgent({
+    id: `scheduled:${taskId}`,
+    name: `scheduled:${taskId}`,
+    model,
+    systemPrompt: args.systemPrompt,
+    maxIterations: args.maxIterations,
+    usage: { enabled: true },
+  });
+
+  const result = await runScheduledTask(taskId, {
+    memoryDir,
+    statusFile: resolveStatusFile(memoryDir),
+    run: async (payloadText) => {
+      const out = await agent.run(payloadText);
+      if (!args.json) process.stdout.write(out + '\n');
+      return out;
+    },
+    payload: task.payload,
+  });
+
+  if (result.skipped) {
+    process.stderr.write(`[scheduled-tasks] skipped "${taskId}" — another run holds the lock.\n`);
+    return;
+  }
+  if (!result.ok) {
+    process.stderr.write(`[scheduled-tasks] "${taskId}" failed: ${result.error}\n`);
+    process.exit(1);
+  }
+}
+
+/**
+ * Foreground scheduler loop — checks every minute and runs any task whose
+ * cron matches the current minute. For dev/testing; production wiring is
+ * `install` + system cron. Honours SIGINT/SIGTERM for a clean exit.
+ */
+async function runForegroundLoop(tasksFile: string, args: ParsedArgs): Promise<void> {
+  const memoryDir = args.memoryDir;
+  const statusFile = resolveStatusFile(memoryDir);
+  process.stderr.write(`[scheduled-tasks] foreground loop. tasks=${tasksFile} memory=${memoryDir}\n`);
+  process.stderr.write('[scheduled-tasks] Ctrl+C to stop.\n');
+
+  let stopped = false;
+  const stop = () => { stopped = true; };
+  process.on('SIGINT', stop);
+  process.on('SIGTERM', stop);
+
+  // Run an immediate tick, then on each minute boundary.
+  await tick();
+  while (!stopped) {
+    await new Promise((r) => setTimeout(r, 1000));
+    const now = new Date();
+    if (now.getSeconds() === 0) await tick();
+  }
+  process.stderr.write('[scheduled-tasks] stopped.\n');
+
+  async function tick(): Promise<void> {
+    const tasks = await loadTasks(tasksFile).catch(() => [] as ScheduledTask[]);
+    const now = new Date();
+    for (const t of tasks) {
+      if (!matchesCron(t.cron, now)) continue;
+      process.stderr.write(`[scheduled-tasks] ${now.toISOString()} firing "${t.id}"\n`);
+      // Reuse runOne so the lock + status + agent wiring is identical to the
+      // crontab-driven path. Swallow errors — a failing task mustn't kill the loop.
+      await runOne(tasksFile, memoryDir, t.id, args).catch((err) => {
+        process.stderr.write(`[scheduled-tasks] "${t.id}" errored: ${err instanceof Error ? err.message : String(err)}\n`);
+      });
+    }
+  }
+}
+
+function resolveStatusFile(memoryDir: string): string {
+  return resolve(memoryDir, 'scheduler-status.json');
+}
+
+/** Write helper for `scheduled-tasks add`-style tooling (not a CLI verb in v1,
+ *  but exported so editors / template packs can persist a tasks file safely). */
+export async function writeTasksFile(tasksFile: string, tasks: ScheduledTask[]): Promise<void> {
+  await mkdir(dirname(tasksFile), { recursive: true });
+  await writeFile(tasksFile, JSON.stringify(tasks, null, 2), 'utf-8');
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,6 +135,16 @@ export type { FilesystemMemoryStoreOptions } from './types.js';
 export { acquireFileLock, withFileLock } from './stores/file-lock.js';
 export type { FileLockOptionsInternal } from './stores/file-lock.js';
 export type { FileLockOptions, LockHandle, LockAdapter } from './types.js';
+// Scheduled tasks (#79) — declarative cron-driven agent runs with lock-file concurrency.
+export {
+  matchesCron,
+  validateScheduledTasks,
+  readStatus,
+  writeStatus,
+  recordRun,
+  runScheduledTask,
+} from './scheduled-tasks.js';
+export type { ScheduledTask, ScheduledTasksConfig, TaskStatus, StatusRecord } from './scheduled-tasks.js';
 export { SandboxBackedMemoryStore } from './stores/sandbox.js';
 export type { SandboxBackedMemoryStoreOptions } from './stores/sandbox.js';
 

--- a/src/scheduled-tasks.ts
+++ b/src/scheduled-tasks.ts
@@ -1,0 +1,332 @@
+/**
+ * Scheduled tasks (#79) — declarative cron-driven agent runs.
+ *
+ * A scheduled task pairs a 5-field cron expression with a payload the agent
+ * should run when the schedule fires. The production wiring is system cron:
+ * `agent-do scheduled-tasks install` emits crontab lines that invoke
+ * `agent-do scheduled-tasks run <id>` on schedule. `start` runs a foreground
+ * loop for dev/testing. Either way, **executing a task acquires the #15 file
+ * lock** so overlapping runs (cron fired before the previous run finished, or
+ * two hosts sharing the same `--memory` dir) serialise rather than clobber.
+ *
+ * ## What's in v1
+ *
+ * - `ScheduledTask` type + `AgentConfig.scheduledTasks?: ScheduledTask[]`,
+ *   validated at `createAgent()` time (unique ids, valid cron, non-empty
+ *   payload).
+ * - `matchesCron(expr, date)` — a correct, dependency-free 5-field matcher.
+ * - `runScheduledTask()` — load the agent, take the lock, run the payload,
+ *   record status. What crontab invokes.
+ * - CLI: `scheduled-tasks run|list|status|start|install`.
+ *
+ * ## Deliberately deferred (noted in changeset)
+ *
+ * - `sessionTarget: 'main'` — appending to a persistent conversation needs a
+ *   history store agent-do doesn't ship yet. v1 runs every task isolated.
+ * - `wakeMode: 'systemEvent'` with a structured payload — there's no
+ *   system-event channel yet; v1 treats the payload as the task text. String
+ *   payloads work fully; structured objects are accepted but stringified.
+ * - Cron niceties beyond the portable 5-field numeric subset (`L`/`W`/`#`,
+ *   month/weekday names, `?`, seconds) — system cron varies by platform on
+ *   these, so v1 sticks to what every cron supports.
+ */
+
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { acquireFileLock } from './stores/file-lock.js';
+import type { FileLockOptions } from './types.js';
+
+/**
+ * One scheduled task.
+ *
+ * `cron` is standard 5-field: minute hour day-of-month month day-of-week
+ * (0-7, where 0 and 7 are Sunday). `payload` is the task text the agent runs.
+ */
+export interface ScheduledTask {
+  /** Stable id. Used in `scheduled-tasks run <id>` and as the lock key. */
+  id: string;
+  /** 5-field cron expression. */
+  cron: string;
+  /** Task text (or stringifiable payload) the agent runs when the schedule fires. */
+  payload: string | Record<string, unknown>;
+  /** Human-readable description. Shown by `list` / `status`. */
+  description?: string;
+  /**
+   * Reserved: `'isolated'` (v1 default — every run starts fresh) vs `'main'`
+   * (append to a persistent conversation — deferred; needs a history store).
+   */
+  sessionTarget?: 'isolated' | 'main';
+  /**
+   * Reserved: `'agentTurn'` (v1 default — payload becomes the task text) vs
+   * `'systemEvent'` (structured wake event — deferred; no event channel yet).
+   */
+  wakeMode?: 'agentTurn' | 'systemEvent';
+}
+
+export interface ScheduledTasksConfig {
+  tasks: ScheduledTask[];
+  /**
+   * Where status (last-run times, outcomes) is recorded. Default
+   * `<memoryDir>/scheduler-status.json`. The lock dir is `<memoryDir>/.locks`
+   * so it reuses the #15 machinery and is shared across hosts.
+   */
+  statusFile?: string;
+  /** Override the lock options (staleMs etc.) for overlap prevention. */
+  lock?: FileLockOptions;
+}
+
+// ── Cron matcher ────────────────────────────────────────────────────────
+
+const FIELDS = ['minute', 'hour', 'dom', 'month', 'dow'] as const;
+type Field = (typeof FIELDS)[number];
+
+const FIELD_RANGES: Record<Field, { min: number; max: number }> = {
+  minute: { min: 0, max: 59 },
+  hour: { min: 0, max: 23 },
+  dom: { min: 1, max: 31 },
+  month: { min: 1, max: 12 },
+  dow: { min: 0, max: 7 }, // 0 and 7 both Sunday
+};
+
+/**
+ * True iff `date` matches the 5-field cron expression `expr`.
+ *
+ * Throws on malformed expressions (unknown field, out-of-range value, bad
+ * step, non-numeric token). Validation happens up front in `createAgent()`,
+ * so a task that passed validation won't throw here — but the matcher is
+ * exported and used directly by tests, so it validates defensively.
+ *
+ * Note on dom/dow interaction (the classic cron gotcha): per Vixie cron, if
+ * BOTH dom and dow are restricted (not `*`), the date matches if EITHER
+ * matches; if only one is restricted, that one must match. This matches the
+ * behaviour of every system cron.
+ */
+export function matchesCron(expr: string, date: Date = new Date()): boolean {
+  const fields = parseCron(expr);
+  const minute = date.getMinutes();
+  const hour = date.getHours();
+  const dom = date.getDate();
+  const month = date.getMonth() + 1; // JS months are 0-based
+  // JS getDay(): 0=Sunday..6=Saturday. Cron dow: 0 and 7 = Sunday.
+  const dow = date.getDay();
+
+  if (!fields.minute.has(minute)) return false;
+  if (!fields.hour.has(hour)) return false;
+  if (!fields.month.has(month)) return false;
+
+  const domStar = fields.dom.isStar;
+  const dowStar = fields.dow.isStar;
+  const domMatch = fields.dom.has(dom);
+  // Normalise 7 → 0 so Sunday matches either spelling.
+  const dowMatch = fields.dow.has(dow) || fields.dow.has(7) && dow === 0;
+
+  if (domStar && dowStar) return true;
+  if (domStar) return dowMatch;
+  if (dowStar) return domMatch;
+  return domMatch || dowMatch; // both restricted → OR (Vixie semantics)
+}
+
+interface ParsedField {
+  has(n: number): boolean;
+  readonly isStar: boolean;
+}
+
+function parseCron(expr: string): Record<Field, ParsedField> {
+  const parts = expr.trim().split(/\s+/);
+  if (parts.length !== 5) {
+    throw new Error(
+      `Invalid cron expression "${expr}": expected 5 fields (minute hour dom month dow), got ${parts.length}.`,
+    );
+  }
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  return {
+    minute: parseField(parts[0]!, 'minute'),
+    hour: parseField(parts[1]!, 'hour'),
+    dom: parseField(parts[2]!, 'dom'),
+    month: parseField(parts[3]!, 'month'),
+    dow: parseField(parts[4]!, 'dow'),
+  };
+}
+
+function parseField(raw: string, field: Field): ParsedField {
+  const { min, max } = FIELD_RANGES[field];
+  const values = new Set<number>();
+  let isStar = false;
+
+  for (const item of raw.split(',')) {
+    if (item === '*') {
+      isStar = true;
+      for (let n = min; n <= max; n++) values.add(normalize(n, field));
+      continue;
+    }
+    // step: a-b/n, */n, or n/n
+    const stepMatch = item.match(/^(.*)\/(\d+)$/);
+    const step = stepMatch ? parseInt(stepMatch[2]!, 10) : 1;
+    const rangePart = stepMatch ? stepMatch[1]! : item;
+    if (step < 1) throw new Error(`Invalid cron step "${item}" in ${field}: step must be >= 1.`);
+
+    let lo: number, hi: number;
+    if (rangePart === '*') {
+      lo = min; hi = max;
+    } else if (rangePart.includes('-')) {
+      const [a, b] = rangePart.split('-');
+      if (a === undefined || b === undefined) {
+        throw new Error(`Invalid cron range "${rangePart}" in ${field}.`);
+      }
+      lo = parseInt(a, 10); hi = parseInt(b, 10);
+    } else {
+      lo = parseInt(rangePart, 10);
+      hi = lo; // single value → degenerate range [lo, lo]
+    }
+    if (Number.isNaN(lo) || Number.isNaN(hi)) {
+      throw new Error(`Invalid cron value "${item}" in ${field}: not a number.`);
+    }
+    if (lo < min || hi > max || lo > hi) {
+      throw new Error(
+        `Cron ${field} value out of range in "${item}": allowed ${min}-${max}.`,
+      );
+    }
+    for (let n = lo; n <= hi; n += step) values.add(normalize(n, field));
+  }
+
+  return {
+    has: (n: number) => values.has(normalize(n, field)),
+    isStar,
+  };
+}
+
+/** For dow, treat 7 as 0 (both Sunday). Other fields pass through. */
+function normalize(n: number, field: Field): number {
+  if (field === 'dow' && n === 7) return 0;
+  return n;
+}
+
+// ── Validation ──────────────────────────────────────────────────────────
+
+export function validateScheduledTasks(tasks: ScheduledTask[]): ScheduledTask[] {
+  const ids = new Set<string>();
+  for (const t of tasks) {
+    if (!t.id || !/^[a-zA-Z0-9_-]+$/.test(t.id)) {
+      throw new Error(`Scheduled task id "${t.id}" is invalid (use [a-zA-Z0-9_-]+).`);
+    }
+    if (ids.has(t.id)) {
+      throw new Error(`Duplicate scheduled task id "${t.id}".`);
+    }
+    ids.add(t.id);
+    // parseCron throws on malformed expressions — that's the validation.
+    parseCron(t.cron);
+    if (t.payload === undefined || t.payload === null) {
+      throw new Error(`Scheduled task "${t.id}" has no payload.`);
+    }
+  }
+  return tasks;
+}
+
+// ── Status tracking ─────────────────────────────────────────────────────
+
+export interface TaskStatus {
+  lastRunAt?: string; // ISO
+  lastDurationMs?: number;
+  lastOutcome?: 'ok' | 'error';
+  lastError?: string;
+  runCount: number;
+}
+
+export type StatusRecord = Record<string, TaskStatus>;
+
+export async function readStatus(statusFile: string): Promise<StatusRecord> {
+  try {
+    const raw = await readFile(statusFile, 'utf-8');
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? (parsed as StatusRecord) : {};
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return {};
+    throw err;
+  }
+}
+
+export async function writeStatus(statusFile: string, record: StatusRecord): Promise<void> {
+  await mkdir(dirname(statusFile), { recursive: true });
+  await writeFile(statusFile, JSON.stringify(record, null, 2), 'utf-8');
+}
+
+/** Record a completed run. Never throws — a status-write failure must not
+ *  mask the run's own outcome. Returns the updated record. */
+export async function recordRun(
+  statusFile: string,
+  taskId: string,
+  outcome: { ok: boolean; durationMs: number; error?: string },
+): Promise<TaskStatus> {
+  const all = await readStatus(statusFile).catch(() => ({}) as StatusRecord);
+  const prev = all[taskId] ?? { runCount: 0 };
+  const next: TaskStatus = {
+    ...prev,
+    lastRunAt: new Date().toISOString(),
+    lastDurationMs: outcome.durationMs,
+    lastOutcome: outcome.ok ? 'ok' : 'error',
+    lastError: outcome.ok ? undefined : (outcome.error ?? 'unknown error'),
+    runCount: prev.runCount + 1,
+  };
+  all[taskId] = next;
+  await writeStatus(statusFile, all).catch(() => { /* best-effort */ });
+  return next;
+}
+
+// ── Overlap-safe execution ──────────────────────────────────────────────
+
+/**
+ * Run a single scheduled task under an exclusive lock, then record status.
+ *
+ * The lock key is the task id; the lock dir is `<memoryDir>/.locks` so it
+ * reuses the #15 machinery and is shared across hosts mounting the same dir.
+ * If the lock can't be acquired (a previous run is still going, or its lock
+ * is fresher than `staleMs`), the run is skipped with outcome `{ skipped }`.
+ *
+ * `run` is the caller-supplied agent executor — typically the agent's
+ * `.run(payloadText)`. Injected so this module stays free of agent-construction
+ * concerns (and stays unit-testable with a mock).
+ */
+export async function runScheduledTask(
+  taskId: string,
+  opts: {
+    memoryDir: string;
+    statusFile: string;
+    lock?: FileLockOptions;
+    run: (payloadText: string) => Promise<string>;
+    payload: string | Record<string, unknown>;
+  },
+): Promise<{ ok: boolean; skipped: boolean; error?: string; durationMs: number }> {
+  const payloadText = typeof opts.payload === 'string'
+    ? opts.payload
+    : JSON.stringify(opts.payload);
+  const lockDir = join(opts.memoryDir, '.locks');
+  const started = Date.now();
+
+  let handle;
+  try {
+    handle = await acquireFileLock(`scheduled-task:${taskId}`, 'scheduler', lockDir, {
+      staleMs: 15 * 60_000, // a single agent turn shouldn't run 15 min; if it does, the next firing reclaims
+      ...opts.lock,
+    });
+  } catch (err) {
+    // Couldn't acquire — a previous run is still active (or its stale lock
+    // hasn't aged out). Skip rather than pile on. Not an error outcome.
+    const skipped = { ok: true, skipped: true, durationMs: Date.now() - started };
+    await recordRun(opts.statusFile, taskId, { ok: true, durationMs: skipped.durationMs });
+    return skipped;
+  }
+
+  try {
+    await opts.run(payloadText);
+    const durationMs = Date.now() - started;
+    await recordRun(opts.statusFile, taskId, { ok: true, durationMs });
+    return { ok: true, skipped: false, durationMs };
+  } catch (err) {
+    const durationMs = Date.now() - started;
+    const message = err instanceof Error ? err.message : String(err);
+    await recordRun(opts.statusFile, taskId, { ok: false, durationMs, error: message });
+    return { ok: false, skipped: false, error: message, durationMs };
+  } finally {
+    await handle.release();
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export type ProviderOptions = Record<
   Record<string, JSONValue | undefined>
 >;
 import type { McpServerConfig } from './mcp.js';
+import type { ScheduledTask } from './scheduled-tasks.js';
 
 // Progress events emitted during agent execution
 export interface ProgressEvent {
@@ -474,6 +475,15 @@ export interface AgentConfig {
    * Rendered with the same injection-safety wrapper skills use.
    */
   policies?: Policy[];
+  /**
+   * Declarative cron-driven runs (#79). Each task fires on its `cron`
+   * schedule and runs its `payload` against the agent under an exclusive
+   * lock (so overlapping firings skip, and a crashed run is reclaimed).
+   * Execute one via `agent-do scheduled-tasks run <id>`; generate the
+   * crontab wiring via `agent-do scheduled-tasks install`. Validated at
+   * `createAgent()` time (unique ids, valid cron, non-empty payload).
+   */
+  scheduledTasks?: ScheduledTask[];
   /**
    * How installed skills are injected into the system prompt (#74).
    *

--- a/tests/cli-scheduled-tasks.test.ts
+++ b/tests/cli-scheduled-tasks.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { parseArgs } from '../src/cli/args.js';
+
+// ── args parsing for the new subcommand ─────────────────────────────────
+
+describe('parseArgs — scheduled-tasks subcommand', () => {
+  it('parses the verb and sets the command', () => {
+    const a = parseArgs(['scheduled-tasks', 'list']);
+    expect(a.command).toBe('scheduled-tasks');
+    expect(a.scheduledTasksSubcommand).toBe('list');
+  });
+
+  it('captures the task id for `run`', () => {
+    const a = parseArgs(['scheduled-tasks', 'run', 'sweep']);
+    expect(a.scheduledTasksSubcommand).toBe('run');
+    expect(a.scheduledTaskId).toBe('sweep');
+  });
+
+  it('accepts every documented verb', () => {
+    for (const v of ['list', 'status', 'install', 'start', 'run'] as const) {
+      const a = parseArgs(['scheduled-tasks', v]);
+      expect(a.scheduledTasksSubcommand).toBe(v);
+    }
+  });
+
+  it('rejects an unknown verb', () => {
+    expect(() => parseArgs(['scheduled-tasks', 'frobnicate'])).toThrow(/list\|status\|install\|start\|run/);
+  });
+
+  it('rejects a missing verb', () => {
+    expect(() => parseArgs(['scheduled-tasks'])).toThrow(/Usage/);
+  });
+
+  it('defaults tasksFile to <memoryDir>/scheduled-tasks.json', () => {
+    const a = parseArgs(['scheduled-tasks', 'list', '--memory', '.data']);
+    expect(a.tasksFile).toBe('.data/scheduled-tasks.json');
+  });
+
+  it('honours an explicit --tasks path', () => {
+    const a = parseArgs(['scheduled-tasks', 'list', '--tasks', '/tmp/my-tasks.json']);
+    expect(a.tasksFile).toBe('/tmp/my-tasks.json');
+  });
+
+  it('does not treat "scheduled-tasks" appearing as a prompt as a subcommand', () => {
+    // When it's NOT the first token, it's a literal prompt (regression guard).
+    const a = parseArgs(['Summarize', 'scheduled-tasks']);
+    expect(a.command).toBe('prompt');
+    expect(a.prompt).toContain('scheduled-tasks');
+  });
+});
+
+// ── runScheduledTasksMode — the run path ────────────────────────────────
+
+describe('runScheduledTasksMode — run', () => {
+  let dir: string;
+  let tasksFile: string;
+  let savedEnv: string | undefined;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'sched-cli-'));
+    tasksFile = join(dir, 'tasks.json');
+    savedEnv = process.env.ANTHROPIC_API_KEY;
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-stub';
+  });
+  afterEach(async () => {
+    if (savedEnv === undefined) delete process.env.ANTHROPIC_API_KEY;
+    else process.env.ANTHROPIC_API_KEY = savedEnv;
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('throws clearly when the tasks file is missing', async () => {
+    const { runScheduledTasksMode } = await import('../src/cli/scheduled-tasks-cmd.js');
+    const args = parseArgs(['scheduled-tasks', 'run', 'x', '--tasks', tasksFile]);
+    await expect(runScheduledTasksMode(args)).rejects.toThrow(/No scheduled-tasks file/);
+  });
+
+  it('throws clearly when the task id is unknown', async () => {
+    await writeFile(tasksFile, JSON.stringify([
+      { id: 'known', cron: '* * * * *', payload: 'hi' },
+    ]));
+    const { runScheduledTasksMode } = await import('../src/cli/scheduled-tasks-cmd.js');
+    const args = parseArgs(['scheduled-tasks', 'run', 'missing', '--tasks', tasksFile, '--memory', dir]);
+    await expect(runScheduledTasksMode(args)).rejects.toThrow(/No scheduled task "missing"/);
+  });
+
+  it('throws on a tasks file with a bad cron (validation surfaces)', async () => {
+    await writeFile(tasksFile, JSON.stringify([
+      { id: 'bad', cron: '* * *', payload: 'hi' }, // 3 fields
+    ]));
+    const { runScheduledTasksMode } = await import('../src/cli/scheduled-tasks-cmd.js');
+    const args = parseArgs(['scheduled-tasks', 'list', '--tasks', tasksFile]);
+    await expect(runScheduledTasksMode(args)).rejects.toThrow(/expected 5 fields/);
+  });
+
+  it('list prints the configured tasks', async () => {
+    await writeFile(tasksFile, JSON.stringify([
+      { id: 'sweep', cron: '*/15 * * * *', payload: 'triage', description: 'inbox' },
+      { id: 'daily', cron: '0 2 * * *', payload: 'prep' },
+    ]));
+    const { runScheduledTasksMode } = await import('../src/cli/scheduled-tasks-cmd.js');
+    const args = parseArgs(['scheduled-tasks', 'list', '--tasks', tasksFile]);
+    const out = captureStdout(() => runScheduledTasksMode(args));
+    const text = await out;
+    expect(text).toContain('sweep');
+    expect(text).toContain('*/15 * * * *');
+    expect(text).toContain('inbox');
+    expect(text).toContain('daily');
+  });
+
+  it('install emits one crontab line per task invoking `scheduled-tasks run`', async () => {
+    await writeFile(tasksFile, JSON.stringify([
+      { id: 'sweep', cron: '*/15 * * * *', payload: 'triage' },
+    ]));
+    const { runScheduledTasksMode } = await import('../src/cli/scheduled-tasks-cmd.js');
+    const args = parseArgs(['scheduled-tasks', 'install', '--tasks', tasksFile, '--memory', dir]);
+    const text = await captureStdout(() => runScheduledTasksMode(args));
+    expect(text).toMatch(/\/15 \* \* \* \* .* scheduled-tasks run sweep/);
+    expect(text).toContain('--tasks');
+    expect(text).toContain('--memory');
+  });
+
+  it('status shows the last-run table and reads from the status file', async () => {
+    await writeFile(tasksFile, JSON.stringify([
+      { id: 'sweep', cron: '*/15 * * * *', payload: 'triage' },
+    ]));
+    // Pre-seed a status record so the table has a row.
+    await writeFile(join(dir, 'scheduler-status.json'), JSON.stringify({
+      sweep: { runCount: 7, lastRunAt: '2026-06-19T09:30:00.000Z', lastOutcome: 'ok' },
+    }));
+    const { runScheduledTasksMode } = await import('../src/cli/scheduled-tasks-cmd.js');
+    const args = parseArgs(['scheduled-tasks', 'status', '--tasks', tasksFile, '--memory', dir]);
+    const text = await captureStdout(() => runScheduledTasksMode(args));
+    expect(text).toContain('sweep');
+    expect(text).toContain('7');           // runCount
+    expect(text).toContain('ok');
+    expect(text).toContain('2026-06-19');  // last-run date
+  });
+});
+
+// ── helpers ─────────────────────────────────────────────────────────────
+
+/** Capture stdout.write/console.log output while `fn` runs. */
+async function captureStdout(fn: () => Promise<unknown>): Promise<string> {
+  let captured = '';
+  const orig = process.stdout.write.bind(process.stdout);
+  const log = console.log;
+  process.stdout.write = ((chunk: unknown) => {
+    captured += typeof chunk === 'string' ? chunk : String(chunk);
+    return true;
+  }) as typeof process.stdout.write;
+  console.log = (...a: unknown[]) => { captured += a.join(' ') + '\n'; };
+  try {
+    await fn();
+  } finally {
+    process.stdout.write = orig;
+    console.log = log;
+  }
+  return captured;
+}
+
+void readFile; // keep import used across describe blocks

--- a/tests/scheduled-tasks.test.ts
+++ b/tests/scheduled-tasks.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  matchesCron,
+  validateScheduledTasks,
+  readStatus,
+  writeStatus,
+  recordRun,
+  runScheduledTask,
+} from '../src/scheduled-tasks.js';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// ── matchesCron: the correctness-critical part ─────────────────────────
+
+describe('matchesCron — basic field matching', () => {
+  // Helper: build a Date at a known wall-clock time so tests are deterministic.
+  const at = (
+    year: number, month: number, day: number,
+    hour: number, minute: number,
+  ): Date => new Date(year, month - 1, day, hour, minute);
+
+  it('matches every minute with * * * * *', () => {
+    const expr = '* * * * *';
+    expect(matchesCron(expr, at(2026, 6, 19, 9, 30))).toBe(true);
+    expect(matchesCron(expr, at(2026, 1, 1, 0, 0))).toBe(true);
+    expect(matchesCron(expr, at(2026, 12, 31, 23, 59))).toBe(true);
+  });
+
+  it('matches an exact minute and hour', () => {
+    const expr = '30 9 * * *'; // 9:30 every day
+    expect(matchesCron(expr, at(2026, 6, 19, 9, 30))).toBe(true);
+    expect(matchesCron(expr, at(2026, 6, 19, 9, 31))).toBe(false);
+    expect(matchesCron(expr, at(2026, 6, 19, 10, 30))).toBe(false);
+  });
+
+  it('matches step values */15', () => {
+    const expr = '*/15 * * * *';
+    expect(matchesCron(expr, at(2026, 6, 19, 9, 0))).toBe(true);
+    expect(matchesCron(expr, at(2026, 6, 19, 9, 15))).toBe(true);
+    expect(matchesCron(expr, at(2026, 6, 19, 9, 30))).toBe(true);
+    expect(matchesCron(expr, at(2026, 6, 19, 9, 45))).toBe(true);
+    expect(matchesCron(expr, at(2026, 6, 19, 9, 7))).toBe(false);
+    expect(matchesCron(expr, at(2026, 6, 19, 9, 59))).toBe(false);
+  });
+
+  it('matches a comma list', () => {
+    const expr = '0,15,30,45 * * * *';
+    expect(matchesCron(expr, at(2026, 6, 19, 9, 0))).toBe(true);
+    expect(matchesCron(expr, at(2026, 6, 19, 9, 15))).toBe(true);
+    expect(matchesCron(expr, at(2026, 6, 19, 9, 30))).toBe(true);
+    expect(matchesCron(expr, at(2026, 6, 19, 9, 45))).toBe(true);
+    expect(matchesCron(expr, at(2026, 6, 19, 9, 20))).toBe(false);
+  });
+
+  it('matches a range', () => {
+    const expr = '0 9-17 * * *'; // top of every hour 9am..5pm
+    for (let h = 0; h < 24; h++) {
+      const m = matchesCron(expr, at(2026, 6, 19, h, 0));
+      expect(m).toBe(h >= 9 && h <= 17);
+    }
+  });
+
+  it('matches a stepped range', () => {
+    const expr = '0 9-17/2 * * *'; // every 2 hours from 9..17
+    expect(matchesCron(expr, at(2026, 6, 19, 9, 0))).toBe(true);
+    expect(matchesCron(expr, at(2026, 6, 19, 11, 0))).toBe(true);
+    expect(matchesCron(expr, at(2026, 6, 19, 13, 0))).toBe(true);
+    expect(matchesCron(expr, at(2026, 6, 19, 15, 0))).toBe(true);
+    expect(matchesCron(expr, at(2026, 6, 19, 17, 0))).toBe(true);
+    expect(matchesCron(expr, at(2026, 6, 19, 10, 0))).toBe(false);
+    expect(matchesCron(expr, at(2026, 6, 19, 16, 0))).toBe(false);
+  });
+
+  it('matches day-of-week (0 and 7 both Sunday)', () => {
+    // 2026-06-21 is a Sunday.
+    expect(matchesCron('0 0 * * 0', at(2026, 6, 21, 0, 0))).toBe(true);
+    expect(matchesCron('0 0 * * 7', at(2026, 6, 21, 0, 0))).toBe(true);
+    // 2026-06-22 is Monday.
+    expect(matchesCron('0 0 * * 1', at(2026, 6, 22, 0, 0))).toBe(true);
+    expect(matchesCron('0 0 * * 0', at(2026, 6, 22, 0, 0))).toBe(false);
+  });
+
+  it('matches month and day-of-month together', () => {
+    const expr = '0 0 1 1 *'; // Jan 1 00:00
+    expect(matchesCron(expr, at(2026, 1, 1, 0, 0))).toBe(true);
+    expect(matchesCron(expr, at(2026, 1, 2, 0, 0))).toBe(false);
+    expect(matchesCron(expr, at(2026, 2, 1, 0, 0))).toBe(false);
+  });
+});
+
+describe('matchesCron — dom/dow OR semantics (Vixie cron)', () => {
+  const at = (y: number, mo: number, d: number, h = 0, mi = 0): Date => new Date(y, mo - 1, d, h, mi);
+
+  it('when both dom and dow are restricted, matches if EITHER matches', () => {
+    // 2026-06-19 is a Friday (dow=5); dom=19.
+    // Run on the 1st of the month OR on Sundays.
+    const expr = '0 0 1 * 0';
+    expect(matchesCron(expr, at(2026, 6, 1, 0, 0))).toBe(true);   // dom=1 → match
+    expect(matchesCron(expr, at(2026, 6, 21, 0, 0))).toBe(true);  // Sunday → match
+    expect(matchesCron(expr, at(2026, 6, 19, 0, 0))).toBe(false); // neither
+  });
+
+  it('when only dom is restricted (dow is *), dow is ignored', () => {
+    const expr = '0 0 15 * *';
+    expect(matchesCron(expr, at(2026, 6, 15, 0, 0))).toBe(true);
+    expect(matchesCron(expr, at(2026, 6, 16, 0, 0))).toBe(false);
+  });
+});
+
+describe('matchesCron — validation', () => {
+  it('rejects expressions that are not 5 fields', () => {
+    expect(() => matchesCron('* * * *')).toThrow(/expected 5 fields/);
+    expect(() => matchesCron('* * * * * *')).toThrow(/expected 5 fields/);
+  });
+
+  it('rejects out-of-range values', () => {
+    expect(() => matchesCron('60 * * * *')).toThrow(/out of range/); // minute 60
+    expect(() => matchesCron('* 24 * * *')).toThrow(/out of range/); // hour 24
+    expect(() => matchesCron('* * 32 * *')).toThrow(/out of range/); // dom 32
+    expect(() => matchesCron('* * 0 * *')).toThrow(/out of range/);  // dom 0
+    expect(() => matchesCron('* * * 13 *')).toThrow(/out of range/); // month 13
+    expect(() => matchesCron('* * * * 8')).toThrow(/out of range/);  // dow 8 (max is 7)
+  });
+
+  it('rejects malformed tokens', () => {
+    expect(() => matchesCron('abc * * * *')).toThrow();
+    expect(() => matchesCron('*/0 * * * *')).toThrow(/step/);
+    expect(() => matchesCron('1- * * * *')).toThrow();
+  });
+});
+
+// ── validateScheduledTasks ─────────────────────────────────────────────
+
+describe('validateScheduledTasks', () => {
+  it('accepts a well-formed task list', () => {
+    const tasks = validateScheduledTasks([
+      { id: 'sweep', cron: '*/15 * * * *', payload: 'triage inbox' },
+      { id: 'daily', cron: '0 2 * * *', payload: { event: 'daily' } },
+    ]);
+    expect(tasks).toHaveLength(2);
+  });
+
+  it('rejects duplicate ids', () => {
+    expect(() =>
+      validateScheduledTasks([
+        { id: 'x', cron: '* * * * *', payload: 'a' },
+        { id: 'x', cron: '* * * * *', payload: 'b' },
+      ]),
+    ).toThrow(/Duplicate scheduled task id "x"/);
+  });
+
+  it('rejects a bad id', () => {
+    expect(() =>
+      validateScheduledTasks([{ id: 'bad id!', cron: '* * * * *', payload: 'a' }]),
+    ).toThrow(/invalid/);
+  });
+
+  it('rejects a bad cron', () => {
+    expect(() =>
+      validateScheduledTasks([{ id: 'ok', cron: '* * *', payload: 'a' }]),
+    ).toThrow(/expected 5 fields/);
+  });
+});
+
+// ── status read/write ──────────────────────────────────────────────────
+
+describe('status tracking', () => {
+  let dir: string;
+  beforeEach(async () => { dir = await mkdtemp(join(tmpdir(), 'sched-status-')); });
+  afterEach(async () => { await rm(dir, { recursive: true, force: true }); });
+
+  it('returns an empty record when no status file exists', async () => {
+    const sf = join(dir, 'status.json');
+    expect(await readStatus(sf)).toEqual({});
+  });
+
+  it('round-trips a written record', async () => {
+    const sf = join(dir, 'sub', 'status.json'); // nested dir auto-created
+    await writeStatus(sf, { sweep: { runCount: 3 } });
+    expect(await readStatus(sf)).toEqual({ sweep: { runCount: 3 } });
+  });
+
+  it('recordRun increments count and stamps last-run metadata', async () => {
+    const sf = join(dir, 'status.json');
+    const r1 = await recordRun(sf, 't', { ok: true, durationMs: 100 });
+    expect(r1.runCount).toBe(1);
+    expect(r1.lastOutcome).toBe('ok');
+    const r2 = await recordRun(sf, 't', { ok: false, durationMs: 200, error: 'boom' });
+    expect(r2.runCount).toBe(2);
+    expect(r2.lastOutcome).toBe('error');
+    expect(r2.lastError).toBe('boom');
+  });
+});
+
+// ── runScheduledTask (overlap-safe execution) ──────────────────────────
+
+describe('runScheduledTask', () => {
+  let dir: string;
+  beforeEach(async () => { dir = await mkdtemp(join(tmpdir(), 'sched-run-')); });
+  afterEach(async () => { await rm(dir, { recursive: true, force: true }); });
+
+  it('runs the payload and records an ok outcome', async () => {
+    const sf = join(dir, 'status.json');
+    let calledWith: string | null = null;
+    const res = await runScheduledTask('sweep', {
+      memoryDir: dir,
+      statusFile: sf,
+      run: async (p) => { calledWith = p; return 'done'; },
+      payload: 'triage the inbox',
+    });
+    expect(res.ok).toBe(true);
+    expect(res.skipped).toBe(false);
+    expect(calledWith).toBe('triage the inbox');
+    const status = await readStatus(sf);
+    expect(status.sweep?.runCount).toBe(1);
+    expect(status.sweep?.lastOutcome).toBe('ok');
+  });
+
+  it('stringifies a structured payload', async () => {
+    const sf = join(dir, 'status.json');
+    let calledWith = '';
+    await runScheduledTask('evt', {
+      memoryDir: dir, statusFile: sf,
+      run: async (p) => { calledWith = p; return ''; },
+      payload: { event: 'daily-prep' },
+    });
+    expect(JSON.parse(calledWith)).toEqual({ event: 'daily-prep' });
+  });
+
+  it('records an error outcome and still releases the lock', async () => {
+    const sf = join(dir, 'status.json');
+    const res = await runScheduledTask('bad', {
+      memoryDir: dir, statusFile: sf,
+      run: async () => { throw new Error('agent exploded'); },
+      payload: 'x',
+    });
+    expect(res.ok).toBe(false);
+    expect(res.error).toBe('agent exploded');
+    const status = await readStatus(sf);
+    expect(status.bad?.lastOutcome).toBe('error');
+    // Lock released → a second run can acquire it immediately.
+    const res2 = await runScheduledTask('bad', {
+      memoryDir: dir, statusFile: sf,
+      run: async () => 'ok', payload: 'x',
+    });
+    expect(res2.ok).toBe(true);
+    expect(status.bad?.runCount).toBe(1); // (read before the 2nd run; check fresh below)
+    expect((await readStatus(sf)).bad?.runCount).toBe(2);
+  });
+
+  it('skips (does not run) when the lock is held by an active run', async () => {
+    const sf = join(dir, 'status.json');
+    // Hold the lock externally for the same task key, then try to run.
+    const { acquireFileLock } = await import('../src/stores/file-lock.js');
+    const holder = await acquireFileLock('scheduled-task:sweep', 'scheduler', join(dir, '.locks'));
+    let ran = false;
+    const res = await runScheduledTask('sweep', {
+      memoryDir: dir, statusFile: sf,
+      run: async () => { ran = true; return ''; },
+      payload: 'x',
+      lock: { staleMs: 60_000, retry: { count: 2, minDelayMs: 1, maxDelayMs: 2 } },
+    });
+    expect(res.skipped).toBe(true);
+    expect(ran).toBe(false);
+    await holder.release();
+  });
+});


### PR DESCRIPTION
Closes #79. Built directly on #15 Tier 1's file lock (the research brief's keystone call — #79 needs cross-process + stale reclaim, which #15 just shipped).

## What it does
A first-class scheduling primitive: a JSON task file + dependency-free cron matcher + CLI subcommand that turns a cron entry into a safe, overlap-proof agent run.

\`\`\`bash
npx agent-do scheduled-tasks list        # show configured tasks
npx agent-do scheduled-tasks install     # emit crontab lines for your tasks
npx agent-do scheduled-tasks run <id>    # run one task (lock-protected)
npx agent-do scheduled-tasks status      # last-run times + outcomes
npx agent-do scheduled-tasks start       # foreground loop (dev/test)
\`\`\`

Tasks live in \`<memoryDir>/scheduled-tasks.json\`. The production wiring is **system cron**: \`install\` emits one crontab line per task that calls \`scheduled-tasks run <id>\` — the system cron does the timing, agent-do does the safe execution.

## Overlap safety (the whole point)
Every \`run\` acquires the #15 file lock, so **overlapping firings skip** (cron fired before the previous run finished, or two hosts share the same \`--memory\` dir). A run killed mid-execution leaves a lock that the next firing reclaims after \`staleMs\` (default 15 min). Last-run times/outcomes/run-counts land in \`scheduler-status.json\`. This is the cross-process guarantee a scheduler needs and an in-process mutex can't provide.

## New exports
\`matchesCron\`, \`validateScheduledTasks\`, \`readStatus\`/\`writeStatus\`/\`recordRun\`, \`runScheduledTask\`, types \`ScheduledTask\`/\`ScheduledTasksConfig\`/\`TaskStatus\`. \`AgentConfig.scheduledTasks?: ScheduledTask[]\` validated at \`createAgent()\` time.

## Verification
\`typecheck\` ✅ · \`build\` ✅ · **832 tests** ✅ (794 + 38 new) · mock eval ✅. End-to-end smoke against the compiled CLI: \`list\`, \`install\` (correct crontab lines), \`status\` (table), and \`run <id>\` reached \`resolveModel\` cleanly (proving the tasks-load → lock → agent-build wiring). 38 tests cover: the cron matcher incl. **Vixie dom/dow OR-semantics**, validation, status tracking, overlap-skip, error outcomes with lock release, and the full CLI args/run/list/install/status paths.

## Cron matcher scope
Portable 5-field numeric subset: \`*/n\`, ranges (\`9-17\`), stepped ranges (\`9-17/2\`), comma lists, 0 and 7 both Sunday, Vixie dom/dow OR-semantics. Month/weekday names and \`L\`/\`W\`/\`#\` are **not** supported (support varies by platform cron; the portable subset matches every system cron).

## Reserved (v1 follow-ups, noted in changeset)
- \`sessionTarget: 'main'\` (persistent conversation) — needs a history store agent-do doesn't ship yet; v1 runs every task isolated.
- \`wakeMode: 'systemEvent'\` (structured wake event) — no event channel yet; v1 treats payload as task text. Structured payloads are accepted but stringified.

The roadmap issue #78 (template packs) is now fully unblocked — it composes policies + slash + routines + **scheduled tasks**.